### PR TITLE
Feat #7: menú lateral con sección Favoritos

### DIFF
--- a/docs/feat-menu-favoritos/changelog.md
+++ b/docs/feat-menu-favoritos/changelog.md
@@ -1,0 +1,22 @@
+# Changelog: Menú lateral con sección Favoritos
+
+**Issue:** #7
+**Fecha:** 2026-03-11
+
+## Archivos creados
+
+| Archivo | Descripción |
+|---------|-------------|
+| `src/components/layout/SideMenu.tsx` | Drawer lateral con header de usuario, navegación y secciones |
+| `src/components/menu/FavoritesList.tsx` | Lista de comercios favoritos con quitar favorito y navegación al mapa |
+| `docs/feat-menu-favoritos/prd.md` | PRD |
+| `docs/feat-menu-favoritos/specs.md` | Especificaciones técnicas |
+| `docs/feat-menu-favoritos/plan.md` | Plan técnico |
+| `docs/feat-menu-favoritos/changelog.md` | Este archivo |
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/components/search/SearchBar.tsx` | Agregada prop `onMenuClick` y conectada al IconButton del menú |
+| `src/components/layout/AppShell.tsx` | Agregado estado `menuOpen`, renderizado de SideMenu, prop `onMenuClick` a SearchBar |

--- a/docs/feat-menu-favoritos/plan.md
+++ b/docs/feat-menu-favoritos/plan.md
@@ -1,0 +1,46 @@
+# Plan Técnico: Menú lateral con sección Favoritos
+
+**Issue:** #7
+**Fecha:** 2026-03-11
+
+## Pasos de implementación
+
+### Paso 1: Crear `FavoritesList.tsx`
+- Crear `src/components/menu/FavoritesList.tsx`
+- Query Firestore `favorites` por `userId`
+- Cruzar con JSON local para resolver Business
+- Renderizar lista con nombre, categoría (chip), dirección
+- Click en item → `setSelectedBusiness` + `onNavigate` (cierra drawer)
+- Botón quitar favorito → `deleteDoc` + remove del estado local
+- Estado vacío con ícono + texto
+
+### Paso 2: Crear `SideMenu.tsx`
+- Crear `src/components/layout/SideMenu.tsx`
+- MUI `Drawer` anchor left, width `min(300px, 80vw)`
+- Estado interno `activeSection: 'nav' | 'favorites'`
+- Vista nav: header usuario (avatar + nombre + editar) + lista navegación
+- Vista favorites: toolbar con botón atrás + FavoritesList
+- Dialog inline para editar displayName
+- Items Comentarios/Feedback deshabilitados con "Próximamente"
+
+### Paso 3: Modificar `SearchBar.tsx`
+- Agregar prop `onMenuClick: () => void`
+- Conectar al `onClick` del IconButton de MenuIcon (línea 33)
+
+### Paso 4: Modificar `AppShell.tsx`
+- Agregar estado `menuOpen`
+- Renderizar `SideMenu` con props `open` y `onClose`
+- Pasar `onMenuClick={() => setMenuOpen(true)}` a SearchBar
+
+### Paso 5: Build & test local
+- `npm run build` para verificar compilación
+- Test manual con emuladores
+
+## Archivos afectados
+
+| Archivo | Tipo |
+|---------|------|
+| `src/components/menu/FavoritesList.tsx` | Crear |
+| `src/components/layout/SideMenu.tsx` | Crear |
+| `src/components/search/SearchBar.tsx` | Modificar |
+| `src/components/layout/AppShell.tsx` | Modificar |

--- a/docs/feat-menu-favoritos/prd.md
+++ b/docs/feat-menu-favoritos/prd.md
@@ -1,0 +1,50 @@
+# PRD: Menú lateral con sección Favoritos
+
+**Issue:** #7
+**Fecha:** 2026-03-11
+
+## Descripción
+
+Agregar un menú lateral (hamburger menu) a la app, accesible desde el ícono de menú en el SearchBar (actualmente placeholder sin funcionalidad). En esta primera iteración se implementa la estructura del menú + la sección Favoritos. Las secciones Comentarios y Feedback quedan como placeholders para futuros issues.
+
+## Contexto del proyecto
+
+- **SearchBar** (`src/components/search/SearchBar.tsx`): ya tiene un `IconButton` con `MenuIcon` sin onClick handler.
+- **FavoriteButton** (`src/components/business/FavoriteButton.tsx`): guarda favoritos en Firestore colección `favorites` con doc ID `{uid}__{businessId}`.
+- **AuthContext** (`src/context/AuthContext.tsx`): provee `user`, `displayName`, `setDisplayName`.
+- **MapContext** (`src/context/MapContext.tsx`): provee `setSelectedBusiness()` para abrir un comercio en el mapa.
+- **useBusinesses** (`src/hooks/useBusinesses.ts`): exporta `allBusinesses` para resolver businessId → Business.
+- **AppShell** (`src/components/layout/AppShell.tsx`): contenedor principal donde se agregaría el drawer.
+
+## Requisitos funcionales
+
+### Menú lateral (drawer)
+1. El ícono hamburguesa en SearchBar abre un drawer lateral (desde la izquierda).
+2. Header del drawer: avatar con inicial del nombre, displayName, botón para editar nombre (reutiliza NameDialog).
+3. Lista de navegación: Favoritos, Comentarios (placeholder), Feedback (placeholder).
+4. Click en "Favoritos" → muestra la lista inline en el drawer.
+5. Botón "atrás" para volver a la lista de navegación.
+
+### Sección Favoritos
+6. Lista de comercios favoritos ordenados por fecha (más reciente primero).
+7. Cada item: nombre del comercio, chip de categoría, dirección.
+8. Click en un favorito → cierra drawer, centra mapa, abre BusinessSheet.
+9. Botón para quitar favorito directamente desde la lista.
+10. Estado vacío: "No tenés favoritos todavía".
+
+## Requisitos no funcionales
+- Drawer responsive: ancho ~300px, máximo 80vw.
+- Lista de favoritos se carga al abrir la sección (no al abrir el drawer).
+- Cruzar favoritos con JSON local (no queries extra por comercio).
+
+## Consideraciones UX
+- Estilo consistente con Google Maps.
+- Drawer se cierra al tocar fuera o al navegar a un comercio.
+- Secciones deshabilitadas en gris con "Próximamente".
+- Avatar con color primario (#1a73e8).
+
+## Buenas prácticas
+- Reutilizar `allBusinesses` de `useBusinesses.ts`.
+- Reutilizar `NameDialog` existente.
+- No crear colecciones nuevas en Firestore.
+- Firestore rules sin cambios.

--- a/docs/feat-menu-favoritos/specs.md
+++ b/docs/feat-menu-favoritos/specs.md
@@ -1,0 +1,106 @@
+# Especificaciones Técnicas: Menú lateral con sección Favoritos
+
+**Issue:** #7
+**Fecha:** 2026-03-11
+
+## Componentes a crear
+
+### 1. `src/components/layout/SideMenu.tsx`
+
+Drawer lateral que contiene la navegación del menú y el contenido de cada sección.
+
+**Props:**
+```typescript
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+```
+
+**Estado interno:**
+- `activeSection: 'nav' | 'favorites'` — controla qué vista se muestra dentro del drawer
+
+**Estructura:**
+- MUI `Drawer` con `anchor="left"`
+- `Box` con `width: min(300px, 80vw)`
+- **Vista 'nav'**: header de usuario + lista de navegación
+- **Vista 'favorites'**: header con botón atrás + FavoritesList
+
+**Header de usuario (vista nav):**
+- `Avatar` con inicial del displayName, bgcolor `#1a73e8`
+- `Typography` con displayName o "Anónimo"
+- `IconButton` con `EditIcon` → llama a un callback para abrir NameDialog
+
+**Nota sobre NameDialog:** El NameDialog actual solo se abre si `displayName === null`. Para reutilizarlo desde el menú, se necesita un mecanismo para forzar su apertura. Opción: agregar estado `forceNameDialog` en AuthContext, o crear un dialog inline en SideMenu. **Decisión: dialog inline simple** en SideMenu para editar nombre (reutiliza `setDisplayName` de AuthContext), ya que es más simple y no modifica el flujo existente del NameDialog.
+
+**Lista de navegación:**
+```
+ListItemButton → Favoritos (FavoriteIcon)
+ListItemButton → Comentarios (ChatBubbleOutlineIcon) — disabled, secondary text "Próximamente"
+ListItemButton → Feedback (FeedbackOutlinedIcon) — disabled, secondary text "Próximamente"
+```
+
+### 2. `src/components/menu/FavoritesList.tsx`
+
+Lista de comercios favoritos del usuario.
+
+**Props:** ninguna (usa hooks internos)
+
+**Lógica:**
+- Usa `useAuth()` para obtener `user.uid`
+- Query Firestore: `getDocs(query(collection(db, 'favorites'), where('userId', '==', user.uid)))`
+- Importa `allBusinesses` desde `useBusinesses.ts` (exportar como constante separada o importar JSON directo)
+- Cruza `businessId` de cada favorito con `allBusinesses` para obtener el objeto Business completo
+- Ordena por `createdAt` descendente
+
+**Nota sobre useBusinesses:** Actualmente `allBusinesses` se exporta desde el hook `useBusinesses()`. Para usarlo en FavoritesList sin depender de MapContext (que agrega filtros), se importará directamente el JSON:
+```typescript
+import businessesData from '../../data/businesses.json';
+import type { Business } from '../../types';
+const allBusinesses: Business[] = businessesData as Business[];
+```
+
+**Render:**
+- `List` de MUI con items:
+  - `ListItemText` primary: nombre del comercio
+  - `ListItemText` secondary: dirección
+  - `Chip` de categoría (usando `CATEGORY_LABELS`)
+  - `IconButton` con `FavoriteIcon` rojo → `deleteDoc` + remove del estado local
+- Click en item → `setSelectedBusiness(business)` via MapContext + `onClose()` del drawer
+- Estado vacío: `Box` centrado con `FavoriteBorderIcon` grande + texto
+
+## Componentes a modificar
+
+### 3. `src/components/search/SearchBar.tsx`
+
+**Cambio:** Agregar prop `onMenuClick` y conectar al IconButton del MenuIcon.
+
+```typescript
+interface Props {
+  onMenuClick: () => void;
+}
+```
+
+Línea 33: agregar `onClick={onMenuClick}` al IconButton.
+
+### 4. `src/components/layout/AppShell.tsx`
+
+**Cambio:** Agregar estado `menuOpen`, pasar `onMenuClick` a SearchBar, renderizar SideMenu.
+
+```typescript
+const [menuOpen, setMenuOpen] = useState(false);
+```
+
+## Interacciones con Firebase
+
+| Acción | Operación |
+|--------|-----------|
+| Cargar favoritos | `getDocs(query(collection(db, 'favorites'), where('userId', '==', uid)))` |
+| Quitar favorito | `deleteDoc(doc(db, 'favorites', `${uid}__${businessId}`))` |
+
+No se crean colecciones nuevas. No se modifican Firestore rules.
+
+## Consideraciones de seguridad
+
+- Las reglas de `favorites` ya permiten `read` y `delete` con `request.auth != null` y validación de `userId`.
+- No se expone data de otros usuarios.

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Box } from '@mui/material';
 import MapView from '../map/MapView';
 import LocationFAB from '../map/LocationFAB';
@@ -5,8 +6,11 @@ import SearchBar from '../search/SearchBar';
 import FilterChips from '../search/FilterChips';
 import BusinessSheet from '../business/BusinessSheet';
 import NameDialog from '../auth/NameDialog';
+import SideMenu from './SideMenu';
 
 export default function AppShell() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <Box
       sx={{
@@ -16,12 +20,13 @@ export default function AppShell() {
         overflow: 'hidden',
       }}
     >
-      <SearchBar />
+      <SearchBar onMenuClick={() => setMenuOpen(true)} />
       <FilterChips />
       <MapView />
       <LocationFAB />
       <BusinessSheet />
       <NameDialog />
+      <SideMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
     </Box>
   );
 }

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+import {
+  Drawer,
+  Box,
+  Avatar,
+  Typography,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Divider,
+  Toolbar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import EditIcon from '@mui/icons-material/Edit';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import FeedbackOutlinedIcon from '@mui/icons-material/FeedbackOutlined';
+import { useAuth } from '../../context/AuthContext';
+import FavoritesList from '../menu/FavoritesList';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Section = 'nav' | 'favorites';
+
+export default function SideMenu({ open, onClose }: Props) {
+  const { displayName, setDisplayName } = useAuth();
+  const [activeSection, setActiveSection] = useState<Section>('nav');
+
+  // Edit name dialog
+  const [nameDialogOpen, setNameDialogOpen] = useState(false);
+  const [nameValue, setNameValue] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleClose = () => {
+    onClose();
+    // Reset to nav after drawer closes
+    setTimeout(() => setActiveSection('nav'), 300);
+  };
+
+  const handleOpenNameDialog = () => {
+    setNameValue(displayName || '');
+    setNameDialogOpen(true);
+  };
+
+  const handleSaveName = async () => {
+    const trimmed = nameValue.trim();
+    if (!trimmed) return;
+    setIsSaving(true);
+    await setDisplayName(trimmed);
+    setIsSaving(false);
+    setNameDialogOpen(false);
+  };
+
+  const userName = displayName || 'Anónimo';
+
+  return (
+    <>
+      <Drawer
+        anchor="left"
+        open={open}
+        onClose={handleClose}
+      >
+        <Box sx={{ width: 'min(300px, 80vw)', height: '100%', display: 'flex', flexDirection: 'column' }}>
+          {activeSection === 'nav' ? (
+            <>
+              {/* User header */}
+              <Box sx={{ p: 2, pb: 1.5 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                  <Avatar sx={{ bgcolor: '#1a73e8', width: 40, height: 40 }}>
+                    {userName.charAt(0).toUpperCase()}
+                  </Avatar>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.2 }} noWrap>
+                      {userName}
+                    </Typography>
+                  </Box>
+                  <IconButton size="small" onClick={handleOpenNameDialog}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              </Box>
+              <Divider />
+
+              {/* Navigation */}
+              <List>
+                <ListItemButton onClick={() => setActiveSection('favorites')}>
+                  <ListItemIcon>
+                    <FavoriteIcon sx={{ color: '#ea4335' }} />
+                  </ListItemIcon>
+                  <ListItemText primary="Favoritos" />
+                </ListItemButton>
+
+                <ListItemButton disabled>
+                  <ListItemIcon>
+                    <ChatBubbleOutlineIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Comentarios" secondary="Próximamente" />
+                </ListItemButton>
+
+                <ListItemButton disabled>
+                  <ListItemIcon>
+                    <FeedbackOutlinedIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Feedback" secondary="Próximamente" />
+                </ListItemButton>
+              </List>
+            </>
+          ) : (
+            <>
+              {/* Section header with back button */}
+              <Toolbar variant="dense" sx={{ gap: 1 }}>
+                <IconButton edge="start" onClick={() => setActiveSection('nav')}>
+                  <ArrowBackIcon />
+                </IconButton>
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                  Favoritos
+                </Typography>
+              </Toolbar>
+              <Divider />
+
+              {/* Section content */}
+              <Box sx={{ flex: 1, overflow: 'auto' }}>
+                <FavoritesList onNavigate={handleClose} />
+              </Box>
+            </>
+          )}
+        </Box>
+      </Drawer>
+
+      {/* Edit name dialog */}
+      <Dialog open={nameDialogOpen} onClose={() => setNameDialogOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Editar nombre</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            value={nameValue}
+            onChange={(e) => setNameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSaveName();
+              }
+            }}
+            inputProps={{ maxLength: 30 }}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setNameDialogOpen(false)}>Cancelar</Button>
+          <Button
+            onClick={handleSaveName}
+            variant="contained"
+            disabled={isSaving || !nameValue.trim()}
+          >
+            Guardar
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/menu/FavoritesList.tsx
+++ b/src/components/menu/FavoritesList.tsx
@@ -1,0 +1,140 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  List,
+  ListItemButton,
+  ListItemText,
+  Chip,
+  IconButton,
+  Typography,
+} from '@mui/material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import { collection, query, where, getDocs, doc, deleteDoc } from 'firebase/firestore';
+import { db } from '../../config/firebase';
+import { useAuth } from '../../context/AuthContext';
+import { useMapContext } from '../../context/MapContext';
+import { CATEGORY_LABELS } from '../../types';
+import type { Business } from '../../types';
+import businessesData from '../../data/businesses.json';
+
+const allBusinesses: Business[] = businessesData as Business[];
+
+interface FavoriteItem {
+  businessId: string;
+  business: Business;
+  createdAt: Date;
+}
+
+interface Props {
+  onNavigate: () => void;
+}
+
+export default function FavoritesList({ onNavigate }: Props) {
+  const { user } = useAuth();
+  const { setSelectedBusiness } = useMapContext();
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadFavorites = useCallback(async () => {
+    if (!user) return;
+    setIsLoading(true);
+    try {
+      const q = query(collection(db, 'favorites'), where('userId', '==', user.uid));
+      const snapshot = await getDocs(q);
+      const items: FavoriteItem[] = [];
+      snapshot.forEach((d) => {
+        const data = d.data();
+        const business = allBusinesses.find((b) => b.id === data.businessId);
+        if (business) {
+          items.push({
+            businessId: data.businessId,
+            business,
+            createdAt: data.createdAt?.toDate() || new Date(),
+          });
+        }
+      });
+      items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      setFavorites(items);
+    } catch (error) {
+      console.error('Error loading favorites:', error);
+    }
+    setIsLoading(false);
+  }, [user]);
+
+  useEffect(() => {
+    loadFavorites();
+  }, [loadFavorites]);
+
+  const handleRemoveFavorite = async (businessId: string) => {
+    if (!user) return;
+    const docId = `${user.uid}__${businessId}`;
+    await deleteDoc(doc(db, 'favorites', docId));
+    setFavorites((prev) => prev.filter((f) => f.businessId !== businessId));
+  };
+
+  const handleSelectBusiness = (business: Business) => {
+    setSelectedBusiness(business);
+    onNavigate();
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ p: 3, textAlign: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          Cargando...
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (favorites.length === 0) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <FavoriteBorderIcon sx={{ fontSize: 48, color: '#ccc', mb: 1 }} />
+        <Typography variant="body2" color="text.secondary">
+          No tenés favoritos todavía
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <List disablePadding>
+      {favorites.map((fav) => (
+        <ListItemButton
+          key={fav.businessId}
+          onClick={() => handleSelectBusiness(fav.business)}
+          sx={{ pr: 1 }}
+        >
+          <ListItemText
+            primary={fav.business.name}
+            secondary={
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}>
+                <Chip
+                  label={CATEGORY_LABELS[fav.business.category]}
+                  size="small"
+                  sx={{ alignSelf: 'flex-start', fontSize: '0.7rem', height: 20 }}
+                />
+                <Typography variant="caption" color="text.secondary">
+                  {fav.business.address}
+                </Typography>
+              </Box>
+            }
+            primaryTypographyProps={{ fontWeight: 500, fontSize: '0.9rem' }}
+          />
+          <IconButton
+            edge="end"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleRemoveFavorite(fav.businessId);
+            }}
+            sx={{ color: '#ea4335' }}
+          >
+            <FavoriteIcon />
+          </IconButton>
+        </ListItemButton>
+      ))}
+    </List>
+  );
+}

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -5,7 +5,11 @@ import ClearIcon from '@mui/icons-material/Clear';
 import MenuIcon from '@mui/icons-material/Menu';
 import { useMapContext } from '../../context/MapContext';
 
-export default function SearchBar() {
+interface Props {
+  onMenuClick: () => void;
+}
+
+export default function SearchBar({ onMenuClick }: Props) {
   const { searchQuery, setSearchQuery } = useMapContext();
   const [focused, setFocused] = useState(false);
 
@@ -30,7 +34,7 @@ export default function SearchBar() {
         transition: 'box-shadow 0.2s',
       }}
     >
-      <IconButton size="small" sx={{ p: 1, color: '#5f6368' }}>
+      <IconButton size="small" onClick={onMenuClick} sx={{ p: 1, color: '#5f6368' }}>
         <MenuIcon />
       </IconButton>
       <InputBase


### PR DESCRIPTION
## Summary
- Agrega drawer lateral desde ícono hamburguesa en SearchBar
- Header con avatar, displayName editable
- Sección Favoritos: lista de comercios guardados, click navega al mapa, quitar favorito
- Placeholders para Comentarios y Feedback (próximamente)

## Test plan
- [ ] Ícono hamburguesa abre el drawer lateral
- [ ] Header muestra nombre del usuario con avatar
- [ ] Editar nombre funciona desde el drawer
- [ ] Click en "Favoritos" muestra la lista de favoritos
- [ ] Click en un favorito cierra drawer y abre el comercio en el mapa
- [ ] Quitar favorito desde la lista funciona
- [ ] Estado vacío cuando no hay favoritos
- [ ] Comentarios y Feedback aparecen deshabilitados con "Próximamente"
- [ ] `npm run build` pasa sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)