### PR TITLE
Feat #9: sección Comentarios en menú lateral

### DIFF
--- a/docs/feat-menu-comentarios/changelog.md
+++ b/docs/feat-menu-comentarios/changelog.md
@@ -1,0 +1,22 @@
+# Changelog: Sección Comentarios en menú lateral
+
+**Issue:** #9
+**Fecha:** 2026-03-11
+
+## Archivos creados
+
+| Archivo | Descripción |
+|---------|-------------|
+| `src/components/menu/CommentsList.tsx` | Lista de comentarios del usuario con navegación al comercio y eliminación |
+| `docs/feat-menu-comentarios/prd.md` | PRD |
+| `docs/feat-menu-comentarios/specs.md` | Especificaciones técnicas |
+| `docs/feat-menu-comentarios/plan.md` | Plan técnico |
+| `docs/feat-menu-comentarios/changelog.md` | Este archivo |
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `firestore.rules` | Agregada regla `allow delete` en `comments` con validación de userId |
+| `src/components/layout/SideMenu.tsx` | Habilitada sección Comentarios, ampliado tipo Section, agregado render de CommentsList |
+| `src/components/business/BusinessComments.tsx` | Agregado botón eliminar en comentarios propios con dialog de confirmación |

--- a/docs/feat-menu-comentarios/plan.md
+++ b/docs/feat-menu-comentarios/plan.md
@@ -1,0 +1,40 @@
+# Plan Técnico: Sección Comentarios en menú lateral
+
+**Issue:** #9
+**Fecha:** 2026-03-11
+
+## Pasos de implementación
+
+### Paso 1: Actualizar `firestore.rules`
+- Agregar `allow delete` en regla de `comments` con validación de userId
+
+### Paso 2: Crear `CommentsList.tsx`
+- Crear `src/components/menu/CommentsList.tsx`
+- Query Firestore por userId, cruzar con JSON local
+- Lista con nombre comercio, texto truncado, fecha
+- Click → navegar al comercio
+- Eliminar con confirmación + optimistic update
+- Estado vacío
+
+### Paso 3: Modificar `SideMenu.tsx`
+- Ampliar tipo Section a incluir `'comments'`
+- Habilitar ListItemButton de Comentarios
+- Agregar caso 'comments' en render (toolbar back + CommentsList)
+
+### Paso 4: Modificar `BusinessComments.tsx`
+- Agregar ícono eliminar en comentarios propios
+- Dialog de confirmación
+- `deleteDoc` + remove del estado local
+
+### Paso 5: Build & test local
+- `npm run build`
+- Test manual con emuladores
+
+## Archivos afectados
+
+| Archivo | Tipo |
+|---------|------|
+| `firestore.rules` | Modificar |
+| `src/components/menu/CommentsList.tsx` | Crear |
+| `src/components/layout/SideMenu.tsx` | Modificar |
+| `src/components/business/BusinessComments.tsx` | Modificar |

--- a/docs/feat-menu-comentarios/prd.md
+++ b/docs/feat-menu-comentarios/prd.md
@@ -1,0 +1,48 @@
+# PRD: Sección Comentarios en menú lateral
+
+**Issue:** #9
+**Fecha:** 2026-03-11
+
+## Descripción
+
+Agregar la sección Comentarios al menú lateral existente. Muestra el historial de comentarios del usuario en todos los comercios. También agrega la posibilidad de eliminar comentarios propios tanto desde el menú como desde el modal del comercio (BusinessComments).
+
+## Contexto del proyecto
+
+- **SideMenu** (`src/components/layout/SideMenu.tsx`): drawer lateral ya implementado con navegación. Comentarios está como placeholder disabled con "Próximamente". El tipo `Section` es `'nav' | 'favorites'`.
+- **BusinessComments** (`src/components/business/BusinessComments.tsx`): muestra comentarios por comercio. Actualmente no tiene opción de eliminar.
+- **Firestore `comments`**: colección con autoId, campos `userId`, `userName`, `businessId`, `text`, `createdAt`. La regla actual solo permite `read` y `create`, **no permite `delete`**.
+- **MapContext**: provee `setSelectedBusiness()` para navegar al comercio.
+- **businesses.json**: datos locales para resolver businessId → Business.
+
+## Requisitos funcionales
+
+### Sección Comentarios en menú lateral
+1. Click en "Comentarios" en la navegación del drawer → muestra lista de comentarios del usuario.
+2. Lista ordenada por fecha (más reciente primero).
+3. Cada item muestra: nombre del comercio, texto del comentario (truncado si es largo), fecha.
+4. Click en un comentario → cierra drawer, centra mapa, abre BusinessSheet del comercio.
+5. Botón para eliminar comentario propio desde la lista (ícono delete con confirmación).
+6. Estado vacío: "No dejaste comentarios todavía".
+
+### Eliminar comentarios desde BusinessComments
+7. En la lista de comentarios del modal del comercio, los comentarios propios del usuario muestran un ícono de eliminar.
+8. Click en eliminar → confirmación → `deleteDoc` + remove del estado local.
+
+### Firestore rules
+9. Agregar regla `delete` en `comments` para que solo el dueño pueda eliminar su comentario.
+
+## Requisitos no funcionales
+- La lista se carga al abrir la sección (no al abrir el drawer).
+- Cruzar `businessId` con JSON local para obtener nombre del comercio.
+- Texto del comentario truncado a ~80 caracteres en la lista del menú.
+
+## Consideraciones UX
+- Consistente con el diseño de FavoritesList (misma estructura de lista).
+- Ícono de eliminar solo visible en comentarios propios (en BusinessComments).
+- Confirmación antes de eliminar para evitar accidentes.
+
+## Buenas prácticas
+- Reutilizar patrón de FavoritesList para la lista de comentarios.
+- Agregar `delete` a Firestore rules con validación de `userId`.
+- Update optimista al eliminar (remove del estado local inmediato).

--- a/docs/feat-menu-comentarios/specs.md
+++ b/docs/feat-menu-comentarios/specs.md
@@ -1,0 +1,84 @@
+# Especificaciones Técnicas: Sección Comentarios en menú lateral
+
+**Issue:** #9
+**Fecha:** 2026-03-11
+
+## Componentes a crear
+
+### 1. `src/components/menu/CommentsList.tsx`
+
+Lista de comentarios del usuario en todos los comercios.
+
+**Props:**
+```typescript
+interface Props {
+  onNavigate: () => void;
+}
+```
+
+**Lógica:**
+- Query Firestore: `getDocs(query(collection(db, 'comments'), where('userId', '==', user.uid)))`
+- Importa JSON directo para resolver businessId → Business (mismo patrón que FavoritesList)
+- Ordena por `createdAt` descendente
+- Estado: `comments`, `isLoading`, `confirmDeleteId` (para dialog de confirmación)
+
+**Render por item:**
+- `ListItemButton` con click → `setSelectedBusiness(business)` + `onNavigate()`
+- Primary: nombre del comercio
+- Secondary: texto truncado (max 80 chars) + fecha formateada
+- `IconButton` con `DeleteOutlineIcon` → abre dialog de confirmación
+
+**Eliminar:**
+- `deleteDoc(doc(db, 'comments', commentId))`
+- Remove optimista del estado local
+
+**Estado vacío:**
+- `ChatBubbleOutlineIcon` grande + "No dejaste comentarios todavía"
+
+## Componentes a modificar
+
+### 2. `src/components/layout/SideMenu.tsx`
+
+**Cambios:**
+- Ampliar tipo `Section`: `'nav' | 'favorites' | 'comments'`
+- Habilitar el `ListItemButton` de Comentarios (quitar `disabled`, agregar `onClick`)
+- Agregar caso `'comments'` en el render condicional (toolbar con back + CommentsList)
+- Import de `CommentsList`
+
+### 3. `src/components/business/BusinessComments.tsx`
+
+**Cambios:**
+- Agregar `IconButton` con `DeleteOutlineIcon` en cada comentario propio (`comment.userId === user?.uid`)
+- Agregar estado `confirmDeleteId: string | null` para dialog de confirmación
+- Agregar `handleDeleteComment(id)`: `deleteDoc` + remove del estado local
+- Agregar `Dialog` de confirmación de eliminación
+- Import de `deleteDoc`, `doc` de Firestore + `DeleteOutlineIcon` + `Dialog/DialogTitle/DialogContent/DialogActions/Button`
+
+### 4. `firestore.rules`
+
+**Cambio en regla `comments`:**
+```
+match /comments/{docId} {
+  allow read: if request.auth != null;
+  allow create: if request.auth != null
+    && request.resource.data.userId == request.auth.uid
+    && request.resource.data.text.size() > 0
+    && request.resource.data.text.size() <= 500;
+  allow delete: if request.auth != null
+    && resource.data.userId == request.auth.uid;
+}
+```
+
+Solo se agrega la línea `allow delete`.
+
+## Interacciones con Firebase
+
+| Acción | Operación |
+|--------|-----------|
+| Cargar comentarios del usuario | `getDocs(query(collection(db, 'comments'), where('userId', '==', uid)))` |
+| Eliminar comentario | `deleteDoc(doc(db, 'comments', commentId))` |
+
+## Consideraciones de seguridad
+
+- La regla `delete` valida que `resource.data.userId == request.auth.uid` (solo el dueño puede eliminar).
+- No se exponen comentarios de otros usuarios en la lista del menú (filtrado por userId).

--- a/firestore.rules
+++ b/firestore.rules
@@ -28,6 +28,8 @@ service cloud.firestore {
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.text.size() > 0
         && request.resource.data.text.size() <= 500;
+      allow delete: if request.auth != null
+        && resource.data.userId == request.auth.uid;
     }
 
     match /userTags/{docId} {

--- a/src/components/business/BusinessComments.tsx
+++ b/src/components/business/BusinessComments.tsx
@@ -9,9 +9,15 @@ import {
   ListItemText,
   Avatar,
   Divider,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
-import { collection, query, where, getDocs, addDoc, serverTimestamp } from 'firebase/firestore';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { collection, query, where, getDocs, addDoc, deleteDoc, doc, serverTimestamp } from 'firebase/firestore';
 import { db } from '../../config/firebase';
 import { useAuth } from '../../context/AuthContext';
 import type { Comment } from '../../types';
@@ -25,6 +31,7 @@ export default function BusinessComments({ businessId }: Props) {
   const [comments, setComments] = useState<Comment[]>([]);
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   const loadComments = useCallback(async () => {
     const q = query(
@@ -73,6 +80,13 @@ export default function BusinessComments({ businessId }: Props) {
       console.error('Error adding comment:', error);
     }
     setIsSubmitting(false);
+  };
+
+  const handleDeleteComment = async () => {
+    if (!confirmDeleteId) return;
+    await deleteDoc(doc(db, 'comments', confirmDeleteId));
+    setComments((prev) => prev.filter((c) => c.id !== confirmDeleteId));
+    setConfirmDeleteId(null);
   };
 
   const formatDate = (date: Date) => {
@@ -149,6 +163,15 @@ export default function BusinessComments({ businessId }: Props) {
                 }
                 secondary={comment.text}
               />
+              {user && comment.userId === user.uid && (
+                <IconButton
+                  size="small"
+                  onClick={() => setConfirmDeleteId(comment.id)}
+                  sx={{ color: '#5f6368', mt: 0.5 }}
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              )}
             </ListItem>
             {index < comments.length - 1 && <Divider />}
           </Box>
@@ -159,6 +182,19 @@ export default function BusinessComments({ businessId }: Props) {
           </Typography>
         )}
       </List>
+
+      <Dialog open={Boolean(confirmDeleteId)} onClose={() => setConfirmDeleteId(null)}>
+        <DialogTitle>Eliminar comentario</DialogTitle>
+        <DialogContent>
+          <Typography>¿Eliminar este comentario?</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDeleteId(null)}>Cancelar</Button>
+          <Button onClick={handleDeleteComment} color="error" variant="contained">
+            Eliminar
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -25,13 +25,14 @@ import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import FeedbackOutlinedIcon from '@mui/icons-material/FeedbackOutlined';
 import { useAuth } from '../../context/AuthContext';
 import FavoritesList from '../menu/FavoritesList';
+import CommentsList from '../menu/CommentsList';
 
 interface Props {
   open: boolean;
   onClose: () => void;
 }
 
-type Section = 'nav' | 'favorites';
+type Section = 'nav' | 'favorites' | 'comments';
 
 export default function SideMenu({ open, onClose }: Props) {
   const { displayName, setDisplayName } = useAuth();
@@ -101,11 +102,11 @@ export default function SideMenu({ open, onClose }: Props) {
                   <ListItemText primary="Favoritos" />
                 </ListItemButton>
 
-                <ListItemButton disabled>
+                <ListItemButton onClick={() => setActiveSection('comments')}>
                   <ListItemIcon>
-                    <ChatBubbleOutlineIcon />
+                    <ChatBubbleOutlineIcon sx={{ color: '#1a73e8' }} />
                   </ListItemIcon>
-                  <ListItemText primary="Comentarios" secondary="Próximamente" />
+                  <ListItemText primary="Comentarios" />
                 </ListItemButton>
 
                 <ListItemButton disabled>
@@ -124,14 +125,15 @@ export default function SideMenu({ open, onClose }: Props) {
                   <ArrowBackIcon />
                 </IconButton>
                 <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                  Favoritos
+                  {activeSection === 'favorites' ? 'Favoritos' : 'Comentarios'}
                 </Typography>
               </Toolbar>
               <Divider />
 
               {/* Section content */}
               <Box sx={{ flex: 1, overflow: 'auto' }}>
-                <FavoritesList onNavigate={handleClose} />
+                {activeSection === 'favorites' && <FavoritesList onNavigate={handleClose} />}
+                {activeSection === 'comments' && <CommentsList onNavigate={handleClose} />}
               </Box>
             </>
           )}

--- a/src/components/menu/CommentsList.tsx
+++ b/src/components/menu/CommentsList.tsx
@@ -1,0 +1,171 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  List,
+  ListItemButton,
+  ListItemText,
+  IconButton,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+} from '@mui/material';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { collection, query, where, getDocs, doc, deleteDoc } from 'firebase/firestore';
+import { db } from '../../config/firebase';
+import { useAuth } from '../../context/AuthContext';
+import { useMapContext } from '../../context/MapContext';
+import type { Business } from '../../types';
+import businessesData from '../../data/businesses.json';
+
+const allBusinesses: Business[] = businessesData as Business[];
+
+interface CommentItem {
+  id: string;
+  businessId: string;
+  business: Business | null;
+  text: string;
+  createdAt: Date;
+}
+
+interface Props {
+  onNavigate: () => void;
+}
+
+export default function CommentsList({ onNavigate }: Props) {
+  const { user } = useAuth();
+  const { setSelectedBusiness } = useMapContext();
+  const [comments, setComments] = useState<CommentItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const loadComments = useCallback(async () => {
+    if (!user) return;
+    setIsLoading(true);
+    try {
+      const q = query(collection(db, 'comments'), where('userId', '==', user.uid));
+      const snapshot = await getDocs(q);
+      const items: CommentItem[] = snapshot.docs.map((d) => {
+        const data = d.data();
+        return {
+          id: d.id,
+          businessId: data.businessId,
+          business: allBusinesses.find((b) => b.id === data.businessId) || null,
+          text: data.text,
+          createdAt: data.createdAt?.toDate() || new Date(),
+        };
+      });
+      items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      setComments(items);
+    } catch (error) {
+      console.error('Error loading comments:', error);
+    }
+    setIsLoading(false);
+  }, [user]);
+
+  useEffect(() => {
+    loadComments();
+  }, [loadComments]);
+
+  const handleDelete = async () => {
+    if (!confirmDeleteId) return;
+    await deleteDoc(doc(db, 'comments', confirmDeleteId));
+    setComments((prev) => prev.filter((c) => c.id !== confirmDeleteId));
+    setConfirmDeleteId(null);
+  };
+
+  const handleSelectBusiness = (business: Business | null) => {
+    if (!business) return;
+    setSelectedBusiness(business);
+    onNavigate();
+  };
+
+  const formatDate = (date: Date) => {
+    return date.toLocaleDateString('es-AR', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  };
+
+  const truncate = (text: string, max: number) => {
+    return text.length > max ? text.slice(0, max) + '...' : text;
+  };
+
+  if (isLoading) {
+    return (
+      <Box sx={{ p: 3, textAlign: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          Cargando...
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (comments.length === 0) {
+    return (
+      <Box sx={{ p: 4, textAlign: 'center' }}>
+        <ChatBubbleOutlineIcon sx={{ fontSize: 48, color: '#ccc', mb: 1 }} />
+        <Typography variant="body2" color="text.secondary">
+          No dejaste comentarios todavía
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <List disablePadding>
+        {comments.map((comment) => (
+          <ListItemButton
+            key={comment.id}
+            onClick={() => handleSelectBusiness(comment.business)}
+            disabled={!comment.business}
+            sx={{ pr: 1 }}
+          >
+            <ListItemText
+              primary={comment.business?.name || 'Comercio desconocido'}
+              secondary={
+                <>
+                  <Typography component="span" variant="body2" color="text.secondary" sx={{ fontSize: '0.8rem', display: 'block' }}>
+                    {truncate(comment.text, 80)}
+                  </Typography>
+                  <Typography component="span" variant="caption" color="text.disabled" sx={{ display: 'block' }}>
+                    {formatDate(comment.createdAt)}
+                  </Typography>
+                </>
+              }
+              primaryTypographyProps={{ fontWeight: 500, fontSize: '0.9rem' }}
+            />
+            <IconButton
+              edge="end"
+              onClick={(e) => {
+                e.stopPropagation();
+                setConfirmDeleteId(comment.id);
+              }}
+              sx={{ color: '#5f6368' }}
+            >
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          </ListItemButton>
+        ))}
+      </List>
+
+      <Dialog open={Boolean(confirmDeleteId)} onClose={() => setConfirmDeleteId(null)}>
+        <DialogTitle>Eliminar comentario</DialogTitle>
+        <DialogContent>
+          <Typography>¿Eliminar este comentario?</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDeleteId(null)}>Cancelar</Button>
+          <Button onClick={handleDelete} color="error" variant="contained">
+            Eliminar
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/menu/FavoritesList.tsx
+++ b/src/components/menu/FavoritesList.tsx
@@ -110,16 +110,17 @@ export default function FavoritesList({ onNavigate }: Props) {
           <ListItemText
             primary={fav.business.name}
             secondary={
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}>
+              <>
                 <Chip
                   label={CATEGORY_LABELS[fav.business.category]}
                   size="small"
-                  sx={{ alignSelf: 'flex-start', fontSize: '0.7rem', height: 20 }}
+                  component="span"
+                  sx={{ alignSelf: 'flex-start', fontSize: '0.7rem', height: 20, display: 'inline-flex', mt: 0.5 }}
                 />
-                <Typography variant="caption" color="text.secondary">
+                <Typography component="span" variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
                   {fav.business.address}
                 </Typography>
-              </Box>
+              </>
             }
             primaryTypographyProps={{ fontWeight: 500, fontSize: '0.9rem' }}
           />


### PR DESCRIPTION
## Summary
- Agrega sección Comentarios al menú lateral con historial del usuario
- Click en comentario → navega al comercio en el mapa
- Eliminar comentarios propios desde el menú y desde el modal del comercio
- Regla `delete` agregada en Firestore rules para `comments`
- Fix de `<p>` anidados en ListItemText (CommentsList y FavoritesList)

## Test plan
- [ ] Click en "Comentarios" en el menú lateral muestra la lista
- [ ] Comentarios se muestran con nombre del comercio, texto truncado y fecha
- [ ] Click en un comentario cierra drawer y abre el comercio en el mapa
- [ ] Eliminar comentario desde el menú lateral funciona con confirmación
- [ ] Eliminar comentario propio desde el modal del comercio funciona
- [ ] No se muestra botón eliminar en comentarios de otros usuarios
- [ ] Estado vacío cuando no hay comentarios
- [ ] Sin warnings de `<p>` anidados en consola
- [ ] `npm run build` pasa sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)