### PR TITLE
Fix #13: customTags read rule permissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -48,8 +48,7 @@ service cloud.firestore {
     }
 
     match /customTags/{docId} {
-      allow read: if request.auth != null
-        && resource.data.userId == request.auth.uid;
+      allow read: if request.auth != null;
       allow create: if request.auth != null
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.label.size() > 0


### PR DESCRIPTION
## Summary
- La regla de read en customTags exigía `resource.data.userId == auth.uid`, lo cual Firestore rechaza porque evalúa las reglas contra el scope de la query
- Relajado a solo requerir autenticación (consistente con favorites, ratings, comments, userTags)
- Las operaciones de write/update/delete siguen validando ownership

## Test plan
- [ ] Abrir un comercio y verificar que las etiquetas custom cargan sin error en consola
- [ ] Crear, editar y eliminar una etiqueta custom

🤖 Generated with [Claude Code](https://claude.com/claude-code)