### PR TITLE
fix: selective refetch and optimistic rating (#41)

### DIFF
--- a/src/components/business/BusinessRating.tsx
+++ b/src/components/business/BusinessRating.tsx
@@ -1,4 +1,4 @@
-import { useMemo, memo } from 'react';
+import { useMemo, useState, memo } from 'react';
 import { Box, Typography, Rating } from '@mui/material';
 import { useAuth } from '../../context/AuthContext';
 import { upsertRating } from '../../services/ratings';
@@ -14,7 +14,7 @@ interface Props {
 export default memo(function BusinessRating({ businessId, ratings, isLoading, onRatingChange }: Props) {
   const { user } = useAuth();
 
-  const { averageRating, totalRatings, myRating } = useMemo(() => {
+  const { averageRating, totalRatings, serverMyRating } = useMemo(() => {
     let sum = 0;
     let myScore: number | null = null;
     for (const r of ratings) {
@@ -26,14 +26,23 @@ export default memo(function BusinessRating({ businessId, ratings, isLoading, on
     return {
       averageRating: ratings.length > 0 ? sum / ratings.length : 0,
       totalRatings: ratings.length,
-      myRating: myScore,
+      serverMyRating: myScore,
     };
   }, [ratings, user]);
 
+  const [pendingRating, setPendingRating] = useState<number | null>(null);
+
+  const myRating = pendingRating ?? serverMyRating;
+
   const handleRate = async (_: unknown, value: number | null) => {
     if (!user || !value) return;
-    await upsertRating(user.uid, businessId, value);
-    onRatingChange();
+    setPendingRating(value);
+    try {
+      await upsertRating(user.uid, businessId, value);
+      onRatingChange();
+    } finally {
+      setPendingRating(null);
+    }
   };
 
   if (!isLoading && ratings.length === 0 && !user) {

--- a/src/hooks/useBusinessData.ts
+++ b/src/hooks/useBusinessData.ts
@@ -4,7 +4,7 @@ import { db } from '../config/firebase';
 import { COLLECTIONS } from '../config/collections';
 import { ratingConverter, commentConverter, userTagConverter, customTagConverter } from '../config/converters';
 import { useAuth } from '../context/AuthContext';
-import { getBusinessCache, setBusinessCache, invalidateBusinessCache } from './useBusinessDataCache';
+import { getBusinessCache, setBusinessCache, invalidateBusinessCache, patchBusinessCache } from './useBusinessDataCache';
 import type { Rating, Comment, UserTag, CustomTag } from '../types';
 
 interface UseBusinessDataReturn {
@@ -15,7 +15,7 @@ interface UseBusinessDataReturn {
   customTags: CustomTag[];
   isLoading: boolean;
   error: boolean;
-  refetch: (collectionName?: 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags') => void;
+  refetch: (collectionName?: CollectionName) => void;
 }
 
 const EMPTY: UseBusinessDataReturn = {
@@ -28,6 +28,50 @@ const EMPTY: UseBusinessDataReturn = {
   error: false,
   refetch: () => {},
 };
+
+type CollectionName = 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags';
+
+async function fetchSingleCollection(bId: string, uid: string, col: CollectionName) {
+  switch (col) {
+    case 'favorites': {
+      const snap = await getDoc(doc(db, COLLECTIONS.FAVORITES, `${uid}__${bId}`));
+      return { isFavorite: snap.exists() };
+    }
+    case 'ratings': {
+      const snap = await getDocs(query(
+        collection(db, COLLECTIONS.RATINGS).withConverter(ratingConverter),
+        where('businessId', '==', bId),
+      ));
+      return { ratings: snap.docs.map((d) => d.data()) };
+    }
+    case 'comments': {
+      const snap = await getDocs(query(
+        collection(db, COLLECTIONS.COMMENTS).withConverter(commentConverter),
+        where('businessId', '==', bId),
+      ));
+      const result = snap.docs.map((d) => d.data()).filter((c) => !c.flagged);
+      result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      return { comments: result };
+    }
+    case 'userTags': {
+      const snap = await getDocs(query(
+        collection(db, COLLECTIONS.USER_TAGS).withConverter(userTagConverter),
+        where('businessId', '==', bId),
+      ));
+      return { userTags: snap.docs.map((d) => d.data()) };
+    }
+    case 'customTags': {
+      const snap = await getDocs(query(
+        collection(db, COLLECTIONS.CUSTOM_TAGS).withConverter(customTagConverter),
+        where('userId', '==', uid),
+        where('businessId', '==', bId),
+      ));
+      const result = snap.docs.map((d) => d.data());
+      result.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+      return { customTags: result };
+    }
+  }
+}
 
 async function fetchBusinessData(bId: string, uid: string) {
   const favDocId = `${uid}__${bId}`;
@@ -116,10 +160,26 @@ export function useBusinessData(businessId: string | null): UseBusinessDataRetur
     load(businessId, user.uid);
   }, [businessId, user, load]);
 
-  const refetch = useCallback(() => {
+  const refetch = useCallback((collectionName?: CollectionName) => {
     if (!businessId || !user) return;
-    invalidateBusinessCache(businessId);
-    load(businessId, user.uid);
+
+    if (!collectionName) {
+      invalidateBusinessCache(businessId);
+      load(businessId, user.uid);
+      return;
+    }
+
+    const id = ++fetchIdRef.current;
+    fetchSingleCollection(businessId, user.uid, collectionName)
+      .then((patch) => {
+        if (fetchIdRef.current !== id) return;
+        setData((prev) => ({ ...prev, ...patch }));
+        patchBusinessCache(businessId, patch);
+      })
+      .catch((err) => {
+        if (fetchIdRef.current !== id) return;
+        if (import.meta.env.DEV) console.error(`Error refetching ${collectionName}:`, err);
+      });
   }, [businessId, user, load]);
 
   if (!businessId) return EMPTY;

--- a/src/hooks/useBusinessDataCache.ts
+++ b/src/hooks/useBusinessDataCache.ts
@@ -30,3 +30,12 @@ export function setBusinessCache(businessId: string, data: Omit<BusinessCacheEnt
 export function invalidateBusinessCache(businessId: string): void {
   cache.delete(businessId);
 }
+
+export function patchBusinessCache(
+  businessId: string,
+  patch: Partial<Omit<BusinessCacheEntry, 'timestamp'>>,
+): void {
+  const entry = cache.get(businessId);
+  if (!entry) return;
+  cache.set(businessId, { ...entry, ...patch, timestamp: Date.now() });
+}


### PR DESCRIPTION
## Summary
- **Selective refetch**: `refetch(collectionName)` now only reloads the specified collection (1 Firestore query) instead of all 5, reducing reads ~80% per action
- **Optimistic rating**: Star rating uses local state to prevent flicker between tap and server response
- **Cache patching**: New `patchBusinessCache` merges partial updates without invalidating the full cache

Closes #41

## Test plan
- [x] TypeScript compiles clean
- [x] 87 tests passing
- [x] ESLint clean
- [x] Tested locally: tags don't reload on unrelated actions, stars don't flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)