### PR TITLE
feat: Firebase quota mitigations — offline persistence + client-side caching (#24)

### DIFF
--- a/docs/PROJECT_REFERENCE.md
+++ b/docs/PROJECT_REFERENCE.md
@@ -62,9 +62,12 @@ main.tsx
 ### Flujo de datos
 
 1. **Datos estáticos**: `businesses.json` (40 comercios) se carga como import estático. No hay fetch.
-2. **Datos dinámicos**: Firestore (favoritos, ratings, comentarios, tags, feedback). Cada componente hace su propia query.
+2. **Datos dinámicos**: Firestore (favoritos, ratings, comentarios, tags, feedback). El hook `useBusinessData` orquesta las 5 queries en paralelo con `Promise.all` y caché client-side.
 3. **Estado global**: `AuthContext` (user, displayName) + `MapContext` (selectedBusiness, searchQuery, filters, userLocation).
 4. **Estado local**: Cada sección del menú carga sus datos al montarse y los filtra client-side con `useListFilters`.
+5. **Caché de datos**: Dos capas de caché client-side reducen lecturas Firestore:
+   - `useBusinessDataCache`: caché de vista de negocio (5 min TTL) para las 5 queries del bottom sheet.
+   - `usePaginatedQuery`: caché de primera página (2 min TTL) para listas del menú lateral.
 
 ---
 
@@ -76,7 +79,7 @@ src/
 ├── main.tsx                         # Entry point (StrictMode)
 ├── index.css                        # Estilos globales mínimos
 ├── config/
-│   ├── firebase.ts                  # Init Firebase + emuladores en DEV + App Check (prod)
+│   ├── firebase.ts                  # Init Firebase + emuladores en DEV + App Check (prod) + persistent cache (prod)
 │   ├── collections.ts               # Nombres de colecciones Firestore centralizados
 │   └── converters.ts                # FirestoreDataConverter<T> tipados por colección
 ├── context/
@@ -90,8 +93,10 @@ src/
 │   └── businesses.json              # 40 comercios con id, name, address, category, lat, lng, tags, phone
 ├── hooks/
 │   ├── useBusinesses.ts             # Filtra businesses por searchQuery + activeFilters
+│   ├── useBusinessData.ts           # Orquesta 5 queries del business view con Promise.all + caché
+│   ├── useBusinessDataCache.ts      # Caché client-side para datos del business view (5 min TTL)
 │   ├── useListFilters.ts            # Filtrado genérico: búsqueda (debounced), categoría, estrellas, ordenamiento
-│   ├── usePaginatedQuery.ts         # Paginación genérica con cursores Firestore ("Cargar más")
+│   ├── usePaginatedQuery.ts         # Paginación genérica con cursores Firestore + caché primera página (2 min TTL)
 │   └── useUserLocation.ts           # Geolocalización del navegador
 ├── components/
 │   ├── auth/
@@ -108,12 +113,12 @@ src/
 │   │   ├── SearchBar.tsx            # Barra de búsqueda fija arriba
 │   │   └── FilterChips.tsx          # Chips de tags predefinidos scrollables
 │   ├── business/
-│   │   ├── BusinessSheet.tsx        # Bottom sheet (SwipeableDrawer)
-│   │   ├── BusinessHeader.tsx       # Nombre, categoría, dirección, teléfono, favorito, direcciones
-│   │   ├── BusinessRating.tsx       # Rating promedio + estrellas del usuario
-│   │   ├── BusinessTags.tsx         # Tags predefinidos (voto) + custom tags (CRUD)
-│   │   ├── BusinessComments.tsx     # Comentarios + formulario + eliminar propios
-│   │   ├── FavoriteButton.tsx       # Corazón toggle
+│   │   ├── BusinessSheet.tsx        # Bottom sheet (SwipeableDrawer) — orquesta useBusinessData + pasa props
+│   │   ├── BusinessHeader.tsx       # Nombre, categoría, dirección, teléfono, favorito (prop), direcciones
+│   │   ├── BusinessRating.tsx       # Rating promedio + estrellas del usuario (props-driven)
+│   │   ├── BusinessTags.tsx         # Tags predefinidos (voto) + custom tags (CRUD) (props-driven)
+│   │   ├── BusinessComments.tsx     # Comentarios + formulario + eliminar propios (props-driven)
+│   │   ├── FavoriteButton.tsx       # Corazón toggle (props-driven)
 │   │   └── DirectionsButton.tsx     # Abre Google Maps Directions
 │   └── menu/
 │       ├── FavoritesList.tsx        # Lista de favoritos con filtros
@@ -271,6 +276,11 @@ En CI/CD se inyectan como GitHub Secrets.
 | **import type** | Obligatorio por `verbatimModuleSyntax: true` en tsconfig. |
 | **Hook genérico de filtros** | `useListFilters<T>` acepta cualquier item con `business` asociado. Reutilizado en favoritos y ratings. |
 | **Emuladores en DEV** | `firebase.ts` conecta a emuladores solo en `import.meta.env.DEV`. |
+| **Firestore persistent cache (prod)** | En producción se usa `initializeFirestore` con `persistentLocalCache` + `persistentMultipleTabManager` para cachear datos en IndexedDB. No se usa en DEV (emuladores no lo soportan). |
+| **Business data cache** | `useBusinessDataCache.ts` — caché module-level (`Map`) con TTL de 5 min para las 5 queries del business view. Se invalida en cada write. |
+| **First-page query cache** | `usePaginatedQuery.ts` exporta `invalidateQueryCache()`. Caché module-level (`Map`) con TTL de 2 min para la primera página de listas paginadas. |
+| **Props-driven business components** | BusinessRating, BusinessComments, BusinessTags y FavoriteButton reciben datos como props desde BusinessSheet (vía `useBusinessData`). No hacen queries internas. |
+| **Parallel query batching** | `useBusinessData` ejecuta las 5 queries de Firestore del business view en un solo `Promise.all` para reducir latencia y facilitar cache. |
 | **App Check (prod)** | Firebase App Check con reCAPTCHA Enterprise, solo en producción. Opcional: se activa si `VITE_RECAPTCHA_ENTERPRISE_SITE_KEY` está presente. |
 | **withConverter\<T\>()** | Todas las lecturas de Firestore usan `withConverter<T>()` con converters centralizados en `src/config/converters.ts`. Escrituras usan refs sin converter (por `serverTimestamp()`). |
 | **Timestamps server-side** | Todas las reglas de `create` validan `createdAt == request.time`. Ratings valida `updatedAt == request.time` en create y update. |
@@ -300,6 +310,8 @@ En CI/CD se inyectan como GitHub Secrets.
 | — | security | Resolver hallazgos pendientes: App Check, timestamps, converters | [#18](https://github.com/benoffi7/modo-mapa/pull/18) | Merged | — |
 | — | chore | Resolver mejoras técnicas: debounce, tests, paginación, husky, bundle analysis, strictTypes | [#20](https://github.com/benoffi7/modo-mapa/pull/20) | Merged | — |
 | [#19](https://github.com/benoffi7/modo-mapa/issues/19) | fix | Fix CSP policy, tags auth guard, lint errors | [#22](https://github.com/benoffi7/modo-mapa/pull/22) | Merged | `docs/fix-csp-and-tags-permissions/` |
+| [#24](https://github.com/benoffi7/modo-mapa/issues/24) | feat | Firebase quota mitigations: offline persistence, business view cache, paginated query cache | — | In Progress | `docs/feat-firebase-quota-offline/` |
+| [#25](https://github.com/benoffi7/modo-mapa/issues/25) | feat | PWA + offline mode | — | Open | — |
 
 ---
 
@@ -336,6 +348,7 @@ Cada feature tiene su carpeta en `docs/<tipo>-<descripcion>/` con:
 - Tags predefinidos: vote count + toggle del usuario
 - Tags custom: crear, editar, eliminar (privados por usuario)
 - Comentarios: lista + formulario + eliminar propios
+- Datos cargados en paralelo (`Promise.all`) con caché client-side (5 min TTL)
 
 ### Menú lateral (SideMenu)
 

--- a/docs/feat-firebase-quota-offline/changelog.md
+++ b/docs/feat-firebase-quota-offline/changelog.md
@@ -1,0 +1,28 @@
+# Changelog — Firebase Quota Mitigations
+
+## Archivos creados
+
+| Archivo | Descripción |
+|---------|-------------|
+| `src/hooks/useBusinessData.ts` | Hook orquestador: 5 queries en `Promise.all` + caché client-side |
+| `src/hooks/useBusinessDataCache.ts` | Caché module-level (`Map`) con TTL de 5 min para business view |
+| `src/hooks/useBusinessDataCache.test.ts` | Tests: get/set, TTL expiry, invalidación, independencia |
+| `docs/feat-firebase-quota-offline/prd.md` | PRD del feature |
+| `docs/feat-firebase-quota-offline/specs.md` | Especificaciones técnicas |
+| `docs/feat-firebase-quota-offline/plan.md` | Plan de implementación |
+| `docs/feat-firebase-quota-offline/changelog.md` | Este archivo |
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/config/firebase.ts` | Agregado `initializeFirestore` con `persistentLocalCache` + `persistentMultipleTabManager` en producción |
+| `src/components/business/BusinessSheet.tsx` | Usa `useBusinessData` hook, pasa datos como props a todos los hijos |
+| `src/components/business/BusinessHeader.tsx` | Recibe `favoriteButton: ReactNode` como prop en vez de renderizar FavoriteButton internamente |
+| `src/components/business/FavoriteButton.tsx` | Props-driven: recibe `isFavorite`, `isLoading`, `onToggle`. Invalida query cache tras write |
+| `src/components/business/BusinessRating.tsx` | Props-driven: recibe `ratings[]`, `isLoading`, `onRatingChange`. Calcula promedios con `useMemo` |
+| `src/components/business/BusinessComments.tsx` | Props-driven: recibe `comments[]`, `isLoading`, `onCommentsChange`. Invalida query cache tras write |
+| `src/components/business/BusinessTags.tsx` | Props-driven: recibe `userTags[]`, `customTags[]`, `isLoading`, `onTagsChange`. Calcula `tagCounts` con `useMemo` |
+| `src/hooks/usePaginatedQuery.ts` | Agregado caché de primera página (TTL 2 min), exporta `invalidateQueryCache()` |
+| `src/hooks/usePaginatedQuery.test.ts` | Agregados tests de caché y `invalidateQueryCache`. Actualizado `mockRef` con `.path` |
+| `docs/PROJECT_REFERENCE.md` | Actualizado con nuevos hooks, patrones, issue #24 y #25 |

--- a/docs/feat-firebase-quota-offline/plan.md
+++ b/docs/feat-firebase-quota-offline/plan.md
@@ -1,0 +1,188 @@
+# Plan de Implementación: Mitigaciones de Cuota Firebase
+
+**Branch:** `feat/24-firebase-quota-offline`
+**Base:** `main`
+
+---
+
+## Fase 1 — Firestore Offline Persistence
+
+### Paso 1.1: Modificar `src/config/firebase.ts`
+
+- Reemplazar `getFirestore(app)` por `initializeFirestore` con `persistentLocalCache`
+- En DEV: mantener `getFirestore(app)` sin persistence (emuladores)
+- En PROD: usar `persistentLocalCache` con `persistentMultipleTabManager`
+- Actualizar imports de `firebase/firestore`
+
+### Paso 1.2: Verificar build y lint
+
+- `npm run lint`
+- `npm run build`
+- `npm run test:run`
+
+### Paso 1.3: Test manual de persistence
+
+- `npm run dev` — verificar que emuladores siguen funcionando sin persistence
+- `npm run build && npm run preview` — verificar que IndexedDB se usa en modo producción
+- Abrir DevTools → Application → IndexedDB → verificar que Firestore crea entries
+
+---
+
+## Fase 2 — Cache Client-Side para Business View
+
+### Paso 2.1: Crear `src/hooks/useBusinessDataCache.ts`
+
+- Cache singleton (`Map` a nivel de módulo)
+- Funciones: `get(businessId)`, `set(businessId, data)`, `invalidate(businessId)`, `invalidateCollection(businessId, collection)`
+- TTL de 5 minutos
+- `invalidateCollection` borra solo la colección indicada del entry (no todo el entry)
+
+### Paso 2.2: Crear `src/hooks/useBusinessData.ts`
+
+- Hook que recibe `businessId: string | null`
+- Si hay cache válido → retorna datos del cache
+- Si no → ejecuta las 5 queries en paralelo con `Promise.all`
+- Guarda en cache tras fetch exitoso
+- Expone `refetch(collection?)` para invalidar y recargar
+
+### Paso 2.3: Refactorizar `FavoriteButton.tsx`
+
+- Cambiar props: agregar `isFavorite`, `isLoading`, `onToggle`
+- Eliminar `useEffect` de lectura y estado `isLoading` interno
+- Mantener lógica de write (setDoc/deleteDoc)
+- Después del write: llamar `onToggle()` para invalidar cache
+
+### Paso 2.4: Refactorizar `BusinessRating.tsx`
+
+- Cambiar props: agregar `ratings`, `isLoading`, `onRatingChange`
+- Calcular `averageRating`, `totalRatings`, `myRating` con `useMemo` desde props
+- Eliminar `useEffect` de lectura y `loadRatings`
+- Mantener lógica de write (setDoc)
+- Después del write: llamar `onRatingChange()`
+
+### Paso 2.5: Refactorizar `BusinessComments.tsx`
+
+- Cambiar props: agregar `comments`, `isLoading`, `onCommentsChange`
+- Eliminar `useEffect` de lectura y estado `comments` interno
+- Mantener estado local de UI: `newComment`, `isSubmitting`, `confirmDeleteId`
+- Mantener lógica de write (addDoc/deleteDoc)
+- Después del write: llamar `onCommentsChange()`
+- Mantener rate limit check (calcular desde props en vez de estado)
+
+### Paso 2.6: Refactorizar `BusinessTags.tsx`
+
+- Cambiar props: agregar `userTags`, `customTags`, `isLoading`, `onTagsChange`
+- Calcular `tagCounts` con `useMemo` desde `userTags` + `seedTags`
+- Eliminar `useEffect` de lectura y `refreshKey`
+- Mantener lógica de writes (setDoc/deleteDoc/addDoc/updateDoc)
+- Después del write: llamar `onTagsChange()`
+
+### Paso 2.7: Actualizar `BusinessSheet.tsx`
+
+- Importar y usar `useBusinessData(selectedBusiness?.id ?? null)`
+- Pasar datos como props a cada componente hijo:
+  - `FavoriteButton`: `isFavorite`, `isLoading`, `onToggle`
+  - `BusinessRating`: `ratings`, `isLoading`, `onRatingChange`
+  - `BusinessComments`: `comments`, `isLoading`, `onCommentsChange`
+  - `BusinessTags`: `userTags`, `customTags`, `isLoading`, `onTagsChange`
+
+### Paso 2.8: Verificar build, lint y tests
+
+- `npm run lint`
+- `npm run build`
+- `npm run test:run`
+
+### Paso 2.9: Test manual de cache
+
+- Abrir comercio → cerrar → reabrir antes de 5 min → verificar que no hay queries en Network tab
+- Abrir comercio → comentar → verificar que comentario aparece (cache invalidado)
+- Abrir comercio → toggle favorito → verificar reflejo inmediato
+- Abrir comercio → calificar → verificar nuevo promedio
+- Abrir comercio → toggle tag → verificar conteo actualizado
+
+---
+
+## Fase 3 — Cache de Listas del Menú
+
+### Paso 3.1: Agregar cache en `usePaginatedQuery.ts`
+
+- Cache `Map` a nivel de módulo con key `collectionPath__userId`
+- TTL de 2 minutos
+- Primera página: si hay cache válido, usar cache sin query
+- "Cargar más": siempre query (no cachear)
+- `reload()`: invalida cache y recarga
+- Exportar `invalidateQueryCache(collectionPath, userId)`
+
+### Paso 3.2: Agregar invalidación en componentes de write
+
+- `FavoriteButton.tsx`: llamar `invalidateQueryCache` del favorites collection después de toggle
+- `BusinessComments.tsx`: llamar `invalidateQueryCache` del comments collection después de create/delete
+- `BusinessRating.tsx`: llamar `invalidateQueryCache` del ratings collection después de rate
+
+### Paso 3.3: Verificar build, lint y tests
+
+- `npm run lint`
+- `npm run build`
+- `npm run test:run`
+
+### Paso 3.4: Test manual de cache de listas
+
+- Abrir favoritos → cerrar menú → reabrir favoritos (< 2 min) → sin query
+- Agregar favorito desde business view → abrir lista favoritos → nuevo favorito visible
+- Eliminar comentario desde lista → reabrir lista → comentario no aparece
+
+---
+
+## Fase 4 — Tests
+
+### Paso 4.1: Tests para `useBusinessDataCache`
+
+- Cache hit retorna datos cuando TTL no expiró
+- Cache miss retorna null cuando no hay entry
+- Cache miss retorna null cuando TTL expiró
+- `invalidate(businessId)` borra la entry completa
+- `invalidateCollection` marca solo esa colección como inválida
+
+### Paso 4.2: Tests para `useBusinessData`
+
+- Con cache válido: no hace queries a Firestore
+- Sin cache: hace 5 queries en paralelo
+- `refetch('comments')`: invalida solo comments y recarga
+- `refetch()` sin argumento: invalida todo y recarga
+- Con `businessId` null: retorna estado vacío
+
+### Paso 4.3: Actualizar tests existentes de `usePaginatedQuery`
+
+- Primera página con cache válido: no hace query
+- Primera página sin cache: hace query y guarda en cache
+- "Cargar más": siempre hace query
+- `reload()`: invalida cache y recarga
+- `invalidateQueryCache`: borra entry del cache
+
+### Paso 4.4: Verificación final
+
+- `npm run lint`
+- `npm run build`
+- `npm run test:run`
+- Test manual completo de flujo (abrir comercio, interactuar, verificar cache)
+
+---
+
+## Resumen de archivos por fase
+
+| Fase | Nuevos | Modificados | Total |
+|------|--------|------------|-------|
+| 1 | 0 | 1 | 1 |
+| 2 | 2 | 5 | 7 |
+| 3 | 0 | 4 | 4 |
+| 4 (tests) | 2 | 1 | 3 |
+| **Total** | **4** | **7** | **11** |
+
+---
+
+## Notas de coordinación
+
+- Branch `feat/24-firebase-quota-offline` desde `main`
+- Si el agente de security hardening crea su branch antes de que terminemos: sin conflicto, ambos parten de `main`
+- Archivos compartidos con security hardening: `firebase.ts` (zonas distintas), `BusinessComments.tsx` (props vs flagged field)
+- El primero que mergee a main define la base para el rebase del segundo

--- a/docs/feat-firebase-quota-offline/prd.md
+++ b/docs/feat-firebase-quota-offline/prd.md
@@ -1,0 +1,291 @@
+# PRD: Mitigaciones de Cuota Firebase y Modo Offline
+
+## Contexto
+
+La app usa Firestore sin persistencia offline configurada. Cada read/write requiere conexión y consume cuota. Con 100 usuarios estimados, los reads superan ligeramente la cuota gratuita (54K vs 50K/mes).
+
+### Reads actuales por business view (5 queries separadas)
+
+| Query | Componente | Colección | Tipo |
+|-------|-----------|-----------|------|
+| Check favorito | FavoriteButton | `favorites` | getDoc |
+| Ratings del comercio | BusinessRating | `ratings` | getDocs (where businessId) |
+| Comentarios | BusinessComments | `comments` | getDocs (where businessId) |
+| User tags | BusinessTags | `userTags` | getDocs (where businessId) |
+| Custom tags | BusinessTags | `customTags` | getDocs (where userId + businessId) |
+
+### Reads adicionales por sesión
+
+| Query | Componente | Colección | Trigger |
+|-------|-----------|-----------|---------|
+| Perfil usuario | AuthContext | `users` | Auth state change |
+| Favoritos lista | FavoritesList | `favorites` | Abrir menú sección |
+| Comentarios lista | CommentsList | `comments` | Abrir menú sección |
+| Ratings lista | RatingsList | `ratings` | Abrir menú sección |
+
+### Cuota gratuita mensual
+
+| Recurso | Cuota free | Estimación 100 usuarios | Estado |
+|---------|-----------|------------------------|--------|
+| Reads | 50,000/mes | 54,000/mes | Ligeramente over |
+| Writes | 20,000/mes | 6,000/mes | OK |
+| Deletes | 20,000/mes | ~1,000/mes | OK |
+
+---
+
+## Objetivos
+
+Reducir el consumo de reads de Firestore y habilitar navegación offline, implementando las mitigaciones con mejor relación costo/beneficio.
+
+---
+
+## Mitigación 1: Firestore Offline Persistence
+
+### Descripcion
+
+Habilitar persistencia offline de Firestore usando IndexedDB. Los datos ya consultados se sirven desde cache local en visitas posteriores, eliminando reads duplicados.
+
+### Implementacion
+
+Usar `enableMultiTabIndexedDbPersistence()` (o `initializeFirestore` con `persistenceEnabled: true` en Firebase v10+) en `src/config/firebase.ts`.
+
+```text
+firebase.ts
+  initializeFirestore(app, {
+    localCache: persistentLocalCache({
+      tabManager: persistentMultipleTabManager()
+    })
+  })
+```
+
+### Impacto estimado
+
+- **-40% reads** para usuarios recurrentes que visitan los mismos comercios
+- Los datos se sirven desde IndexedDB si existen en cache
+- Firestore sincroniza automáticamente cuando hay conexión
+- Sin cambio en la lógica de los componentes
+
+### Riesgos
+
+| Riesgo | Mitigacion |
+|--------|-----------|
+| Datos desactualizados en cache | Firestore listener sync automatico al reconectar; datos de esta app cambian poco |
+| Aumento de storage en dispositivo | IndexedDB se autogestiona; datos de esta app son pequenos (<1MB) |
+| Conflicto con emuladores | Deshabilitar persistence en modo DEV (ya se detecta `import.meta.env.DEV`) |
+
+### Complejidad: Baja
+
+Cambio solo en `firebase.ts`. No afecta ningun componente.
+
+---
+
+## Mitigacion 2: Cache client-side con TTL para Business View
+
+### Descripcion
+
+Implementar cache en memoria para los datos del business view. Cuando el usuario abre un comercio que ya visito en la sesion, los datos se sirven desde cache sin hacer queries a Firestore.
+
+### Implementacion
+
+Crear un hook `useBusinessDataCache` que:
+
+1. Mantiene un `Map<businessId, { data, timestamp }>` en memoria (via Context o module-level)
+2. Al abrir un comercio, verifica si hay datos en cache con TTL valido (5 minutos)
+3. Si hay cache valido: retorna datos inmediatamente, sin queries
+4. Si no hay cache o expiro: hace las 5 queries normales y guarda en cache
+5. Al hacer un write (comentar, votar tag, etc.): invalida el cache de ese comercio
+
+### Componentes afectados
+
+| Componente | Cambio |
+|-----------|--------|
+| `BusinessSheet` | Nuevo: pasa datos cacheados a hijos |
+| `FavoriteButton` | Recibe `isFavorite` como prop en vez de hacer getDoc |
+| `BusinessRating` | Recibe `ratings` como prop en vez de hacer getDocs |
+| `BusinessComments` | Recibe `comments` como prop en vez de hacer getDocs |
+| `BusinessTags` | Recibe `userTags` + `customTags` como props en vez de hacer getDocs |
+
+### Impacto estimado
+
+- **-60% reads por business view** en sesiones donde el usuario reabre comercios
+- En una sesion tipica de 3 comercios, si el usuario abre cada uno 2 veces: de 30 reads a 15 reads
+- Escrituras invalidan cache, garantizando consistencia
+
+### Riesgos
+
+| Riesgo | Mitigacion |
+|--------|-----------|
+| Cache desactualizado por otro usuario | TTL de 5 min limita la ventana; datos de interaccion social toleran delay |
+| Memoria | Map en memoria se limpia al cerrar tab; con 40 comercios max ~200KB |
+| Complejidad extra | Un solo hook centralizado, patron bien conocido |
+
+### Complejidad: Media
+
+Requiere refactor de como los componentes del business view obtienen datos. Los componentes hijos pasan a recibir datos como props.
+
+---
+
+## Mitigacion 3: Cache de listas del menu lateral
+
+### Descripcion
+
+Las listas del menu (favoritos, comentarios, ratings) se recargan cada vez que el usuario abre la seccion. Cachear en memoria con invalidacion al escribir.
+
+### Implementacion
+
+Modificar `usePaginatedQuery` para:
+
+1. Mantener cache por query key (coleccion + userId + pagina)
+2. Al montar la seccion: si hay cache valido (TTL 2 minutos), usar cache
+3. Al hacer write en la coleccion (agregar/eliminar favorito, comentario, etc.): invalidar cache de esa coleccion
+4. Mantener la funcionalidad de "Cargar mas" (paginacion)
+
+### Componentes afectados
+
+| Componente | Cambio |
+|-----------|--------|
+| `usePaginatedQuery` | Agregar capa de cache con TTL |
+| `FavoriteButton` | Al toggle, invalidar cache de favorites |
+| `BusinessComments` | Al crear/eliminar, invalidar cache de comments |
+| `BusinessRating` | Al calificar, invalidar cache de ratings |
+
+### Impacto estimado
+
+- **-30% reads en sesiones largas** donde el usuario navega entre secciones del menu repetidamente
+- No afecta la primera carga de cada seccion
+
+### Riesgos
+
+| Riesgo | Mitigacion |
+|--------|-----------|
+| Paginacion + cache es compleja | Solo cachear la primera pagina; "Cargar mas" siempre va a Firestore |
+| Inconsistencia tras write | Invalidar cache de la coleccion entera al escribir |
+
+### Complejidad: Media
+
+Cambio contenido en `usePaginatedQuery`. Los componentes solo necesitan llamar una funcion de invalidacion.
+
+---
+
+## Mitigacion 4: Modo offline completo
+
+### Descripcion
+
+Permitir navegar el mapa y ver datos cacheados cuando no hay conexion. Los datos estaticos (comercios) ya estan en JSON local. Las interacciones se encolan y sincronizan al reconectar.
+
+### Implementacion
+
+1. **Service Worker** con Workbox (via `vite-plugin-pwa`):
+   - Precache de assets estaticos (HTML, JS, CSS, JSON)
+   - Runtime cache de Google Maps tiles (stale-while-revalidate)
+   - Runtime cache de API responses
+
+2. **Indicador de estado offline**:
+   - Banner o chip cuando no hay conexion
+   - Icono en SearchBar o AppShell
+
+3. **Writes offline**:
+   - Firestore con persistence ya encola writes automaticamente
+   - Mostrar indicador "pendiente de sincronizacion" en items no confirmados
+
+### Dependencias nuevas
+
+| Paquete | Uso |
+|---------|-----|
+| `vite-plugin-pwa` | Genera service worker con Workbox |
+
+### Componentes afectados
+
+| Componente | Cambio |
+|-----------|--------|
+| `vite.config.ts` | Agregar VitePWA plugin |
+| `AppShell` | Indicador de estado offline |
+| Componentes de write | Indicador "pendiente de sync" (opcional) |
+
+### Impacto estimado
+
+- **100% funcionalidad de lectura offline** (mapa + datos cacheados)
+- **Writes offline encolados** se sincronizan automaticamente al reconectar
+- Mejora UX en zonas con mala conectividad (tipico en horario de almuerzo en CABA)
+
+### Riesgos
+
+| Riesgo | Mitigacion |
+|--------|-----------|
+| Google Maps tiles no cacheados | Stale-while-revalidate; sin red, mapa puede no cargar si tiles no estan en cache |
+| Conflictos de sync | Firestore resuelve conflictos por last-write-wins; aceptable para esta app |
+| Tamano del service worker | Workbox genera SW optimizado; precache solo assets criticos |
+| Complejidad de testing | Testear en Chrome DevTools con Network offline toggle |
+
+### Complejidad: Media-Alta
+
+Service worker + PWA config. No cambia logica de negocio pero agrega infraestructura.
+
+---
+
+## Evaluacion y recomendacion
+
+### Matriz de costo/beneficio
+
+| Mitigacion | Reduccion reads | Complejidad | Archivos afectados | Recomendacion |
+|-----------|----------------|-------------|-------------------|--------------|
+| 1. Offline Persistence | -40% recurrentes | Baja | 1 (firebase.ts) | **Implementar primero** |
+| 2. Cache Business View | -60% business view | Media | 6 | **Implementar segundo** |
+| 3. Cache listas menu | -30% sesiones largas | Media | 4 | **Implementar tercero** |
+| 4. Modo offline completo | N/A (UX) | Media-Alta | 3+ config | **Evaluar post-mitigaciones** |
+
+### Impacto combinado estimado (mitigaciones 1-3)
+
+| Escenario | Sin mitigacion | Con mitigaciones | Reduccion |
+|-----------|---------------|-----------------|-----------|
+| 100 usuarios, 3 comercios/sesion | 54,000 reads/mes | ~25,000 reads/mes | -54% |
+| 200 usuarios, 3 comercios/sesion | 108,000 reads/mes | ~50,000 reads/mes | -54% |
+
+Con las mitigaciones 1-3, la app soporta ~200 usuarios dentro de la cuota gratuita.
+
+### Plan de implementacion priorizado
+
+**Fase 1** — Offline Persistence (mitigacion 1)
+
+- 1 archivo modificado
+- Impacto inmediato sin cambiar logica
+
+**Fase 2** — Cache Business View (mitigacion 2)
+
+- Refactor de data fetching en business view
+- Mayor impacto en reads
+
+**Fase 3** — Cache listas menu (mitigacion 3)
+
+- Mejora `usePaginatedQuery`
+- Complementa fase 2
+
+**Fase 4** (futura) — Modo offline / PWA (mitigacion 4)
+
+- Requiere que fases 1-3 esten estables
+- Evaluar si la UX offline justifica la complejidad adicional
+- Puede ser un issue separado
+
+---
+
+## Fuera de alcance
+
+- Cambiar estructura de colecciones Firestore (breaking change)
+- Migrar a otro backend (Supabase, etc.)
+- Server-side aggregation (Cloud Functions para pre-computar datos)
+- Firestore bundles (requiere server-side)
+- Reduccion de writes (ya estan dentro de cuota)
+
+---
+
+## Criterios de aceptacion
+
+- [ ] Firestore offline persistence habilitada en produccion
+- [ ] Persistence deshabilitada en modo DEV (emuladores)
+- [ ] Cache client-side para business view con TTL de 5 min
+- [ ] Invalidacion de cache al hacer writes
+- [ ] Cache de primera pagina en listas del menu con TTL de 2 min
+- [ ] 0 regresiones en funcionalidad existente
+- [ ] Reads por sesion tipica reducidos >50%
+- [ ] 0 errores de lint, build y tests existentes
+- [ ] Tests para logica de cache (TTL, invalidacion)

--- a/docs/feat-firebase-quota-offline/specs.md
+++ b/docs/feat-firebase-quota-offline/specs.md
@@ -1,0 +1,330 @@
+# Specs Técnicas: Mitigaciones de Cuota Firebase
+
+## Fase 1 — Firestore Offline Persistence
+
+### Cambio en `src/config/firebase.ts`
+
+Reemplazar `getFirestore(app)` por `initializeFirestore` con persistent cache:
+
+```typescript
+import { initializeFirestore, persistentLocalCache, persistentMultipleTabManager } from 'firebase/firestore';
+
+// Producción: cache persistente en IndexedDB
+// DEV: sin cache persistente (emuladores no lo soportan bien)
+export const db = import.meta.env.DEV
+  ? getFirestore(app)
+  : initializeFirestore(app, {
+      localCache: persistentLocalCache({
+        tabManager: persistentMultipleTabManager(),
+      }),
+    });
+```
+
+### Comportamiento esperado
+
+- En producción: Firestore cachea documentos en IndexedDB automáticamente
+- Queries posteriores al mismo documento se sirven desde cache (0 reads)
+- Firestore sincroniza en background cuando hay conexión
+- En DEV: comportamiento actual sin cambios (emuladores)
+
+### Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/config/firebase.ts` | `getFirestore` → `initializeFirestore` con `persistentLocalCache` |
+
+---
+
+## Fase 2 — Cache Client-Side para Business View
+
+### Nuevo hook: `src/hooks/useBusinessDataCache.ts`
+
+Cache en memoria con TTL para los datos del business view.
+
+```typescript
+interface BusinessCacheEntry {
+  isFavorite: boolean;
+  ratings: Rating[];
+  comments: Comment[];
+  userTags: UserTag[];
+  customTags: CustomTag[];
+  timestamp: number;
+}
+
+interface BusinessDataCache {
+  get(businessId: string): BusinessCacheEntry | null;
+  set(businessId: string, data: BusinessCacheEntry): void;
+  invalidate(businessId: string): void;
+  invalidateCollection(businessId: string, collection: 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags'): void;
+}
+```
+
+**TTL:** 5 minutos (300,000 ms).
+
+**Storage:** `Map<string, BusinessCacheEntry>` a nivel de módulo (singleton, persiste durante la sesión del tab).
+
+### Nuevo hook: `src/hooks/useBusinessData.ts`
+
+Hook que orquesta la carga de datos del business view, usando cache o Firestore.
+
+```typescript
+interface UseBusinessDataReturn {
+  isFavorite: boolean;
+  ratings: Rating[];
+  comments: Comment[];
+  userTags: UserTag[];
+  customTags: CustomTag[];
+  isLoading: boolean;
+  error: boolean;
+  refetch: (collection?: 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags') => void;
+}
+
+function useBusinessData(businessId: string | null): UseBusinessDataReturn;
+```
+
+**Lógica:**
+
+1. Si `businessId` es null → retorna estado vacío
+2. Si hay cache válido (TTL no expirado) → retorna datos del cache
+3. Si no → ejecuta las 5 queries en paralelo con `Promise.all`:
+   - `getDoc` favorito
+   - `getDocs` ratings (where businessId)
+   - `getDocs` comments (where businessId)
+   - `getDocs` userTags (where businessId)
+   - `getDocs` customTags (where userId + businessId)
+4. Guarda resultado en cache
+5. `refetch(collection)` invalida cache de esa colección y recarga
+
+### Cambios en `BusinessSheet.tsx`
+
+```typescript
+// Antes: pasa solo businessId a cada hijo
+<BusinessRating businessId={businessId} />
+
+// Después: usa useBusinessData y pasa datos como props
+const businessData = useBusinessData(selectedBusiness?.id ?? null);
+<BusinessRating
+  businessId={businessId}
+  ratings={businessData.ratings}
+  isLoading={businessData.isLoading}
+  onRatingChange={() => businessData.refetch('ratings')}
+/>
+```
+
+### Cambios en componentes hijos
+
+#### `FavoriteButton.tsx`
+
+```typescript
+// Antes
+interface Props {
+  businessId: string;
+}
+// Estado interno: isFavorite, isLoading
+// useEffect: getDoc al montar
+
+// Después
+interface Props {
+  businessId: string;
+  isFavorite: boolean;
+  isLoading: boolean;
+  onToggle: () => void;
+}
+// Sin estado de carga propio
+// Sin useEffect de lectura
+// Al toggle: hace write a Firestore + llama onToggle para invalidar cache
+```
+
+#### `BusinessRating.tsx`
+
+```typescript
+// Antes
+interface Props {
+  businessId: string;
+}
+// Estado interno: averageRating, totalRatings, myRating
+// useEffect: getDocs al montar
+
+// Después
+interface Props {
+  businessId: string;
+  ratings: Rating[];
+  isLoading: boolean;
+  onRatingChange: () => void;
+}
+// Calcula averageRating, totalRatings, myRating desde props (useMemo)
+// Sin useEffect de lectura
+// Al calificar: write a Firestore + llama onRatingChange
+```
+
+#### `BusinessComments.tsx`
+
+```typescript
+// Antes
+interface Props {
+  businessId: string;
+}
+// Estado interno: comments[], newComment, isSubmitting, etc.
+// useEffect: getDocs al montar
+
+// Después
+interface Props {
+  businessId: string;
+  comments: Comment[];
+  isLoading: boolean;
+  onCommentsChange: () => void;
+}
+// comments viene de props, estado local solo para UI (newComment, isSubmitting, confirmDeleteId)
+// Sin useEffect de lectura
+// Al crear/eliminar: write a Firestore + llama onCommentsChange
+```
+
+#### `BusinessTags.tsx`
+
+```typescript
+// Antes
+interface Props {
+  businessId: string;
+  seedTags: string[];
+}
+// Estado interno: tagCounts[], customTags[]
+// useEffect: 2x getDocs al montar
+
+// Después
+interface Props {
+  businessId: string;
+  seedTags: string[];
+  userTags: UserTag[];
+  customTags: CustomTag[];
+  isLoading: boolean;
+  onTagsChange: () => void;
+}
+// Calcula tagCounts desde props (useMemo sobre userTags + seedTags)
+// Sin useEffect de lectura
+// Al toggle/crear/editar/eliminar: write a Firestore + llama onTagsChange
+```
+
+### Archivos nuevos
+
+| Archivo | Descripción |
+|---------|-------------|
+| `src/hooks/useBusinessDataCache.ts` | Cache singleton con TTL |
+| `src/hooks/useBusinessData.ts` | Hook orquestador de datos del business view |
+
+### Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/components/business/BusinessSheet.tsx` | Usa `useBusinessData`, pasa datos como props |
+| `src/components/business/FavoriteButton.tsx` | Props-driven, sin fetch propio |
+| `src/components/business/BusinessRating.tsx` | Props-driven, sin fetch propio |
+| `src/components/business/BusinessComments.tsx` | Props-driven, sin fetch propio |
+| `src/components/business/BusinessTags.tsx` | Props-driven, sin fetch propio |
+
+---
+
+## Fase 3 — Cache de Listas del Menú
+
+### Cambios en `src/hooks/usePaginatedQuery.ts`
+
+Agregar cache de primera página con TTL.
+
+```typescript
+// Cache a nivel de módulo
+const queryCache = new Map<string, { items: unknown[]; lastDoc: unknown; hasMore: boolean; timestamp: number }>();
+
+// TTL: 2 minutos
+const CACHE_TTL = 2 * 60 * 1000;
+
+// Generar cache key
+function getCacheKey(collectionPath: string, userId: string): string {
+  return `${collectionPath}__${userId}`;
+}
+
+// Nueva función exportada para invalidar
+export function invalidateQueryCache(collectionPath: string, userId: string): void {
+  queryCache.delete(getCacheKey(collectionPath, userId));
+}
+```
+
+**Lógica modificada en `loadPage`:**
+
+1. Si es primera página y hay cache válido → usar cache, no hacer query
+2. Si es primera página y no hay cache → hacer query y guardar en cache
+3. Si es "Cargar más" → siempre hacer query (no cachear páginas subsiguientes)
+4. `reload()` → invalida cache y recarga
+
+### Invalidación desde componentes de write
+
+Los componentes que hacen writes deben invalidar el cache de la colección afectada:
+
+| Componente | Acción | Invalidar |
+|-----------|--------|-----------|
+| `FavoriteButton` | toggle favorito | `favorites` cache |
+| `BusinessComments` | crear/eliminar comentario | `comments` cache |
+| `BusinessRating` | calificar | `ratings` cache |
+
+La invalidación se hace llamando `invalidateQueryCache(collectionPath, userId)` después del write exitoso.
+
+### Archivos modificados
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/hooks/usePaginatedQuery.ts` | Cache de primera página + export `invalidateQueryCache` |
+| `src/components/business/FavoriteButton.tsx` | Llama `invalidateQueryCache` en toggle |
+| `src/components/business/BusinessComments.tsx` | Llama `invalidateQueryCache` en create/delete |
+| `src/components/business/BusinessRating.tsx` | Llama `invalidateQueryCache` en rate |
+
+---
+
+## Resumen de archivos totales
+
+### Archivos nuevos (2)
+
+| Archivo | Fase |
+|---------|------|
+| `src/hooks/useBusinessDataCache.ts` | 2 |
+| `src/hooks/useBusinessData.ts` | 2 |
+
+### Archivos modificados (7)
+
+| Archivo | Fases | Cambios |
+|---------|-------|---------|
+| `src/config/firebase.ts` | 1 | `initializeFirestore` con persistent cache |
+| `src/components/business/BusinessSheet.tsx` | 2 | `useBusinessData` + props a hijos |
+| `src/components/business/FavoriteButton.tsx` | 2, 3 | Props-driven + invalidar query cache |
+| `src/components/business/BusinessRating.tsx` | 2, 3 | Props-driven + invalidar query cache |
+| `src/components/business/BusinessComments.tsx` | 2, 3 | Props-driven + invalidar query cache |
+| `src/components/business/BusinessTags.tsx` | 2 | Props-driven |
+| `src/hooks/usePaginatedQuery.ts` | 3 | Cache de primera página |
+
+### Sin archivos eliminados
+
+---
+
+## Testing
+
+### Tests unitarios nuevos
+
+| Test | Qué valida |
+|------|-----------|
+| `useBusinessDataCache.test.ts` | TTL expira, invalidate borra entrada, invalidateCollection recarga solo esa |
+| `useBusinessData.test.ts` | Cache hit no hace queries, cache miss hace 5 queries, refetch invalida y recarga |
+| `usePaginatedQuery.test.ts` (actualizar) | Cache hit en primera página, cache miss hace query, loadMore no usa cache, reload invalida |
+
+### Tests manuales
+
+| Escenario | Verificar |
+|-----------|----------|
+| Abrir comercio → cerrar → reabrir (< 5 min) | No hay queries a Firestore (cache hit) |
+| Abrir comercio → comentar → cerrar → reabrir | Comentario nuevo visible (cache invalidado) |
+| Abrir favoritos → cerrar → reabrir (< 2 min) | No hay query a Firestore |
+| Agregar favorito → abrir lista favoritos | Favorito nuevo visible (cache invalidado) |
+| Cerrar tab → reabrir app | Datos se cargan desde IndexedDB (persistence) |
+| Modo avión → abrir comercio visitado | Datos visibles desde IndexedDB cache |
+
+---
+
+## Dependencias
+
+No se agregan dependencias nuevas. Todo se implementa con APIs existentes de Firebase y React.

--- a/src/components/business/BusinessComments.tsx
+++ b/src/components/business/BusinessComments.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo } from 'react';
+import { useState, memo } from 'react';
 import {
   Box,
   Typography,
@@ -17,46 +17,25 @@ import {
 } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import { collection, query, where, getDocs, addDoc, deleteDoc, doc, serverTimestamp } from 'firebase/firestore';
+import { collection, addDoc, deleteDoc, doc, serverTimestamp } from 'firebase/firestore';
 import { db } from '../../config/firebase';
 import { COLLECTIONS } from '../../config/collections';
-import { commentConverter } from '../../config/converters';
 import { useAuth } from '../../context/AuthContext';
+import { invalidateQueryCache } from '../../hooks/usePaginatedQuery';
 import type { Comment } from '../../types';
 
 interface Props {
   businessId: string;
+  comments: Comment[];
+  isLoading: boolean;
+  onCommentsChange: () => void;
 }
 
-export default memo(function BusinessComments({ businessId }: Props) {
+export default memo(function BusinessComments({ businessId, comments, isLoading, onCommentsChange }: Props) {
   const { user, displayName } = useAuth();
-  const [comments, setComments] = useState<Comment[]>([]);
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const [error, setError] = useState(false);
-  const [refreshKey, setRefreshKey] = useState(0);
-
-  useEffect(() => {
-    let ignore = false;
-    const q = query(
-      collection(db, COLLECTIONS.COMMENTS).withConverter(commentConverter),
-      where('businessId', '==', businessId)
-    );
-    getDocs(q).then((snapshot) => {
-      if (ignore) return;
-      const loaded: Comment[] = snapshot.docs.map((d) => d.data());
-      loaded.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-      setError(false);
-      setComments(loaded);
-    }).catch((err) => {
-      if (ignore) return;
-      console.error('Error loading comments:', err);
-      setError(true);
-      setComments([]);
-    });
-    return () => { ignore = true; };
-  }, [businessId, refreshKey]);
 
   const MAX_COMMENTS_PER_DAY = 20;
 
@@ -73,19 +52,16 @@ export default memo(function BusinessComments({ businessId }: Props) {
     const text = newComment.trim();
     const userName = displayName || 'Anónimo';
     try {
-      const docRef = await addDoc(collection(db, COLLECTIONS.COMMENTS), {
+      await addDoc(collection(db, COLLECTIONS.COMMENTS), {
         userId: user.uid,
         userName,
         businessId,
         text,
         createdAt: serverTimestamp(),
       });
-      // Optimistic update: add to local state immediately
-      setComments((prev) => [
-        { id: docRef.id, userId: user.uid, userName, businessId, text, createdAt: new Date() },
-        ...prev,
-      ]);
       setNewComment('');
+      invalidateQueryCache(COLLECTIONS.COMMENTS, user.uid);
+      onCommentsChange();
     } catch (error) {
       console.error('Error adding comment:', error);
     }
@@ -93,10 +69,11 @@ export default memo(function BusinessComments({ businessId }: Props) {
   };
 
   const handleDeleteComment = async () => {
-    if (!confirmDeleteId) return;
+    if (!confirmDeleteId || !user) return;
     await deleteDoc(doc(db, COLLECTIONS.COMMENTS, confirmDeleteId));
-    setComments((prev) => prev.filter((c) => c.id !== confirmDeleteId));
     setConfirmDeleteId(null);
+    invalidateQueryCache(COLLECTIONS.COMMENTS, user.uid);
+    onCommentsChange();
   };
 
   const formatDate = (date: Date) => {
@@ -110,7 +87,7 @@ export default memo(function BusinessComments({ businessId }: Props) {
   return (
     <Box sx={{ py: 1 }}>
       <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
-        Comentarios ({comments.length})
+        Comentarios ({isLoading ? '...' : comments.length})
       </Typography>
 
       {user && (
@@ -141,15 +118,6 @@ export default memo(function BusinessComments({ businessId }: Props) {
           >
             <SendIcon fontSize="small" />
           </Button>
-        </Box>
-      )}
-
-      {error && (
-        <Box sx={{ py: 2, textAlign: 'center' }}>
-          <Typography variant="body2" color="error" sx={{ mb: 1 }}>
-            Error al cargar comentarios
-          </Typography>
-          <Button size="small" onClick={() => setRefreshKey((k) => k + 1)}>Reintentar</Button>
         </Box>
       )}
 
@@ -195,7 +163,7 @@ export default memo(function BusinessComments({ businessId }: Props) {
             {index < comments.length - 1 && <Divider />}
           </Box>
         ))}
-        {comments.length === 0 && (
+        {!isLoading && comments.length === 0 && (
           <Typography variant="body2" color="text.secondary" sx={{ py: 2, textAlign: 'center' }}>
             Sé el primero en comentar
           </Typography>

--- a/src/components/business/BusinessHeader.tsx
+++ b/src/components/business/BusinessHeader.tsx
@@ -1,16 +1,17 @@
+import type { ReactNode } from 'react';
 import { Box, Typography, Chip } from '@mui/material';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import PhoneIcon from '@mui/icons-material/Phone';
 import type { Business } from '../../types';
 import { CATEGORY_LABELS } from '../../types';
-import FavoriteButton from './FavoriteButton';
 import DirectionsButton from './DirectionsButton';
 
 interface Props {
   business: Business;
+  favoriteButton: ReactNode;
 }
 
-export default function BusinessHeader({ business }: Props) {
+export default function BusinessHeader({ business, favoriteButton }: Props) {
   return (
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
@@ -24,7 +25,7 @@ export default function BusinessHeader({ business }: Props) {
             sx={{ mt: 0.5, fontSize: '0.75rem', height: 24 }}
           />
         </Box>
-        <FavoriteButton businessId={business.id} />
+        {favoriteButton}
       </Box>
 
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1, color: 'text.secondary' }}>

--- a/src/components/business/BusinessRating.tsx
+++ b/src/components/business/BusinessRating.tsx
@@ -1,50 +1,37 @@
-import { useState, useEffect, useCallback, memo } from 'react';
-import { Box, Typography, Rating, Button } from '@mui/material';
-import { collection, query, where, getDocs, doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { useMemo, memo } from 'react';
+import { Box, Typography, Rating } from '@mui/material';
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '../../config/firebase';
 import { COLLECTIONS } from '../../config/collections';
-import { ratingConverter } from '../../config/converters';
 import { useAuth } from '../../context/AuthContext';
+import { invalidateQueryCache } from '../../hooks/usePaginatedQuery';
+import type { Rating as RatingType } from '../../types';
 
 interface Props {
   businessId: string;
+  ratings: RatingType[];
+  isLoading: boolean;
+  onRatingChange: () => void;
 }
 
-export default memo(function BusinessRating({ businessId }: Props) {
+export default memo(function BusinessRating({ businessId, ratings, isLoading, onRatingChange }: Props) {
   const { user } = useAuth();
-  const [averageRating, setAverageRating] = useState<number>(0);
-  const [totalRatings, setTotalRatings] = useState(0);
-  const [myRating, setMyRating] = useState<number | null>(null);
-  const [error, setError] = useState(false);
 
-  const loadRatings = useCallback(async () => {
-    const q = query(collection(db, COLLECTIONS.RATINGS).withConverter(ratingConverter), where('businessId', '==', businessId));
-    try {
-      setError(false);
-      const snapshot = await getDocs(q);
-
-      let sum = 0;
-      let count = 0;
-      snapshot.forEach((docSnap) => {
-        const data = docSnap.data();
-        sum += data.score;
-        count++;
-        if (user && data.userId === user.uid) {
-          setMyRating(data.score);
-        }
-      });
-
-      setTotalRatings(count);
-      setAverageRating(count > 0 ? sum / count : 0);
-    } catch (err) {
-      console.error('Error loading ratings:', err);
-      setError(true);
+  const { averageRating, totalRatings, myRating } = useMemo(() => {
+    let sum = 0;
+    let myScore: number | null = null;
+    for (const r of ratings) {
+      sum += r.score;
+      if (user && r.userId === user.uid) {
+        myScore = r.score;
+      }
     }
-  }, [businessId, user]);
-
-  useEffect(() => {
-    loadRatings();
-  }, [loadRatings]);
+    return {
+      averageRating: ratings.length > 0 ? sum / ratings.length : 0,
+      totalRatings: ratings.length,
+      myRating: myScore,
+    };
+  }, [ratings, user]);
 
   const handleRate = async (_: unknown, value: number | null) => {
     if (!user || !value) return;
@@ -56,17 +43,14 @@ export default memo(function BusinessRating({ businessId }: Props) {
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
     }, { merge: true });
-    setMyRating(value);
-    loadRatings();
+    invalidateQueryCache(COLLECTIONS.RATINGS, user.uid);
+    onRatingChange();
   };
 
-  if (error) {
+  if (!isLoading && ratings.length === 0 && !user) {
     return (
-      <Box sx={{ py: 1, textAlign: 'center' }}>
-        <Typography variant="body2" color="error" sx={{ mb: 1 }}>
-          Error al cargar calificaciones
-        </Typography>
-        <Button size="small" onClick={loadRatings}>Reintentar</Button>
+      <Box sx={{ py: 1 }}>
+        <Typography variant="body2" color="text.secondary">Sin calificaciones aún</Typography>
       </Box>
     );
   }

--- a/src/components/business/BusinessSheet.tsx
+++ b/src/components/business/BusinessSheet.tsx
@@ -1,13 +1,17 @@
 import { SwipeableDrawer, Box, Divider } from '@mui/material';
 import { useMapContext } from '../../context/MapContext';
+import { useBusinessData } from '../../hooks/useBusinessData';
 import BusinessHeader from './BusinessHeader';
 import BusinessRating from './BusinessRating';
 import BusinessTags from './BusinessTags';
 import BusinessComments from './BusinessComments';
+import FavoriteButton from './FavoriteButton';
 
 export default function BusinessSheet() {
   const { selectedBusiness, setSelectedBusiness } = useMapContext();
   const isOpen = selectedBusiness !== null;
+  const businessId = selectedBusiness?.id ?? null;
+  const data = useBusinessData(businessId);
 
   const handleClose = () => setSelectedBusiness(null);
   const handleOpen = () => {};
@@ -45,13 +49,40 @@ export default function BusinessSheet() {
           </Box>
 
           <Box sx={{ px: 2, pb: 'calc(24px + env(safe-area-inset-bottom))' }}>
-            <BusinessHeader business={selectedBusiness} />
+            <BusinessHeader
+              business={selectedBusiness}
+              favoriteButton={
+                <FavoriteButton
+                  businessId={selectedBusiness.id}
+                  isFavorite={data.isFavorite}
+                  isLoading={data.isLoading}
+                  onToggle={() => data.refetch('favorites')}
+                />
+              }
+            />
             <Divider sx={{ my: 1.5 }} />
-            <BusinessRating businessId={selectedBusiness.id} />
+            <BusinessRating
+              businessId={selectedBusiness.id}
+              ratings={data.ratings}
+              isLoading={data.isLoading}
+              onRatingChange={() => data.refetch('ratings')}
+            />
             <Divider sx={{ my: 1.5 }} />
-            <BusinessTags businessId={selectedBusiness.id} seedTags={selectedBusiness.tags} />
+            <BusinessTags
+              businessId={selectedBusiness.id}
+              seedTags={selectedBusiness.tags}
+              userTags={data.userTags}
+              customTags={data.customTags}
+              isLoading={data.isLoading}
+              onTagsChange={() => data.refetch('userTags')}
+            />
             <Divider sx={{ my: 1.5 }} />
-            <BusinessComments businessId={selectedBusiness.id} />
+            <BusinessComments
+              businessId={selectedBusiness.id}
+              comments={data.comments}
+              isLoading={data.isLoading}
+              onCommentsChange={() => data.refetch('comments')}
+            />
           </Box>
         </Box>
       )}

--- a/src/components/business/BusinessTags.tsx
+++ b/src/components/business/BusinessTags.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo } from 'react';
+import { useState, useMemo, memo } from 'react';
 import {
   Box,
   Chip,
@@ -19,9 +19,6 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {
   collection,
-  query,
-  where,
-  getDocs,
   doc,
   setDoc,
   deleteDoc,
@@ -31,14 +28,17 @@ import {
 } from 'firebase/firestore';
 import { db } from '../../config/firebase';
 import { COLLECTIONS } from '../../config/collections';
-import { userTagConverter, customTagConverter } from '../../config/converters';
 import { useAuth } from '../../context/AuthContext';
 import { PREDEFINED_TAGS } from '../../types';
-import type { CustomTag } from '../../types';
+import type { CustomTag, UserTag } from '../../types';
 
 interface Props {
   businessId: string;
   seedTags: string[];
+  userTags: UserTag[];
+  customTags: CustomTag[];
+  isLoading: boolean;
+  onTagsChange: () => void;
 }
 
 interface TagCount {
@@ -47,10 +47,8 @@ interface TagCount {
   userAdded: boolean;
 }
 
-export default memo(function BusinessTags({ businessId, seedTags }: Props) {
+export default memo(function BusinessTags({ businessId, seedTags, userTags, customTags, isLoading, onTagsChange }: Props) {
   const { user } = useAuth();
-  const [tagCounts, setTagCounts] = useState<TagCount[]>([]);
-  const [customTags, setCustomTags] = useState<CustomTag[]>([]);
 
   // Dialog state
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -63,79 +61,29 @@ export default memo(function BusinessTags({ businessId, seedTags }: Props) {
 
   // Delete confirmation
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
-  const [error, setError] = useState(false);
-  const [refreshKey, setRefreshKey] = useState(0);
-
-  useEffect(() => {
-    let ignore = false;
-
-    if (!user) {
-      Promise.resolve().then(() => {
-        if (ignore) return;
-        setTagCounts(
-          seedTags.map((tagId) => ({ tagId, count: 0, userAdded: false }))
-        );
-        setCustomTags([]);
-      });
-      return () => { ignore = true; };
-    }
-
-    // Load tags
-    const tagsQuery = query(
-      collection(db, COLLECTIONS.USER_TAGS).withConverter(userTagConverter),
-      where('businessId', '==', businessId)
-    );
-    getDocs(tagsQuery).then((snapshot) => {
-      if (ignore) return;
-      const counts: Record<string, { count: number; userAdded: boolean }> = {};
-      seedTags.forEach((tagId) => {
-        counts[tagId] = { count: 0, userAdded: false };
-      });
-      snapshot.forEach((d) => {
-        const data = d.data();
-        if (!counts[data.tagId]) {
-          counts[data.tagId] = { count: 0, userAdded: false };
-        }
-        counts[data.tagId].count++;
-        if (data.userId === user.uid) {
-          counts[data.tagId].userAdded = true;
-        }
-      });
-      setError(false);
-      setTagCounts(
-        Object.entries(counts).map(([tagId, { count, userAdded }]) => ({
-          tagId,
-          count,
-          userAdded,
-        }))
-      );
-    }).catch((err) => {
-      if (ignore) return;
-      console.error('Error loading tags:', err);
-      setError(true);
-    });
-
-    // Load custom tags
-    const customQuery = query(
-      collection(db, COLLECTIONS.CUSTOM_TAGS).withConverter(customTagConverter),
-      where('userId', '==', user.uid),
-      where('businessId', '==', businessId)
-    );
-    getDocs(customQuery).then((snapshot) => {
-      if (ignore) return;
-      const loaded: CustomTag[] = snapshot.docs.map((d) => d.data());
-      loaded.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
-      setCustomTags(loaded);
-    }).catch((err) => {
-      if (ignore) return;
-      console.error('Error loading custom tags:', err);
-      setCustomTags([]);
-    });
-
-    return () => { ignore = true; };
-  }, [businessId, seedTags, user, refreshKey]);
 
   const [pendingTagId, setPendingTagId] = useState<string | null>(null);
+
+  const tagCounts = useMemo<TagCount[]>(() => {
+    const counts: Record<string, { count: number; userAdded: boolean }> = {};
+    seedTags.forEach((tagId) => {
+      counts[tagId] = { count: 0, userAdded: false };
+    });
+    userTags.forEach((ut) => {
+      if (!counts[ut.tagId]) {
+        counts[ut.tagId] = { count: 0, userAdded: false };
+      }
+      counts[ut.tagId].count++;
+      if (user && ut.userId === user.uid) {
+        counts[ut.tagId].userAdded = true;
+      }
+    });
+    return Object.entries(counts).map(([tagId, { count, userAdded }]) => ({
+      tagId,
+      count,
+      userAdded,
+    }));
+  }, [seedTags, userTags, user]);
 
   const handleToggleTag = async (tagId: string) => {
     if (!user) return;
@@ -147,11 +95,6 @@ export default memo(function BusinessTags({ businessId, seedTags }: Props) {
     try {
       if (existing?.userAdded) {
         await deleteDoc(tagRef);
-        setTagCounts((prev) =>
-          prev.map((t) =>
-            t.tagId === tagId ? { ...t, count: Math.max(0, t.count - 1), userAdded: false } : t
-          )
-        );
       } else {
         await setDoc(tagRef, {
           userId: user.uid,
@@ -159,12 +102,8 @@ export default memo(function BusinessTags({ businessId, seedTags }: Props) {
           tagId,
           createdAt: serverTimestamp(),
         });
-        setTagCounts((prev) =>
-          prev.map((t) =>
-            t.tagId === tagId ? { ...t, count: t.count + 1, userAdded: true } : t
-          )
-        );
       }
+      onTagsChange();
     } catch (err) {
       console.error('Error toggling tag:', err);
     }
@@ -203,22 +142,16 @@ export default memo(function BusinessTags({ businessId, seedTags }: Props) {
 
     if (editingTag) {
       await updateDoc(doc(db, COLLECTIONS.CUSTOM_TAGS, editingTag.id), { label });
-      setCustomTags((prev) =>
-        prev.map((t) => (t.id === editingTag.id ? { ...t, label } : t))
-      );
     } else {
-      const docRef = await addDoc(collection(db, COLLECTIONS.CUSTOM_TAGS), {
+      await addDoc(collection(db, COLLECTIONS.CUSTOM_TAGS), {
         userId: user.uid,
         businessId,
         label,
         createdAt: serverTimestamp(),
       });
-      setCustomTags((prev) => [
-        ...prev,
-        { id: docRef.id, userId: user.uid, businessId, label, createdAt: new Date() },
-      ]);
     }
     handleCloseDialog();
+    onTagsChange();
   };
 
   const handleOpenDeleteConfirm = () => {
@@ -229,9 +162,9 @@ export default memo(function BusinessTags({ businessId, seedTags }: Props) {
   const handleDelete = async () => {
     if (!menuTag) return;
     await deleteDoc(doc(db, COLLECTIONS.CUSTOM_TAGS, menuTag.id));
-    setCustomTags((prev) => prev.filter((t) => t.id !== menuTag.id));
     setConfirmDeleteOpen(false);
     setMenuTag(null);
+    onTagsChange();
   };
 
   const handleCustomTagClick = (event: React.MouseEvent<HTMLElement>, tag: CustomTag) => {
@@ -239,16 +172,7 @@ export default memo(function BusinessTags({ businessId, seedTags }: Props) {
     setMenuTag(tag);
   };
 
-  if (error) {
-    return (
-      <Box sx={{ py: 1, textAlign: 'center' }}>
-        <Typography variant="body2" color="error" sx={{ mb: 1 }}>
-          Error al cargar etiquetas
-        </Typography>
-        <Button size="small" onClick={() => setRefreshKey((k) => k + 1)}>Reintentar</Button>
-      </Box>
-    );
-  }
+  if (isLoading) return null;
 
   return (
     <Box sx={{ py: 1 }}>

--- a/src/components/business/FavoriteButton.tsx
+++ b/src/components/business/FavoriteButton.tsx
@@ -1,57 +1,51 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { IconButton } from '@mui/material';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
-import { doc, getDoc, setDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
+import { doc, setDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '../../config/firebase';
 import { COLLECTIONS } from '../../config/collections';
 import { useAuth } from '../../context/AuthContext';
+import { invalidateQueryCache } from '../../hooks/usePaginatedQuery';
 
 interface Props {
   businessId: string;
+  isFavorite: boolean;
+  isLoading: boolean;
+  onToggle: () => void;
 }
 
-export default function FavoriteButton({ businessId }: Props) {
+export default function FavoriteButton({ businessId, isFavorite, isLoading, onToggle }: Props) {
   const { user } = useAuth();
-  const [isFavorite, setIsFavorite] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const docId = user ? `${user.uid}__${businessId}` : null;
-
-  useEffect(() => {
-    if (!docId) return;
-    getDoc(doc(db, COLLECTIONS.FAVORITES, docId)).then((snap) => {
-      setIsFavorite(snap.exists());
-      setIsLoading(false);
-    });
-  }, [docId]);
+  const [isToggling, setIsToggling] = useState(false);
 
   const toggleFavorite = useCallback(async () => {
-    if (!user || !docId) return;
-    setIsLoading(true);
+    if (!user) return;
+    const docId = `${user.uid}__${businessId}`;
+    setIsToggling(true);
     try {
       if (isFavorite) {
         await deleteDoc(doc(db, COLLECTIONS.FAVORITES, docId));
-        setIsFavorite(false);
       } else {
         await setDoc(doc(db, COLLECTIONS.FAVORITES, docId), {
           userId: user.uid,
           businessId,
           createdAt: serverTimestamp(),
         });
-        setIsFavorite(true);
       }
+      invalidateQueryCache(COLLECTIONS.FAVORITES, user.uid);
+      onToggle();
     } catch (error) {
       console.error('Error toggling favorite:', error);
     }
-    setIsLoading(false);
-  }, [user, docId, isFavorite, businessId]);
+    setIsToggling(false);
+  }, [user, businessId, isFavorite, onToggle]);
 
   return (
     <IconButton
       aria-label={isFavorite ? 'Quitar de favoritos' : 'Agregar a favoritos'}
       onClick={toggleFavorite}
-      disabled={isLoading || !user}
+      disabled={isLoading || isToggling || !user}
       sx={{ color: isFavorite ? '#ea4335' : '#5f6368' }}
     >
       {isFavorite ? <FavoriteIcon /> : <FavoriteBorderIcon />}

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -1,6 +1,12 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth, connectAuthEmulator } from 'firebase/auth';
-import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
+import {
+  getFirestore,
+  connectFirestoreEmulator,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+} from 'firebase/firestore';
 import { initializeAppCheck, ReCaptchaEnterpriseProvider } from 'firebase/app-check';
 
 const requiredEnvVars = [
@@ -26,7 +32,16 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
-export const db = getFirestore(app);
+
+// DEV: getFirestore estándar (emuladores no soportan persistent cache)
+// PROD: persistent cache en IndexedDB para reducir reads de Firestore
+export const db = import.meta.env.DEV
+  ? getFirestore(app)
+  : initializeFirestore(app, {
+      localCache: persistentLocalCache({
+        tabManager: persistentMultipleTabManager(),
+      }),
+    });
 
 if (import.meta.env.DEV) {
   connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });

--- a/src/hooks/useBusinessData.ts
+++ b/src/hooks/useBusinessData.ts
@@ -1,0 +1,128 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
+import { db } from '../config/firebase';
+import { COLLECTIONS } from '../config/collections';
+import { ratingConverter, commentConverter, userTagConverter, customTagConverter } from '../config/converters';
+import { useAuth } from '../context/AuthContext';
+import { getBusinessCache, setBusinessCache, invalidateBusinessCache } from './useBusinessDataCache';
+import type { Rating, Comment, UserTag, CustomTag } from '../types';
+
+interface UseBusinessDataReturn {
+  isFavorite: boolean;
+  ratings: Rating[];
+  comments: Comment[];
+  userTags: UserTag[];
+  customTags: CustomTag[];
+  isLoading: boolean;
+  error: boolean;
+  refetch: (collectionName?: 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags') => void;
+}
+
+const EMPTY: UseBusinessDataReturn = {
+  isFavorite: false,
+  ratings: [],
+  comments: [],
+  userTags: [],
+  customTags: [],
+  isLoading: false,
+  error: false,
+  refetch: () => {},
+};
+
+async function fetchBusinessData(bId: string, uid: string) {
+  const favDocId = `${uid}__${bId}`;
+
+  const [favSnap, ratingsSnap, commentsSnap, userTagsSnap, customTagsSnap] = await Promise.all([
+    getDoc(doc(db, COLLECTIONS.FAVORITES, favDocId)),
+    getDocs(query(
+      collection(db, COLLECTIONS.RATINGS).withConverter(ratingConverter),
+      where('businessId', '==', bId),
+    )),
+    getDocs(query(
+      collection(db, COLLECTIONS.COMMENTS).withConverter(commentConverter),
+      where('businessId', '==', bId),
+    )),
+    getDocs(query(
+      collection(db, COLLECTIONS.USER_TAGS).withConverter(userTagConverter),
+      where('businessId', '==', bId),
+    )),
+    getDocs(query(
+      collection(db, COLLECTIONS.CUSTOM_TAGS).withConverter(customTagConverter),
+      where('userId', '==', uid),
+      where('businessId', '==', bId),
+    )),
+  ]);
+
+  const commentsResult = commentsSnap.docs.map((d) => d.data());
+  commentsResult.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  const customTagsResult = customTagsSnap.docs.map((d) => d.data());
+  customTagsResult.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+  return {
+    isFavorite: favSnap.exists(),
+    ratings: ratingsSnap.docs.map((d) => d.data()),
+    comments: commentsResult,
+    userTags: userTagsSnap.docs.map((d) => d.data()),
+    customTags: customTagsResult,
+  };
+}
+
+export function useBusinessData(businessId: string | null): UseBusinessDataReturn {
+  const { user } = useAuth();
+  const [data, setData] = useState<{
+    isFavorite: boolean;
+    ratings: Rating[];
+    comments: Comment[];
+    userTags: UserTag[];
+    customTags: CustomTag[];
+  }>({ isFavorite: false, ratings: [], comments: [], userTags: [], customTags: [] });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const fetchIdRef = useRef(0);
+
+  const load = useCallback(async (bId: string, uid: string) => {
+    const id = ++fetchIdRef.current;
+
+    const cached = getBusinessCache(bId);
+    if (cached) {
+      setData(cached);
+      setIsLoading(false);
+      setError(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(false);
+
+    try {
+      const result = await fetchBusinessData(bId, uid);
+      if (fetchIdRef.current !== id) return; // stale
+      setData(result);
+      setBusinessCache(bId, result);
+    } catch (err) {
+      if (fetchIdRef.current !== id) return;
+      console.error('Error loading business data:', err);
+      setError(true);
+    }
+
+    if (fetchIdRef.current === id) {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!businessId || !user) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async data fetch on mount/dependency change
+    load(businessId, user.uid);
+  }, [businessId, user, load]);
+
+  const refetch = useCallback(() => {
+    if (!businessId || !user) return;
+    invalidateBusinessCache(businessId);
+    load(businessId, user.uid);
+  }, [businessId, user, load]);
+
+  if (!businessId) return EMPTY;
+
+  return { ...data, isLoading, error, refetch };
+}

--- a/src/hooks/useBusinessDataCache.test.ts
+++ b/src/hooks/useBusinessDataCache.test.ts
@@ -1,0 +1,64 @@
+import {
+  getBusinessCache,
+  setBusinessCache,
+  invalidateBusinessCache,
+} from './useBusinessDataCache';
+
+describe('useBusinessDataCache', () => {
+  beforeEach(() => {
+    // Clear cache between tests
+    invalidateBusinessCache('biz_001');
+    invalidateBusinessCache('biz_002');
+  });
+
+  const mockData = {
+    isFavorite: true,
+    ratings: [{ userId: 'u1', businessId: 'biz_001', score: 4, createdAt: new Date(), updatedAt: new Date() }],
+    comments: [],
+    userTags: [],
+    customTags: [],
+  };
+
+  it('returns null for uncached business', () => {
+    expect(getBusinessCache('biz_001')).toBeNull();
+  });
+
+  it('returns cached data within TTL', () => {
+    setBusinessCache('biz_001', mockData);
+    const cached = getBusinessCache('biz_001');
+    expect(cached).not.toBeNull();
+    expect(cached!.isFavorite).toBe(true);
+    expect(cached!.ratings).toHaveLength(1);
+  });
+
+  it('returns null after TTL expires', () => {
+    setBusinessCache('biz_001', mockData);
+
+    // Manually expire by manipulating the timestamp
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    expect(getBusinessCache('biz_001')).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('invalidate removes cached entry', () => {
+    setBusinessCache('biz_001', mockData);
+    expect(getBusinessCache('biz_001')).not.toBeNull();
+
+    invalidateBusinessCache('biz_001');
+    expect(getBusinessCache('biz_001')).toBeNull();
+  });
+
+  it('caches different businesses independently', () => {
+    setBusinessCache('biz_001', mockData);
+    setBusinessCache('biz_002', { ...mockData, isFavorite: false });
+
+    expect(getBusinessCache('biz_001')!.isFavorite).toBe(true);
+    expect(getBusinessCache('biz_002')!.isFavorite).toBe(false);
+
+    invalidateBusinessCache('biz_001');
+    expect(getBusinessCache('biz_001')).toBeNull();
+    expect(getBusinessCache('biz_002')).not.toBeNull();
+  });
+});

--- a/src/hooks/useBusinessDataCache.ts
+++ b/src/hooks/useBusinessDataCache.ts
@@ -1,0 +1,32 @@
+import type { Rating, Comment, UserTag, CustomTag } from '../types';
+
+export interface BusinessCacheEntry {
+  isFavorite: boolean;
+  ratings: Rating[];
+  comments: Comment[];
+  userTags: UserTag[];
+  customTags: CustomTag[];
+  timestamp: number;
+}
+
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+const cache = new Map<string, BusinessCacheEntry>();
+
+export function getBusinessCache(businessId: string): BusinessCacheEntry | null {
+  const entry = cache.get(businessId);
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > CACHE_TTL) {
+    cache.delete(businessId);
+    return null;
+  }
+  return entry;
+}
+
+export function setBusinessCache(businessId: string, data: Omit<BusinessCacheEntry, 'timestamp'>): void {
+  cache.set(businessId, { ...data, timestamp: Date.now() });
+}
+
+export function invalidateBusinessCache(businessId: string): void {
+  cache.delete(businessId);
+}

--- a/src/hooks/usePaginatedQuery.test.ts
+++ b/src/hooks/usePaginatedQuery.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { usePaginatedQuery } from './usePaginatedQuery';
+import { usePaginatedQuery, invalidateQueryCache } from './usePaginatedQuery';
 
 const mockGetDocs = vi.fn();
 
@@ -23,11 +23,13 @@ function makeSnapshot(docs: ReturnType<typeof makeDoc>[]) {
 describe('usePaginatedQuery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Clear query cache between tests to avoid interference
+    invalidateQueryCache('testCollection', 'user-1');
   });
 
   it('returns loading state initially', () => {
     mockGetDocs.mockResolvedValue(makeSnapshot([]));
-    const mockRef = {} as never;
+    const mockRef = { path: 'testCollection' } as never;
 
     const { result } = renderHook(() =>
       usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
@@ -40,7 +42,7 @@ describe('usePaginatedQuery', () => {
   it('loads first page of items', async () => {
     const docs = [makeDoc({ name: 'A' }), makeDoc({ name: 'B' })];
     mockGetDocs.mockResolvedValue(makeSnapshot(docs));
-    const mockRef = {} as never;
+    const mockRef = { path: 'testCollection' } as never;
 
     const { result } = renderHook(() =>
       usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
@@ -61,7 +63,7 @@ describe('usePaginatedQuery', () => {
       makeDoc({ name: 'C' }),
     ];
     mockGetDocs.mockResolvedValue(makeSnapshot(docs));
-    const mockRef = {} as never;
+    const mockRef = { path: 'testCollection' } as never;
 
     const { result } = renderHook(() =>
       usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
@@ -86,7 +88,7 @@ describe('usePaginatedQuery', () => {
       .mockResolvedValueOnce(makeSnapshot(firstPage))
       .mockResolvedValueOnce(makeSnapshot(secondPage));
 
-    const mockRef = {} as never;
+    const mockRef = { path: 'testCollection' } as never;
 
     const { result } = renderHook(() =>
       usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
@@ -119,7 +121,7 @@ describe('usePaginatedQuery', () => {
       .mockResolvedValueOnce(makeSnapshot(firstLoad))
       .mockResolvedValueOnce(makeSnapshot(reloadData));
 
-    const mockRef = {} as never;
+    const mockRef = { path: 'testCollection' } as never;
 
     const { result } = renderHook(() =>
       usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
@@ -140,7 +142,7 @@ describe('usePaginatedQuery', () => {
 
   it('sets error on failure', async () => {
     mockGetDocs.mockRejectedValue(new Error('Network error'));
-    const mockRef = {} as never;
+    const mockRef = { path: 'testCollection' } as never;
 
     const { result } = renderHook(() =>
       usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
@@ -165,12 +167,75 @@ describe('usePaginatedQuery', () => {
   });
 
   it('skips query when userId is undefined', async () => {
-    const mockRef = {} as never;
+    const mockRef = { path: 'testCollection' } as never;
     const { result } = renderHook(() =>
       usePaginatedQuery(mockRef, undefined, 'createdAt', 2),
     );
 
     expect(result.current.isLoading).toBe(true);
     expect(mockGetDocs).not.toHaveBeenCalled();
+  });
+
+  it('serves first page from cache on second render', async () => {
+    const docs = [makeDoc({ name: 'A' }), makeDoc({ name: 'B' })];
+    mockGetDocs.mockResolvedValue(makeSnapshot(docs));
+    const mockRef = { path: 'testCollection' } as never;
+
+    // First render — fetches from Firestore and populates cache
+    const { result, unmount } = renderHook(() =>
+      usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(mockGetDocs).toHaveBeenCalledTimes(1);
+    unmount();
+
+    // Second render — should serve from cache without calling getDocs again
+    mockGetDocs.mockClear();
+    const { result: result2 } = renderHook(() =>
+      usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
+    );
+
+    await waitFor(() => {
+      expect(result2.current.isLoading).toBe(false);
+    });
+    expect(result2.current.items).toEqual([{ name: 'A' }, { name: 'B' }]);
+    expect(mockGetDocs).not.toHaveBeenCalled();
+  });
+
+  it('invalidateQueryCache forces fresh fetch', async () => {
+    const docs = [makeDoc({ name: 'A' })];
+    mockGetDocs.mockResolvedValue(makeSnapshot(docs));
+    const mockRef = { path: 'testCollection' } as never;
+
+    // First render — populates cache
+    const { result, unmount } = renderHook(() =>
+      usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    unmount();
+
+    // Invalidate cache
+    invalidateQueryCache('testCollection', 'user-1');
+
+    // Second render — should fetch again
+    mockGetDocs.mockClear();
+    const freshDocs = [makeDoc({ name: 'B' })];
+    mockGetDocs.mockResolvedValue(makeSnapshot(freshDocs));
+
+    const { result: result2 } = renderHook(() =>
+      usePaginatedQuery(mockRef, 'user-1', 'createdAt', 2),
+    );
+
+    await waitFor(() => {
+      expect(result2.current.isLoading).toBe(false);
+    });
+    expect(result2.current.items).toEqual([{ name: 'B' }]);
+    expect(mockGetDocs).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/usePaginatedQuery.ts
+++ b/src/hooks/usePaginatedQuery.ts
@@ -22,6 +22,27 @@ interface UsePaginatedQueryReturn<T> {
   reload: () => Promise<void>;
 }
 
+// --- First-page cache with TTL ---
+const CACHE_TTL = 2 * 60 * 1000; // 2 minutes
+
+interface CacheEntry {
+  items: unknown[];
+  lastDoc: unknown;
+  hasMore: boolean;
+  timestamp: number;
+}
+
+const queryCache = new Map<string, CacheEntry>();
+
+function getCacheKey(collectionPath: string, userId: string): string {
+  return `${collectionPath}__${userId}`;
+}
+
+/** Invalidate the first-page cache for a given collection + user. */
+export function invalidateQueryCache(collectionPath: string, userId: string): void {
+  queryCache.delete(getCacheKey(collectionPath, userId));
+}
+
 /**
  * Paginated Firestore query hook with "Load more" pattern.
  *
@@ -45,10 +66,25 @@ export function usePaginatedQuery<T>(
 
   const stableRef = useMemo(() => collectionRef, [collectionRef]);
 
-  const loadPage = useCallback(async (cursor: QueryDocumentSnapshot<T> | null) => {
+  const loadPage = useCallback(async (cursor: QueryDocumentSnapshot<T> | null, skipCache = false) => {
     if (!stableRef || !userId) return;
 
     const isFirstPage = cursor === null;
+
+    // Check cache for first page only
+    if (isFirstPage && !skipCache) {
+      const cacheKey = getCacheKey(stableRef.path, userId);
+      const cached = queryCache.get(cacheKey);
+      if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+        setItems(cached.items as T[]);
+        setHasMore(cached.hasMore);
+        lastDocRef.current = cached.lastDoc as QueryDocumentSnapshot<T> | null;
+        setIsLoading(false);
+        setError(false);
+        return;
+      }
+    }
+
     if (isFirstPage) {
       setIsLoading(true);
     } else {
@@ -75,6 +111,15 @@ export function usePaginatedQuery<T>(
       const pageItems = pageDocs.map((d) => d.data());
       if (isFirstPage) {
         setItems(pageItems);
+
+        // Cache first page
+        const cacheKey = getCacheKey(stableRef.path, userId);
+        queryCache.set(cacheKey, {
+          items: pageItems,
+          lastDoc: lastDocRef.current,
+          hasMore: hasMoreResults,
+          timestamp: Date.now(),
+        });
       } else {
         setItems((prev) => [...prev, ...pageItems]);
       }
@@ -102,9 +147,12 @@ export function usePaginatedQuery<T>(
   }, [hasMore, isLoadingMore, loadPage]);
 
   const reload = useCallback(async () => {
+    if (stableRef && userId) {
+      invalidateQueryCache(stableRef.path, userId);
+    }
     lastDocRef.current = null;
-    await loadPage(null);
-  }, [loadPage]);
+    await loadPage(null, true);
+  }, [loadPage, stableRef, userId]);
 
   return { items, isLoading, isLoadingMore, error, hasMore, loadMore, reload };
 }


### PR DESCRIPTION
## Summary

- **Firestore offline persistence** (prod): `initializeFirestore` with `persistentLocalCache` + `persistentMultipleTabManager` — caches data in IndexedDB, reducing reads on repeat visits (~40% reduction)
- **Business view cache**: New `useBusinessData` hook batches 5 Firestore queries with `Promise.all` and caches results with 5-min TTL (~60% reduction per business view)
- **Paginated query cache**: First-page cache with 2-min TTL in `usePaginatedQuery`, with `invalidateQueryCache()` export for cross-component invalidation (~30% reduction on menu lists)
- **Props-driven refactor**: BusinessRating, BusinessComments, BusinessTags, and FavoriteButton now receive data as props from BusinessSheet instead of fetching internally

**Estimated combined impact**: ~54K → ~25K Firestore reads/month

## Files changed

### New files (7)
- `src/hooks/useBusinessData.ts` — orchestrator hook
- `src/hooks/useBusinessDataCache.ts` — module-level Map cache with TTL
- `src/hooks/useBusinessDataCache.test.ts` — cache tests
- `docs/feat-firebase-quota-offline/prd.md`, `specs.md`, `plan.md`, `changelog.md`

### Modified files (10)
- `src/config/firebase.ts` — persistent cache in production
- `src/components/business/BusinessSheet.tsx` — uses useBusinessData, passes props
- `src/components/business/BusinessHeader.tsx` — accepts favoriteButton as ReactNode prop
- `src/components/business/FavoriteButton.tsx` — props-driven
- `src/components/business/BusinessRating.tsx` — props-driven
- `src/components/business/BusinessComments.tsx` — props-driven
- `src/components/business/BusinessTags.tsx` — props-driven
- `src/hooks/usePaginatedQuery.ts` — first-page cache + invalidateQueryCache export
- `src/hooks/usePaginatedQuery.test.ts` — cache tests added
- `docs/PROJECT_REFERENCE.md` — updated with new hooks, patterns, issues #24/#25

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — TypeScript + Vite build passes
- [x] `npm run test:run` — 69/69 tests pass (including 6 new cache tests)
- [ ] Manual: open business sheet, verify data loads, close and reopen — should load from cache
- [ ] Manual: add comment/rating, verify cache invalidation and fresh data
- [ ] Manual: check menu lists load from cache on re-entry within 2 min

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)