### PR TITLE
Feat #5: tags personalizados por usuario

### DIFF
--- a/PROCEDURES.md
+++ b/PROCEDURES.md
@@ -39,6 +39,34 @@ En GitHub repo Settings > Secrets and variables > Actions, agregar:
 - `VITE_FIREBASE_APP_ID`
 - `FIREBASE_SERVICE_ACCOUNT` (JSON de service account de Firebase)
 
+## Flujo para nuevas funcionalidades
+
+Toda funcionalidad nueva sigue estas etapas con aprobación del usuario en cada paso:
+
+1. **PRD (Product Requirements Document)** — Claude lo crea incluyendo:
+   - Descripción de la funcionalidad
+   - Contexto del proyecto y estructura actual
+   - Requisitos funcionales y no funcionales
+   - Buenas prácticas y consideraciones UX
+2. **Aprobación del usuario** — No avanzar sin OK
+3. **Especificaciones técnicas** — Detalle de implementación:
+   - Modelos de datos / interfaces
+   - Componentes a crear o modificar
+   - Interacciones con Firebase
+   - Consideraciones de seguridad
+4. **Aprobación del usuario** — No avanzar sin OK
+5. **Plan técnico** — Pasos ordenados de implementación
+6. **Implementación** — Siguiendo el flujo de ramas/PR habitual
+
+### Documentación de features/fixes
+Toda la documentación se guarda en `docs/<tipo>-<descripcion>/`:
+- `prd.md` — Product Requirements Document
+- `specs.md` — Especificaciones técnicas
+- `plan.md` — Plan técnico de implementación
+- `changelog.md` — Archivos modificados/creados durante la implementación
+
+Cada iteración se empieza desde cero actualizando los archivos existentes (no se crean versiones).
+
 ## Flujo para corrección de errores / mejoras
 
 1. **Crear issue en GitHub** con descripción del error o mejora

--- a/docs/feat-custom-user-tags/changelog.md
+++ b/docs/feat-custom-user-tags/changelog.md
@@ -1,0 +1,26 @@
+# Changelog: Tags personalizados por usuario
+
+**Issue:** #5
+**Fecha:** 2026-03-11
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `firestore.rules` | Agregada regla para colección `customTags` (read/create/update/delete con validaciones) |
+| `src/components/business/BusinessTags.tsx` | Reescrito para soportar tags personalizados: crear, editar, eliminar con dialogs y menú contextual |
+
+## Archivos creados
+
+| Archivo | Descripción |
+|---------|-------------|
+| `docs/feat-custom-user-tags/prd.md` | Product Requirements Document |
+| `docs/feat-custom-user-tags/specs.md` | Especificaciones técnicas |
+| `docs/feat-custom-user-tags/plan.md` | Plan técnico |
+| `docs/feat-custom-user-tags/changelog.md` | Este archivo |
+
+## Archivos existentes sin cambios
+
+| Archivo | Nota |
+|---------|------|
+| `src/types/index.ts` | Interface `CustomTag` ya existía (agregada previamente) |

--- a/docs/feat-custom-user-tags/plan.md
+++ b/docs/feat-custom-user-tags/plan.md
@@ -1,0 +1,47 @@
+# Plan Técnico: Tags personalizados por usuario
+
+**Issue:** #5
+**Fecha:** 2026-03-11
+
+## Pasos de implementación
+
+### Paso 1: Reglas de Firestore
+- Agregar regla para colección `customTags` en `firestore.rules`
+- Read restringido al dueño (`resource.data.userId == request.auth.uid`)
+- Create/Update validan userId y label (1-30 chars)
+- Delete solo por el dueño
+
+### Paso 2: Modificar `BusinessTags.tsx`
+Este es el cambio principal. En orden:
+
+1. **Imports**: agregar `updateDoc`, `addDoc` de Firestore + iconos MUI (`LabelOutlined`) + componentes MUI (`Dialog`, `TextField`, `Menu`, `MenuItem`, `IconButton`)
+2. **Estado nuevo**:
+   - `customTags: CustomTag[]` — tags personalizados del usuario para este comercio
+   - `dialogOpen: boolean` — controla dialog de crear/editar
+   - `editingTag: CustomTag | null` — si es null, estamos creando; si tiene valor, editando
+   - `dialogValue: string` — valor del input en el dialog
+   - `menuAnchor: HTMLElement | null` — anchor del menú contextual
+   - `menuTag: CustomTag | null` — tag seleccionado en el menú
+   - `confirmDeleteOpen: boolean` — controla dialog de confirmación de borrado
+3. **`loadCustomTags()`**: query a `customTags` donde `userId == user.uid` y `businessId == businessId`
+4. **Llamar `loadCustomTags()`** en el `useEffect` existente (junto con `loadTags`)
+5. **`handleCreateOrEdit()`**: si `editingTag` es null → `addDoc`, sino → `updateDoc`. Trim + validar largo. Optimistic update.
+6. **`handleDelete()`**: `deleteDoc` + optimistic update
+7. **Render**: después de los chips predefinidos:
+   - Mapear `customTags` como chips outlined/secondary con ícono `LabelOutlined`
+   - onClick de cada custom tag → abrir menú con "Editar" / "Eliminar"
+   - Chip "+" (Agregar) al final, solo si `user` existe → abre dialog
+8. **Dialog de crear/editar**: TextField con maxLength 30, botón Guardar
+9. **Dialog de confirmación de borrado**: texto + botones Cancelar/Eliminar
+10. **Menu contextual**: MenuItem "Editar" y "Eliminar"
+
+### Paso 3: Build & test local
+- `npm run build` para verificar que compila sin errores
+- Test manual con emuladores: crear, editar, eliminar tags personalizados
+
+## Archivos afectados
+
+| Archivo | Tipo de cambio |
+|---------|---------------|
+| `firestore.rules` | Agregar regla `customTags` |
+| `src/components/business/BusinessTags.tsx` | Modificar (cambio principal) |

--- a/docs/feat-custom-user-tags/prd.md
+++ b/docs/feat-custom-user-tags/prd.md
@@ -1,0 +1,47 @@
+# PRD: Tags personalizados por usuario
+
+**Issue:** #5
+**Fecha:** 2026-03-11
+
+## Descripción
+
+Permitir a los usuarios crear etiquetas personalizadas para cualquier comercio. Estas etiquetas son **privadas** — solo visibles para el usuario que las creó — y se pueden editar y borrar.
+
+## Contexto del proyecto
+
+- La app ya tiene un sistema de **tags predefinidos** (`src/components/business/BusinessTags.tsx`) donde los usuarios votan tags como "Barato", "Delivery", etc. Estos son públicos y muestran un conteo de votos.
+- Los tags predefinidos se definen en `src/types/index.ts` como `PREDEFINED_TAGS` (6 tags: barato, apto_celiacos, apto_veganos, rapido, delivery, buena_atencion).
+- La data de comercios viene de `src/data/businesses.json` con tags "seed" por comercio.
+- Firebase Firestore es el backend. Los tags de usuarios se guardan en la colección `userTags` con IDs compuestos (`userId__businessId__tagId`).
+- La interfaz `CustomTag` ya existe en `src/types/index.ts` con campos: id, userId, businessId, label, createdAt.
+
+## Requisitos funcionales
+
+1. **Agregar tag personalizado**: Un chip "+" al final de la lista de tags predefinidos permite al usuario escribir un tag libre (texto corto).
+2. **Visibilidad privada**: Los tags personalizados solo son visibles para el usuario que los creó. Otros usuarios no los ven.
+3. **Editar tag**: El usuario puede modificar el texto de un tag personalizado que creó.
+4. **Eliminar tag**: El usuario puede borrar un tag personalizado con confirmación.
+5. **Persistencia**: Los tags se guardan en Firestore y persisten entre sesiones.
+6. **Autenticación requerida**: Solo usuarios autenticados pueden crear/editar/borrar tags personalizados. El chip "+" solo aparece si el usuario está logueado.
+
+## Requisitos no funcionales
+
+- Máximo ~30 caracteres por tag para mantener el diseño compacto.
+- Los tags personalizados se muestran visualmente diferenciados de los predefinidos (ej: otro color o estilo).
+- La interacción debe ser fluida en mobile (input inline o dialog simple).
+- Operaciones optimistas donde sea posible para UX rápida.
+
+## Consideraciones UX
+
+- El chip "+" se muestra al final de la fila de tags predefinidos, solo si el usuario está autenticado.
+- Los tags personalizados se renderizan después de los predefinidos, con un estilo diferenciado (ej: outlined con color secundario o un ícono distinto).
+- Para editar/borrar: long-press o menú contextual en el chip del tag personalizado.
+- Feedback visual inmediato al crear/editar/borrar.
+- No hay límite de cantidad de tags personalizados por comercio (razonable por naturaleza del uso).
+
+## Buenas prácticas
+
+- Usar IDs compuestos en Firestore para consultas eficientes.
+- Reglas de seguridad: solo el dueño del tag puede leer/editar/borrar sus tags personalizados.
+- Sanitizar input del usuario (trim, largo máximo).
+- Mantener consistencia visual con el sistema de tags existente.

--- a/docs/feat-custom-user-tags/specs.md
+++ b/docs/feat-custom-user-tags/specs.md
@@ -1,0 +1,109 @@
+# Especificaciones Técnicas: Tags personalizados por usuario
+
+**Issue:** #5
+**Fecha:** 2026-03-11
+
+## Modelo de datos
+
+### Colección Firestore: `customTags`
+
+Nueva colección separada de `userTags` (que es para votos en tags predefinidos).
+
+```
+customTags/{autoId}
+{
+  userId: string,       // uid del usuario
+  businessId: string,   // id del comercio
+  label: string,        // texto del tag (max 30 chars)
+  createdAt: Timestamp
+}
+```
+
+**Decisión**: Se usa `autoId` (no ID compuesto) porque un usuario puede tener múltiples tags personalizados para el mismo comercio. Cada tag es independiente.
+
+### Interface TypeScript (ya existe en `src/types/index.ts`)
+
+```typescript
+export interface CustomTag {
+  id: string;
+  userId: string;
+  businessId: string;
+  label: string;
+  createdAt: Date;
+}
+```
+
+## Componentes a modificar
+
+### 1. `src/components/business/BusinessTags.tsx`
+
+**Cambios:**
+- Agregar estado `customTags: CustomTag[]` para los tags personalizados del usuario actual.
+- Agregar `loadCustomTags()` que consulta `customTags` filtrando por `userId` y `businessId`.
+- Renderizar un chip "+" (solo si `user` existe) al final de los tags predefinidos.
+- Renderizar los tags personalizados después de los predefinidos con estilo diferenciado (outlined, color secundario).
+- Agregar estado para modal/input de creación y edición.
+- Al hacer click en un tag personalizado: abrir menú con opciones "Editar" y "Eliminar".
+
+### 2. `src/types/index.ts`
+
+**Sin cambios** — la interface `CustomTag` ya existe.
+
+### 3. `firestore.rules`
+
+**Agregar regla** para la colección `customTags`:
+```
+match /customTags/{docId} {
+  allow read: if request.auth != null
+    && resource.data.userId == request.auth.uid;
+  allow create: if request.auth != null
+    && request.resource.data.userId == request.auth.uid
+    && request.resource.data.label.size() > 0
+    && request.resource.data.label.size() <= 30;
+  allow update: if request.auth != null
+    && resource.data.userId == request.auth.uid
+    && request.resource.data.label.size() > 0
+    && request.resource.data.label.size() <= 30;
+  allow delete: if request.auth != null
+    && resource.data.userId == request.auth.uid;
+}
+```
+
+**Nota clave**: `read` solo permite leer tags propios (`resource.data.userId == request.auth.uid`), garantizando privacidad server-side.
+
+## Interacciones con Firebase
+
+| Acción | Operación Firestore |
+|--------|-------------------|
+| Cargar tags propios | `getDocs(query(collection(db, 'customTags'), where('userId', '==', uid), where('businessId', '==', businessId)))` |
+| Crear tag | `addDoc(collection(db, 'customTags'), { userId, businessId, label, createdAt: serverTimestamp() })` |
+| Editar tag | `updateDoc(doc(db, 'customTags', tagId), { label: newLabel })` |
+| Eliminar tag | `deleteDoc(doc(db, 'customTags', tagId))` |
+
+## UX / UI
+
+### Chip "+"
+- Chip outlined con ícono `Add`, texto "Agregar"
+- Solo visible si `user !== null`
+- Al hacer click: abre un `Dialog` simple con un `TextField` para escribir el label
+
+### Tags personalizados
+- Chips con `variant="outlined"`, `color="secondary"` para diferenciarlos de los predefinidos
+- Ícono: `Label` (de MUI icons) para distinguirlos visualmente
+- Al hacer click: abre un `Menu` (popover) con opciones "Editar" y "Eliminar"
+
+### Dialog de creación/edición
+- `Dialog` de MUI con `TextField` (max 30 chars)
+- Botón "Guardar" deshabilitado si el input está vacío
+- Título: "Agregar etiqueta" / "Editar etiqueta"
+
+### Eliminación
+- `Dialog` de confirmación: "¿Eliminar etiqueta '{label}'?"
+- Botones: "Cancelar" / "Eliminar"
+
+## Consideraciones de seguridad
+
+- Las reglas de Firestore garantizan que solo el dueño puede leer/escribir sus custom tags.
+- Validación de largo (1-30 chars) tanto en client como en Firestore rules.
+- `label` se sanitiza con `.trim()` antes de guardar.
+- No se permite HTML en el label (Chip de MUI escapa texto por defecto).

--- a/firestore.rules
+++ b/firestore.rules
@@ -37,5 +37,20 @@ service cloud.firestore {
       allow delete: if request.auth != null
         && resource.data.userId == request.auth.uid;
     }
+
+    match /customTags/{docId} {
+      allow read: if request.auth != null
+        && resource.data.userId == request.auth.uid;
+      allow create: if request.auth != null
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.label.size() > 0
+        && request.resource.data.label.size() <= 30;
+      allow update: if request.auth != null
+        && resource.data.userId == request.auth.uid
+        && request.resource.data.label.size() > 0
+        && request.resource.data.label.size() <= 30;
+      allow delete: if request.auth != null
+        && resource.data.userId == request.auth.uid;
+    }
   }
 }

--- a/src/components/business/BusinessTags.tsx
+++ b/src/components/business/BusinessTags.tsx
@@ -1,11 +1,38 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Box, Chip, Typography } from '@mui/material';
+import {
+  Box,
+  Chip,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Menu,
+  MenuItem,
+} from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import CheckIcon from '@mui/icons-material/Check';
-import { collection, query, where, getDocs, doc, setDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
+import LabelOutlinedIcon from '@mui/icons-material/LabelOutlined';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  setDoc,
+  deleteDoc,
+  addDoc,
+  updateDoc,
+  serverTimestamp,
+} from 'firebase/firestore';
 import { db } from '../../config/firebase';
 import { useAuth } from '../../context/AuthContext';
 import { PREDEFINED_TAGS } from '../../types';
+import type { CustomTag } from '../../types';
 
 interface Props {
   businessId: string;
@@ -21,6 +48,19 @@ interface TagCount {
 export default function BusinessTags({ businessId, seedTags }: Props) {
   const { user } = useAuth();
   const [tagCounts, setTagCounts] = useState<TagCount[]>([]);
+  const [customTags, setCustomTags] = useState<CustomTag[]>([]);
+
+  // Dialog state
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingTag, setEditingTag] = useState<CustomTag | null>(null);
+  const [dialogValue, setDialogValue] = useState('');
+
+  // Context menu state
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [menuTag, setMenuTag] = useState<CustomTag | null>(null);
+
+  // Delete confirmation
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   const loadTags = useCallback(async () => {
     const q = query(collection(db, 'userTags'), where('businessId', '==', businessId));
@@ -53,9 +93,35 @@ export default function BusinessTags({ businessId, seedTags }: Props) {
     );
   }, [businessId, seedTags, user]);
 
+  const loadCustomTags = useCallback(async () => {
+    if (!user) {
+      setCustomTags([]);
+      return;
+    }
+    const q = query(
+      collection(db, 'customTags'),
+      where('userId', '==', user.uid),
+      where('businessId', '==', businessId)
+    );
+    try {
+      const snapshot = await getDocs(q);
+      const loaded: CustomTag[] = snapshot.docs.map((d) => ({
+        id: d.id,
+        ...d.data(),
+        createdAt: d.data().createdAt?.toDate() || new Date(),
+      })) as CustomTag[];
+      loaded.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+      setCustomTags(loaded);
+    } catch (error) {
+      console.error('Error loading custom tags:', error);
+      setCustomTags([]);
+    }
+  }, [businessId, user]);
+
   useEffect(() => {
     loadTags();
-  }, [loadTags]);
+    loadCustomTags();
+  }, [loadTags, loadCustomTags]);
 
   const handleToggleTag = async (tagId: string) => {
     if (!user) return;
@@ -76,12 +142,78 @@ export default function BusinessTags({ businessId, seedTags }: Props) {
     loadTags();
   };
 
+  // Custom tag handlers
+  const handleOpenCreateDialog = () => {
+    setEditingTag(null);
+    setDialogValue('');
+    setDialogOpen(true);
+  };
+
+  const handleOpenEditDialog = () => {
+    if (!menuTag) return;
+    setEditingTag(menuTag);
+    setDialogValue(menuTag.label);
+    setMenuAnchor(null);
+    setMenuTag(null);
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+    setEditingTag(null);
+    setDialogValue('');
+  };
+
+  const handleSaveCustomTag = async () => {
+    if (!user) return;
+    const label = dialogValue.trim();
+    if (!label || label.length > 30) return;
+
+    if (editingTag) {
+      await updateDoc(doc(db, 'customTags', editingTag.id), { label });
+      setCustomTags((prev) =>
+        prev.map((t) => (t.id === editingTag.id ? { ...t, label } : t))
+      );
+    } else {
+      const docRef = await addDoc(collection(db, 'customTags'), {
+        userId: user.uid,
+        businessId,
+        label,
+        createdAt: serverTimestamp(),
+      });
+      setCustomTags((prev) => [
+        ...prev,
+        { id: docRef.id, userId: user.uid, businessId, label, createdAt: new Date() },
+      ]);
+    }
+    handleCloseDialog();
+  };
+
+  const handleOpenDeleteConfirm = () => {
+    setMenuAnchor(null);
+    setConfirmDeleteOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!menuTag) return;
+    await deleteDoc(doc(db, 'customTags', menuTag.id));
+    setCustomTags((prev) => prev.filter((t) => t.id !== menuTag.id));
+    setConfirmDeleteOpen(false);
+    setMenuTag(null);
+  };
+
+  const handleCustomTagClick = (event: React.MouseEvent<HTMLElement>, tag: CustomTag) => {
+    setMenuAnchor(event.currentTarget);
+    setMenuTag(tag);
+  };
+
   return (
     <Box sx={{ py: 1 }}>
       <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
         Etiquetas
       </Typography>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+        {/* Predefined tags */}
         {PREDEFINED_TAGS.map((tag) => {
           const tagData = tagCounts.find((t) => t.tagId === tag.id);
           const isSeed = seedTags.includes(tag.id);
@@ -106,7 +238,102 @@ export default function BusinessTags({ businessId, seedTags }: Props) {
             />
           );
         })}
+
+        {/* Custom tags */}
+        {customTags.map((tag) => (
+          <Chip
+            key={tag.id}
+            label={tag.label}
+            size="small"
+            icon={<LabelOutlinedIcon fontSize="small" />}
+            onClick={(e) => handleCustomTagClick(e, tag)}
+            variant="outlined"
+            color="secondary"
+          />
+        ))}
+
+        {/* Add custom tag button */}
+        {user && (
+          <Chip
+            label="Agregar"
+            size="small"
+            icon={<AddIcon fontSize="small" />}
+            onClick={handleOpenCreateDialog}
+            variant="outlined"
+            sx={{ borderStyle: 'dashed' }}
+          />
+        )}
       </Box>
+
+      {/* Context menu for custom tags */}
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={() => {
+          setMenuAnchor(null);
+          setMenuTag(null);
+        }}
+      >
+        <MenuItem onClick={handleOpenEditDialog}>
+          <EditIcon fontSize="small" sx={{ mr: 1 }} />
+          Editar
+        </MenuItem>
+        <MenuItem onClick={handleOpenDeleteConfirm}>
+          <DeleteIcon fontSize="small" sx={{ mr: 1 }} />
+          Eliminar
+        </MenuItem>
+      </Menu>
+
+      {/* Create/Edit dialog */}
+      <Dialog open={dialogOpen} onClose={handleCloseDialog} maxWidth="xs" fullWidth>
+        <DialogTitle>{editingTag ? 'Editar etiqueta' : 'Agregar etiqueta'}</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            placeholder="Ej: Tiene estacionamiento"
+            value={dialogValue}
+            onChange={(e) => setDialogValue(e.target.value.slice(0, 30))}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSaveCustomTag();
+              }
+            }}
+            helperText={`${dialogValue.length}/30`}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseDialog}>Cancelar</Button>
+          <Button
+            onClick={handleSaveCustomTag}
+            variant="contained"
+            disabled={!dialogValue.trim()}
+          >
+            Guardar
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={confirmDeleteOpen} onClose={() => setConfirmDeleteOpen(false)}>
+        <DialogTitle>Eliminar etiqueta</DialogTitle>
+        <DialogContent>
+          <Typography>
+            ¿Eliminar etiqueta &ldquo;{menuTag?.label}&rdquo;?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => { setConfirmDeleteOpen(false); setMenuTag(null); }}>
+            Cancelar
+          </Button>
+          <Button onClick={handleDelete} color="error" variant="contained">
+            Eliminar
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,14 @@ export interface UserTag {
   createdAt: Date;
 }
 
+export interface CustomTag {
+  id: string;
+  userId: string;
+  businessId: string;
+  label: string;
+  createdAt: Date;
+}
+
 export const PREDEFINED_TAGS = [
   { id: 'barato', label: 'Barato', icon: 'AttachMoney' },
   { id: 'apto_celiacos', label: 'Apto celíacos', icon: 'NoFood' },


### PR DESCRIPTION
## Summary
- Agrega tags personalizados privados por comercio (crear, editar, eliminar)
- Nueva colección `customTags` en Firestore con reglas de seguridad (solo el dueño lee/escribe)
- Chip "Agregar" con borde dashed, tags custom con estilo outlined/secondary
- Menú contextual (Editar/Eliminar) al clickear un tag propio
- Dialogs para crear/editar (max 30 chars) y confirmación de borrado
- Agrega flujo de nuevas funcionalidades (PRD → specs → plan) en PROCEDURES.md
- Documentación completa en docs/feat-custom-user-tags/

## Test plan
- [ ] Crear tag personalizado desde el chip "Agregar"
- [ ] Verificar que el tag aparece con estilo outlined/secondary
- [ ] Editar un tag propio desde el menú contextual
- [ ] Eliminar un tag propio con confirmación
- [ ] Verificar que los tags persisten al recargar
- [ ] Verificar que los tags no son visibles para otros usuarios
- [ ] `npm run build` pasa sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)