### PR TITLE
feat: Comentarios 2.0 + Compartir comercio (#45, #46)

### DIFF
--- a/docs/INFORME_MEJORAS_FUNCIONALES.md
+++ b/docs/INFORME_MEJORAS_FUNCIONALES.md
@@ -1,0 +1,624 @@
+# Informe de Mejoras Funcionales — Modo Mapa v2.0
+
+**Fecha:** 2026-03-12
+**Version base:** 1.5.1
+**Objetivo:** Roadmap de mejoras funcionales para transformar Modo Mapa de una herramienta de consulta en una plataforma social gastronómica.
+
+---
+
+## Resumen ejecutivo
+
+| # | Feature | Prioridad | Complejidad | Impacto |
+|---|---------|-----------|-------------|---------|
+| F1 | Comentarios 2.0 (editar, eliminar, likes, orden) | Alta | Media | Alto |
+| F2 | Fotos de menú (upload + validación admin) | Alta | Alta | Alto |
+| F3 | Hub social (rankings de usuarios) | Media | Media | Alto |
+| F4 | Notificaciones in-app | Media | Media | Medio |
+| F5 | Respuestas a comentarios (threads) | Media | Media | Medio |
+| F6 | Perfil de usuario público | Baja | Baja | Medio |
+| F7 | Reseñas detalladas (multi-criterio) | Baja | Media | Medio |
+| F8 | Compartir comercio | Baja | Baja | Bajo |
+| F9 | Historial de visitas | Baja | Baja | Bajo |
+| F10 | Sugerencias personalizadas | Baja | Alta | Alto |
+
+---
+
+## F1 — Comentarios 2.0
+
+**Issue existente:** [#17](https://github.com/benoffi7/modo-mapa/issues/17) (edición)
+
+### Alcance
+
+Transformar la sección de comentarios de "solo escribir y borrar" a una experiencia interactiva completa con edición, likes y ordenamiento.
+
+### Sub-features
+
+#### F1.1 — Editar comentarios propios
+
+- Botón "Editar" (icono lápiz) visible solo en comentarios del usuario actual
+- Inline editing: el texto del comentario se convierte en TextField editable
+- Botones "Guardar" / "Cancelar"
+- Campo `updatedAt` en Firestore para trackear ediciones
+- Indicador visual "editado" (texto sutil al lado de la fecha)
+- Validación: mismas reglas que creación (1-500 chars, moderación server-side)
+- Firestore rules: solo el owner puede actualizar, validar `updatedAt == request.time`
+
+**Archivos afectados:**
+
+- `src/services/comments.ts` — nueva función `editComment(commentId, text)`
+- `src/components/business/BusinessComments.tsx` — UI de edición inline
+- `src/types/index.ts` — agregar `updatedAt?` al tipo `Comment`
+- `firestore.rules` — regla de update para comments
+- `functions/src/triggers/comments.ts` — trigger onUpdate para re-moderar
+
+#### F1.2 — Eliminar comentarios (mejora UX)
+
+- Actualmente funciona, pero mejorar el feedback visual
+- Animación de salida (fade out) al eliminar
+- Undo transitorio (snackbar "Comentario eliminado" con botón "Deshacer", 5 segundos)
+- Eliminar el dialog de confirmación actual (el undo lo reemplaza)
+
+**Archivos afectados:**
+
+- `src/components/business/BusinessComments.tsx` — snackbar + undo logic
+- `src/components/menu/CommentsList.tsx` — mismo patrón en lista del menú
+
+#### F1.3 — Likes en comentarios
+
+- Botón corazón/thumbs-up en cada comentario (no en los propios)
+- Contador de likes visible
+- Toggle: likear / deslikear
+- Colección `commentLikes` en Firestore: doc ID `{userId}__{commentId}`
+- Cloud Function trigger para actualizar contador `likeCount` en el comentario
+- Ordenamiento por utilidad basado en likes
+
+**Modelo de datos:**
+
+```text
+commentLikes/{userId}__{commentId}
+  ├── userId: string
+  ├── commentId: string
+  └── createdAt: Timestamp
+```
+
+**Campos nuevos en Comment:**
+
+```text
+likeCount: number (default 0, actualizado por Cloud Function)
+```
+
+**Archivos afectados:**
+
+- `src/types/index.ts` — agregar `likeCount` a Comment
+- `src/services/comments.ts` — `likeComment(commentId)`, `unlikeComment(commentId)`
+- `src/config/collections.ts` — nueva colección `commentLikes`
+- `src/config/converters.ts` — converter para commentLikes
+- `src/components/business/BusinessComments.tsx` — botón like + contador
+- `firestore.rules` — reglas para commentLikes
+- `functions/src/triggers/commentLikes.ts` — counter trigger
+- `src/hooks/useBusinessData.ts` — incluir likes del usuario en la query
+
+#### F1.4 — Ordenamiento de comentarios
+
+- Selector de orden en la sección de comentarios del comercio:
+  - **Más recientes** (default actual)
+  - **Más antiguos**
+  - **Más útiles** (por likeCount descendente)
+- Chips o Select compacto para no ocupar mucho espacio en el bottom sheet
+- El orden se aplica client-side sobre los comentarios ya cargados
+
+**Archivos afectados:**
+
+- `src/components/business/BusinessComments.tsx` — selector + lógica de sort
+
+### Dependencias
+
+- F1.3 (likes) debe implementarse antes o junto con F1.4 (ordenamiento por utilidad)
+- F1.1 y F1.2 son independientes entre sí
+
+### Estimación de complejidad
+
+- F1.1: Baja — es una operación CRUD estándar sobre infraestructura existente
+- F1.2: Baja — solo UI, sin cambios en backend
+- F1.3: Media — nueva colección + trigger + UI
+- F1.4: Baja — solo lógica client-side de sort
+
+---
+
+## F2 — Fotos de menú
+
+### Alcance
+
+Permitir a usuarios subir fotos del menú de un comercio. El admin valida las fotos desde el dashboard. Si se aprueba, aparece un botón "Ver menú" en el comercio.
+
+### Flujo de usuario
+
+```text
+1. Usuario abre comercio → ve botón "Subir foto del menú" (icono cámara)
+2. Selecciona imagen (máx 5 MB, JPG/PNG/WebP)
+3. Preview de la imagen antes de enviar
+4. Envía → Cloud Function valida tamaño/tipo, sube a Cloud Storage
+5. Estado: "Pendiente de revisión" visible para el usuario que subió
+6. Admin ve en dashboard → tab "Fotos" → lista de fotos pendientes con preview
+7. Admin aprueba o rechaza (con motivo opcional)
+8. Si aprueba → botón "Ver menú" aparece en el comercio para todos
+9. Si rechaza → usuario ve estado "Rechazada" con motivo
+```
+
+### Modelo de datos
+
+```text
+menuPhotos/{autoId}
+  ├── userId: string
+  ├── businessId: string
+  ├── storagePath: string          # ruta en Cloud Storage
+  ├── thumbnailPath: string        # thumbnail generado por Cloud Function
+  ├── status: 'pending' | 'approved' | 'rejected'
+  ├── rejectionReason?: string
+  ├── reviewedBy?: string          # admin userId
+  ├── reviewedAt?: Timestamp
+  ├── createdAt: Timestamp
+  └── reportCount: number          # para reportes de contenido inapropiado
+```
+
+### Cloud Storage
+
+```text
+gs://modo-mapa-app.appspot.com/menus/
+  ├── {businessId}/
+  │   ├── {photoId}_original.jpg
+  │   └── {photoId}_thumb.jpg     # 400px, generado server-side
+```
+
+### Componentes nuevos
+
+| Componente | Ubicación | Descripción |
+|-----------|-----------|-------------|
+| `MenuPhotoButton` | `business/` | Botón "Ver menú" / "Subir foto" en BusinessSheet |
+| `MenuPhotoUpload` | `business/` | Dialog de upload con preview + crop básico |
+| `MenuPhotoViewer` | `business/` | Lightbox para ver la foto del menú aprobada |
+| `PhotoReviewPanel` | `admin/` | Tab nueva en admin: lista de fotos pendientes, aprobar/rechazar |
+
+### Cloud Functions
+
+| Función | Tipo | Descripción |
+|---------|------|-------------|
+| `onMenuPhotoCreate` | trigger (onCreate) | Validar tipo/tamaño, generar thumbnail, actualizar counter |
+| `approveMenuPhoto` | callable | Cambiar status a 'approved', notificar |
+| `rejectMenuPhoto` | callable | Cambiar status a 'rejected' con motivo |
+
+### Consideraciones técnicas
+
+- **Compresión client-side**: Usar `browser-image-compression` para reducir antes de subir (max 2 MB)
+- **Storage rules**: Solo el owner puede subir, nadie puede leer directamente (usar signed URLs o Cloud Function proxy)
+- **Rate limit**: Max 3 fotos pendientes por usuario (evitar spam)
+- **Quota Firebase Storage**: Plan Spark tiene 5 GB. Considerar limitar a 1 foto aprobada por comercio
+- **Cleanup**: Cloud Function scheduled para eliminar fotos rechazadas después de 7 días
+
+### Dependencias
+
+- Requiere Firebase Storage (ya configurado en el proyecto pero no usado actualmente)
+- Requiere agregar `firebase/storage` al frontend
+
+### Estimación de complejidad: Alta
+
+- Nueva infraestructura (Storage, thumbnails, signed URLs)
+- Panel admin nuevo
+- Flujo de moderación async
+
+---
+
+## F3 — Hub social (rankings de usuarios)
+
+### Alcance
+
+Sección nueva en el menú lateral: "Comunidad" o "Rankings". Muestra los usuarios más activos con filtros temporales.
+
+### Diseño
+
+```text
+┌─────────────────────────────┐
+│ ← Rankings                  │
+│                             │
+│ [Esta semana] [Este mes] [Este año]
+│                             │
+│ 🏆 Top contribuidores      │
+│                             │
+│  1. Juan P.        142 pts  │
+│     ████████████████ 🥇     │
+│  2. María G.       98 pts   │
+│     ███████████ 🥈           │
+│  3. Carlos R.      87 pts   │
+│     █████████ 🥉             │
+│  4. Ana L.         54 pts   │
+│     ██████                   │
+│  5. Pedro M.       41 pts   │
+│     ████                     │
+│  ...                        │
+│                             │
+│ 📊 Tu actividad             │
+│  Comentarios: 12            │
+│  Ratings: 8                 │
+│  Likes dados: 23            │
+│  Favoritos: 15              │
+│  Tags: 5                    │
+│  Posición: #7 de 45         │
+│                             │
+│ ──────────────────────────  │
+│ Puntuación:                 │
+│  Comentario = 3 pts         │
+│  Rating = 2 pts             │
+│  Like = 1 pt                │
+│  Tag = 1 pt                 │
+│  Favorito = 1 pt            │
+└─────────────────────────────┘
+```
+
+### Sistema de puntos
+
+| Acción | Puntos |
+|--------|--------|
+| Comentario | 3 |
+| Rating | 2 |
+| Like dado | 1 |
+| Tag custom creado | 1 |
+| Favorito | 1 |
+| Foto de menú aprobada | 5 |
+
+### Modelo de datos
+
+Reutilizar la infraestructura existente de `dailyMetrics`. Agregar un cron semanal/mensual que calcule rankings y los guarde en una nueva colección:
+
+```text
+userRankings/{period}          # 'weekly_2026-W11', 'monthly_2026-03', 'yearly_2026'
+  ├── period: string
+  ├── startDate: Timestamp
+  ├── endDate: Timestamp
+  ├── rankings: [              # top 50
+  │   { userId, displayName, score, breakdown: { comments, ratings, likes, tags, favorites, photos } }
+  │ ]
+  └── totalParticipants: number
+```
+
+### Componentes nuevos
+
+| Componente | Ubicación | Descripción |
+|-----------|-----------|-------------|
+| `RankingsView` | `menu/` | Vista principal con tabs de período + lista de rankings |
+| `UserScoreCard` | `menu/` | Card "Tu actividad" con desglose de puntos |
+| `RankingItem` | `menu/` | Fila de ranking con barra de progreso y medalla |
+
+### Cloud Functions
+
+| Función | Tipo | Descripción |
+|---------|------|-------------|
+| `computeWeeklyRanking` | scheduled (lunes 4AM) | Calcula ranking semanal |
+| `computeMonthlyRanking` | scheduled (1ro de cada mes, 4AM) | Calcula ranking mensual |
+| `computeYearlyRanking` | scheduled (1ro de enero, 4AM) | Calcula ranking anual |
+
+### Consideraciones
+
+- Los rankings se calculan server-side para evitar queries costosas client-side
+- Solo se guardan top 50 para limitar tamaño del documento
+- El "Tu actividad" del usuario actual se puede calcular client-side sumando sus datos existentes
+- Los displayNames se desnormalizan en el ranking (se actualizan en cada cálculo)
+
+### Estimación de complejidad: Media
+
+- La infraestructura de métricas ya existe (dailyMetrics, UsersPanel)
+- Solo se necesita un cron nuevo y una UI de lista
+
+---
+
+## F4 — Notificaciones in-app
+
+### Alcance
+
+Sistema de notificaciones para mantener al usuario informado de interacciones con su contenido.
+
+### Eventos que generan notificación
+
+| Evento | Mensaje | Requiere F# |
+|--------|---------|-------------|
+| Like en tu comentario | "A Juan le gustó tu comentario en La Parrilla" | F1.3 |
+| Respuesta a tu comentario | "María respondió tu comentario en Café Roma" | F5 |
+| Foto de menú aprobada | "Tu foto del menú de Pizzería Banchero fue aprobada" | F2 |
+| Foto de menú rechazada | "Tu foto del menú fue rechazada: imagen borrosa" | F2 |
+| Llegaste al top 3 | "Subiste al puesto #2 del ranking semanal" | F3 |
+
+### Modelo de datos
+
+```text
+notifications/{autoId}
+  ├── userId: string           # destinatario
+  ├── type: 'like' | 'reply' | 'photo_approved' | 'photo_rejected' | 'ranking'
+  ├── actorId?: string         # quien generó la acción
+  ├── actorName?: string       # desnormalizado
+  ├── businessId?: string
+  ├── referenceId?: string     # commentId, photoId, etc
+  ├── message: string
+  ├── read: boolean
+  ├── createdAt: Timestamp
+  └── expiresAt: Timestamp     # auto-cleanup después de 30 días
+```
+
+### UI
+
+- Icono de campana en el header del menú lateral (o en SearchBar)
+- Badge con contador de no leídas
+- Lista de notificaciones con swipe-to-dismiss o mark-as-read
+- Click en notificación navega al contexto (comercio, comentario, ranking)
+
+### Estimación de complejidad: Media
+
+- Cloud Function triggers generan las notificaciones
+- UI relativamente simple (lista + badge)
+- La complejidad está en la navegación contextual
+
+---
+
+## F5 — Respuestas a comentarios (threads)
+
+### Alcance
+
+Permitir responder a un comentario existente, creando un hilo de conversación.
+
+### Diseño
+
+```text
+Juan P. — 12/03, 14:30
+  "Las milanesas son espectaculares"
+  ♡ 5    💬 2    Responder
+
+    └─ María G. — 12/03, 15:00
+       "Totalmente! Probaste la napolitana?"
+       ♡ 1
+
+    └─ Pedro M. — 12/03, 16:20
+       "Yo recomiendo la de pollo"
+       ♡ 0
+```
+
+### Modelo de datos
+
+Agregar campo opcional al Comment existente:
+
+```text
+parentId?: string     # ID del comentario padre (null = top-level)
+```
+
+### Consideraciones
+
+- Máximo 1 nivel de anidamiento (respuestas a respuestas se muestran planas)
+- Las respuestas heredan el businessId del padre
+- Eliminar un padre no elimina las respuestas (quedan como "comentario eliminado")
+- Mostrar respuestas colapsadas por default, expandir con "Ver 2 respuestas"
+
+### Estimación de complejidad: Media
+
+- Cambio en estructura de datos es simple
+- La complejidad está en la UI del threading
+
+---
+
+## F6 — Perfil de usuario público
+
+### Alcance
+
+Al tocar el nombre de un usuario (en comentarios, rankings, etc.) se abre un mini-perfil.
+
+### Contenido del perfil
+
+- Avatar + displayName
+- Miembro desde (createdAt)
+- Stats: comentarios, ratings, favoritos, likes recibidos
+- Posición en ranking actual
+- Badge si está en top 3 (semanal/mensual)
+- Últimos 5 comentarios del usuario
+
+### UI
+
+- Bottom sheet o dialog modal
+- No requiere nueva ruta (es un overlay)
+
+### Estimación de complejidad: Baja
+
+- Los datos ya existen, solo necesita una query nueva y UI
+
+---
+
+## F7 — Reseñas multi-criterio
+
+### Alcance
+
+Extender el sistema de rating actual (1-5 estrellas global) con criterios específicos.
+
+### Criterios propuestos
+
+| Criterio | Icono |
+|----------|-------|
+| Comida | 🍽️ |
+| Atención | 👋 |
+| Precio | 💰 |
+| Ambiente | 🏠 |
+| Rapidez | ⚡ |
+
+### Diseño
+
+- Al calificar, se muestra un panel expandible con los 5 criterios
+- Cada criterio tiene estrellas 1-5 (opcional, solo el global es obligatorio)
+- En el comercio se muestra el desglose promedio como barras horizontales
+- Ranking de "Mejor relación precio-calidad", "Mejor atención", etc.
+
+### Modelo de datos
+
+Agregar al Rating existente:
+
+```text
+criteria?: {
+  food?: number        # 1-5
+  service?: number     # 1-5
+  price?: number       # 1-5
+  ambiance?: number    # 1-5
+  speed?: number       # 1-5
+}
+```
+
+### Estimación de complejidad: Media
+
+- Backwards compatible (criteria es opcional)
+- La complejidad está en calcular promedios por criterio server-side
+
+---
+
+## F8 — Compartir comercio
+
+### Alcance
+
+Botón "Compartir" en BusinessSheet que genera un deep link al comercio.
+
+### Implementación
+
+- Usa Web Share API (nativa en móviles) con fallback a copiar al clipboard
+- URL: `https://modo-mapa-app.web.app/?business={businessId}`
+- Al abrir el link, el mapa centra y abre el bottom sheet del comercio
+- Texto compartido: "Mirá {nombre} en Modo Mapa — {dirección}"
+
+### Estimación de complejidad: Baja
+
+- Web Share API es trivial
+- El deep link requiere leer query params en AppShell y setear selectedBusiness
+
+---
+
+## F9 — Historial de visitas
+
+### Alcance
+
+Registro automático de qué comercios abrió el usuario, con fecha.
+
+### Implementación
+
+- Guardar en localStorage (no Firestore) para no gastar quota
+- Estructura: `{ businessId, lastVisited, visitCount }[]`
+- Nueva sección en menú lateral: "Visitados recientemente"
+- Chip "Nuevo" en markers de comercios no visitados
+- Límite: últimos 100 comercios
+
+### Estimación de complejidad: Baja
+
+- 100% client-side, sin backend
+
+---
+
+## F10 — Sugerencias personalizadas
+
+### Alcance
+
+"Para vos" — lista de comercios sugeridos basados en el comportamiento del usuario.
+
+### Algoritmo (heurístico simple)
+
+```text
+score(business) =
+  + 3 si la categoría coincide con las más favoriteadas del usuario
+  + 2 si tiene tags que el usuario suele votar
+  + 1 si está cerca de la ubicación actual
+  - 5 si ya es favorito (no sugerir lo que ya conoce)
+  - 3 si ya tiene rating del usuario
+```
+
+### Implementación
+
+- 100% client-side usando datos ya disponibles (favorites, ratings, userTags, location)
+- Sección "Sugeridos para vos" en el menú lateral o como cards horizontales sobre el mapa
+- Se recalcula cada vez que se abre (no persiste)
+
+### Estimación de complejidad: Alta (por la lógica de scoring)
+
+- Pero sin costo de Firestore, todo es client-side
+
+---
+
+## Roadmap sugerido
+
+### Fase 1 — Interacción social (v2.0)
+
+Objetivo: hacer la experiencia de comentarios rica e interactiva.
+
+| Feature | Issue |
+|---------|-------|
+| F1.1 Editar comentarios | #17 (existente) |
+| F1.2 Eliminar con undo | nuevo |
+| F1.3 Likes en comentarios | nuevo |
+| F1.4 Ordenamiento | nuevo |
+| F8 Compartir comercio | nuevo |
+
+### Fase 2 — Contenido visual (v2.1)
+
+Objetivo: agregar fotos de menú y mejorar la utilidad de cada comercio.
+
+| Feature | Issue |
+|---------|-------|
+| F2 Fotos de menú | nuevo |
+| F9 Historial de visitas | nuevo |
+
+### Fase 3 — Comunidad (v2.2)
+
+Objetivo: gamificación y engagement.
+
+| Feature | Issue |
+|---------|-------|
+| F3 Hub social / Rankings | nuevo |
+| F4 Notificaciones in-app | nuevo |
+| F6 Perfil de usuario público | nuevo |
+
+### Fase 4 — Profundidad (v2.3)
+
+Objetivo: más detalle en la información.
+
+| Feature | Issue |
+|---------|-------|
+| F5 Threads de comentarios | nuevo |
+| F7 Reseñas multi-criterio | nuevo |
+| F10 Sugerencias personalizadas | nuevo |
+
+---
+
+## Impacto en Firestore quota
+
+| Feature | Reads adicionales | Writes adicionales | Storage |
+|---------|-------------------|--------------------| --------|
+| F1 Comentarios 2.0 | +1 query (likes) por comercio | +likes (bajo, toggle) | — |
+| F2 Fotos de menú | +1 query por comercio | +uploads (bajo, rate limited) | +Cloud Storage |
+| F3 Rankings | +1 read por período | +cron writes (bajo) | — |
+| F4 Notificaciones | +1 query por sesión | +trigger writes | — |
+| F5 Threads | Sin cambio (mismo query) | Sin cambio | — |
+| F6 Perfiles | +1 query por click | — | — |
+| F7 Multi-criterio | Sin cambio | Sin cambio (mismo doc) | — |
+| F8 Compartir | — | — | — |
+| F9 Historial | — (localStorage) | — | — |
+| F10 Sugerencias | — (client-side) | — | — |
+
+**Conclusión:** La mayoría de features tienen impacto bajo en quota. F2 (fotos) es la excepción por Cloud Storage. F4 (notificaciones) puede generar más writes pero son controlables con batching.
+
+---
+
+## Notas técnicas
+
+### Reutilización de infraestructura existente
+
+- **Service layer**: Todas las features nuevas siguen el mismo patrón (`src/services/`)
+- **Cloud Functions triggers**: Patrón idéntico al de comments/ratings/favorites
+- **Admin panel**: `useAsyncData` + `AdminPanelWrapper` para nuevos tabs
+- **Paginación**: `usePaginatedQuery` reutilizable para todas las listas nuevas
+- **Cache**: `useBusinessDataCache` se extiende con nuevos campos
+- **Moderación**: El moderador de contenido existente aplica a F1.1 (editar) y F5 (respuestas)
+
+### Consideraciones de seguridad
+
+- Todas las features de escritura pasan por el service layer con validación
+- Todas necesitan Firestore rules correspondientes
+- F2 requiere Storage rules específicas
+- Rate limiting server-side para F1.3 (likes), F2 (uploads), F4 (notificaciones)
+- F3 no necesita rate limiting (es read-only para usuarios)

--- a/docs/PROJECT_REFERENCE.md
+++ b/docs/PROJECT_REFERENCE.md
@@ -1,6 +1,6 @@
 # Modo Mapa — Referencia completa del proyecto
 
-**Version:** 1.5.1
+**Version:** 2.0.0
 **Repo:** <https://github.com/benoffi7/modo-mapa>
 **Produccion:** <https://modo-mapa-app.web.app>
 **Ultima actualizacion:** 2026-03-12
@@ -63,10 +63,11 @@ main.tsx
                  ├─ MapView (Google Maps + markers)
                  ├─ LocationFAB (geolocalizacion)
                  ├─ BusinessSheet (bottom sheet con detalle)
-                 │    ├─ BusinessHeader (nombre, direccion, favorito, direcciones)
+                 │    ├─ BusinessHeader (nombre, direccion, favorito, share, direcciones)
                  │    ├─ BusinessRating (estrellas promedio + calificar)
                  │    ├─ BusinessTags (tags predefinidos + custom)
-                 │    └─ BusinessComments (lista + formulario + eliminar)
+                 │    ├─ BusinessComments (lista + formulario + editar + undo delete + likes + sorting)
+                 │    └─ ShareButton (Web Share API + clipboard fallback)
                  ├─ NameDialog (nombre de usuario, primera visita)
                  └─ SideMenu (drawer lateral)
                       ├─ Header (avatar + nombre + editar)
@@ -102,7 +103,8 @@ functions/
 │   ├── admin/
 │   │   └── backups.ts        → createBackup, listBackups, restoreBackup, deleteBackup (callable)
 │   ├── triggers/
-│   │   ├── comments.ts       → rate limit + moderacion + counters
+│   │   ├── comments.ts       → rate limit + moderacion + counters + onUpdate re-moderation
+│   │   ├── commentLikes.ts   → likeCount increment/decrement + rate limit + counters
 │   │   ├── customTags.ts     → rate limit + moderacion + counters
 │   │   ├── feedback.ts       → rate limit + moderacion + counters
 │   │   ├── ratings.ts        → counters (create/update/delete)
@@ -144,8 +146,8 @@ src/
 ├── index.css                        # Estilos globales minimos
 ├── config/
 │   ├── firebase.ts                  # Init Firebase + emuladores en DEV + App Check (prod) + persistent cache (prod)
-│   ├── collections.ts               # Nombres de colecciones Firestore centralizados
-│   ├── converters.ts                # FirestoreDataConverter<T> tipados por coleccion (incl. feedback)
+│   ├── collections.ts               # Nombres de colecciones Firestore centralizados (incl. COMMENT_LIKES)
+│   ├── converters.ts                # FirestoreDataConverter<T> tipados por coleccion (incl. feedback, commentLike)
 │   ├── adminConverters.ts           # Converters para AdminCounters, DailyMetrics, AbuseLog
 │   └── metricsConverter.ts          # Converter para PublicMetrics (solo campos publicos)
 ├── context/
@@ -156,12 +158,12 @@ src/
 │   ├── index.ts                     # Barrel export de todas las operaciones CRUD
 │   ├── favorites.ts                 # addFavorite, removeFavorite
 │   ├── ratings.ts                   # upsertRating
-│   ├── comments.ts                  # addComment, deleteComment
+│   ├── comments.ts                  # addComment, editComment, deleteComment, likeComment, unlikeComment
 │   ├── tags.ts                      # addUserTag, removeUserTag, createCustomTag, updateCustomTag, deleteCustomTag
 │   ├── feedback.ts                  # sendFeedback
 │   └── admin.ts                     # fetchCounters, fetchRecent*, fetchUsersPanelData, fetchDailyMetrics, fetchAbuseLogs
 ├── types/
-│   ├── index.ts                     # Business, Rating, Comment, CustomTag, UserTag, Favorite, Feedback
+│   ├── index.ts                     # Business, Rating, Comment, CommentLike, CustomTag, UserTag, Favorite, Feedback
 │   ├── admin.ts                     # AdminCounters, DailyMetrics (extends PublicMetrics), AbuseLog
 │   └── metrics.ts                   # PublicMetrics, TopTagEntry, TopBusinessEntry, TopRatedEntry
 ├── theme/
@@ -229,8 +231,9 @@ src/
 │   │   ├── BusinessTags.tsx         # Tags predefinidos (voto) + custom tags (orquestacion, props-driven)
 │   │   ├── CustomTagDialog.tsx      # Dialog crear/editar custom tag (memoizado)
 │   │   ├── DeleteTagDialog.tsx      # Dialog confirmacion eliminacion tag (memoizado)
-│   │   ├── BusinessComments.tsx     # Comentarios + formulario + eliminar propios (props-driven, flagged filtrados)
+│   │   ├── BusinessComments.tsx     # Comentarios + formulario + editar + undo delete + likes + sorting (props-driven)
 │   │   ├── FavoriteButton.tsx       # Corazon toggle (props-driven)
+│   │   ├── ShareButton.tsx          # Compartir comercio (Web Share API + clipboard fallback)
 │   │   └── DirectionsButton.tsx     # Abre Google Maps Directions
 │   ├── ui/
 │   │   ├── OfflineIndicator.tsx     # Chip MUI offline (PWA)
@@ -277,7 +280,7 @@ Capa de abstraccion entre componentes y Firestore. Los componentes nunca importa
 |--------|-----------|-------------|
 | `favorites.ts` | `favorites` | `addFavorite`, `removeFavorite`, `getFavoritesCollection` |
 | `ratings.ts` | `ratings` | `upsertRating`, `getRatingsCollection` |
-| `comments.ts` | `comments` | `addComment`, `deleteComment`, `getCommentsCollection` |
+| `comments.ts` | `comments`, `commentLikes` | `addComment`, `editComment`, `deleteComment`, `likeComment`, `unlikeComment`, `getCommentsCollection` |
 | `tags.ts` | `userTags`, `customTags` | `addUserTag`, `removeUserTag`, `createCustomTag`, `updateCustomTag`, `deleteCustomTag` |
 | `feedback.ts` | `feedback` | `sendFeedback` |
 | `admin.ts` | Todas (read-only) | `fetchCounters`, `fetchRecent*` (6 colecciones), `fetchAllCustomTags`, `fetchUsersPanelData`, `fetchDailyMetrics`, `fetchAbuseLogs` |
@@ -299,7 +302,7 @@ Capa de abstraccion entre componentes y Firestore. Los componentes nunca importa
 | Hook | Descripcion |
 |------|-------------|
 | `useAsyncData<T>` | Hook generico para fetch async. Retorna `{ data, loading, error }`. Usado por todos los paneles admin via `AdminPanelWrapper`. |
-| `useBusinessData` | Orquesta 5 queries Firestore del business view con `Promise.all` + cache (5 min TTL). |
+| `useBusinessData` | Orquesta 5 queries Firestore del business view con `Promise.all` + cache (5 min TTL). Tambien fetchea user likes por comentario. |
 | `useBusinessDataCache` | Cache module-level (`Map`) para datos del business view. TTL 5 min. Se invalida en cada write. Soporta `patchBusinessCache` para updates parciales. |
 | `useColorMode` | Hook para dark/light mode. Consume `ColorModeContext`. Retorna `{ mode, toggleColorMode }`. |
 | `useBusinesses` | Filtra `businesses.json` por searchQuery + activeFilters con `useDeferredValue`. |
@@ -362,7 +365,8 @@ return (
 | `users` | `{userId}` | displayName, createdAt | R/W owner; admin read |
 | `favorites` | `{userId}__{businessId}` | userId, businessId, createdAt | Read auth; create/delete owner |
 | `ratings` | `{userId}__{businessId}` | userId, businessId, score (1-5), createdAt, updatedAt | Read auth; create/update owner, score 1-5 |
-| `comments` | auto-generated | userId, userName, businessId, text (1-500), createdAt, flagged? | Read auth; create owner; delete owner |
+| `comments` | auto-generated | userId, userName, businessId, text (1-500), createdAt, updatedAt?, likeCount, flagged? | Read auth; create owner; update owner (text+updatedAt only); delete owner |
+| `commentLikes` | `{userId}__{commentId}` | userId, commentId, createdAt | Read auth; create/delete owner |
 | `userTags` | `{userId}__{businessId}__{tagId}` | userId, businessId, tagId, createdAt | Read auth; create/delete owner |
 | `customTags` | auto-generated | userId, businessId, label (1-30), createdAt | Read auth; create/update/delete owner |
 | `feedback` | auto-generated | userId, message (1-1000), category (bug/sugerencia/otro), createdAt, flagged? | Create auth+owner; read/delete owner; admin read |
@@ -398,7 +402,7 @@ CATEGORY_LABELS: restaurant→Restaurante, cafe→Cafe, bakery→Panaderia, bar�
                  fastfood→Comida rapida, icecream→Heladeria, pizza→Pizzeria
 
 // Admin types
-interface AdminCounters { comments, ratings, favorites, feedback, users, customTags, userTags, dailyReads, dailyWrites, dailyDeletes }
+interface AdminCounters { comments, ratings, favorites, feedback, users, customTags, userTags, commentLikes, dailyReads, dailyWrites, dailyDeletes }
 interface DailyMetrics { date, ratingDistribution, topFavorited, topCommented, topRated, topTags, dailyReads/Writes/Deletes, byCollection, activeUsers }
 interface AbuseLog { id, userId, type, collection, detail, timestamp }
 ```
@@ -572,10 +576,12 @@ Antes de cada restore, se crea automaticamente un backup con prefijo `pre-restor
 |--------|-------------|
 | **Auth anonima + Google Sign-In** | Usuarios normales se autentican anonimamente. Admin usa Google Sign-In solo en `/admin`. |
 | **Admin guard (2 capas)** | Frontend: `AdminGuard` verifica `user.email === 'benoffi11@gmail.com'`. Server: Firestore rules con `request.auth.token.email`. |
-| **Doc ID compuesto** | `{userId}__{businessId}` para favoritos, ratings y userTags. Garantiza unicidad sin queries extra. |
+| **Doc ID compuesto** | `{userId}__{businessId}` para favoritos, ratings y userTags. `{userId}__{commentId}` para commentLikes. Garantiza unicidad sin queries extra. |
 | **Service layer** | Componentes llaman `src/services/` para CRUD. Nunca importan `firebase/firestore` directamente para escrituras. |
 | **Datos estaticos + dinamicos** | Comercios en JSON local, interacciones en Firestore. Se cruzan por `businessId` client-side. |
-| **Optimistic UI** | Comentarios se agregan al state local antes de que Firestore confirme. |
+| **Optimistic UI** | Comentarios se agregan al state local antes de que Firestore confirme. Likes usan Maps para toggle state + delta count. |
+| **Undo delete** | Comentarios se eliminan con undo (5s timer + Snackbar). Usado en BusinessComments y CommentsList. |
+| **Deep linking** | `?business={id}` en URL abre el bottom sheet del comercio. Usado por ShareButton. |
 | **Rate limiting (3 capas)** | Client-side (UI) + server-side (Cloud Functions triggers) + Cloud Functions callable (Firestore-backed, 5/min/user). |
 | **Moderacion de contenido** | Cloud Functions filtran texto con lista de banned words (configurable en `config/moderation`). |
 | **Counters server-side** | Cloud Functions triggers actualizan `config/counters` atomicamente con `FieldValue.increment`. |
@@ -622,7 +628,7 @@ Antes de cada restore, se crea automaticamente un backup con prefijo `pre-restor
 | [#11](https://github.com/benoffi7/modo-mapa/issues/11) | feat | Feedback, Ratings, Agregar comercio, Version, Filtros | [#12](https://github.com/benoffi7/modo-mapa/pull/12) | Merged | `docs/feat-menu-feedback-ratings-version/` |
 | [#13](https://github.com/benoffi7/modo-mapa/issues/13) | fix | customTags read rule demasiado restrictiva | [#14](https://github.com/benoffi7/modo-mapa/pull/14) | Merged | — |
 | [#15](https://github.com/benoffi7/modo-mapa/issues/15) | security | Auditoria de seguridad — hallazgos iniciales | [#16](https://github.com/benoffi7/modo-mapa/pull/16) | Merged | — |
-| [#17](https://github.com/benoffi7/modo-mapa/issues/17) | feat | Agregar edicion de comentarios | — | Open | — |
+| [#17](https://github.com/benoffi7/modo-mapa/issues/17) | feat | Agregar edicion de comentarios | — | Closed (via #45) | — |
 | — | security | Resolver hallazgos pendientes: App Check, timestamps, converters | [#18](https://github.com/benoffi7/modo-mapa/pull/18) | Merged | — |
 | — | chore | Resolver mejoras tecnicas: debounce, tests, paginacion, husky, bundle analysis, strictTypes | [#20](https://github.com/benoffi7/modo-mapa/pull/20) | Merged | — |
 | [#19](https://github.com/benoffi7/modo-mapa/issues/19) | fix | Fix CSP policy, tags auth guard, lint errors | [#22](https://github.com/benoffi7/modo-mapa/pull/22) | Merged | `docs/fix-csp-and-tags-permissions/` |
@@ -637,6 +643,8 @@ Antes de cada restore, se crea automaticamente un backup con prefijo `pre-restor
 | [#39](https://github.com/benoffi7/modo-mapa/issues/39) | feat | Sentry error tracking | [#40](https://github.com/benoffi7/modo-mapa/pull/40) | Merged | — |
 | [#41](https://github.com/benoffi7/modo-mapa/issues/41) | fix | Tags reload on any action + rating flicker | [#42](https://github.com/benoffi7/modo-mapa/pull/42) | Merged | — |
 | [#43](https://github.com/benoffi7/modo-mapa/issues/43) | feat | Dark mode + theme playground | — | Open | — |
+| [#45](https://github.com/benoffi7/modo-mapa/issues/45) | feat | Comentarios 2.0: editar, undo delete, likes, sorting | — | Open | `docs/feat-comments-2.0/` |
+| [#46](https://github.com/benoffi7/modo-mapa/issues/46) | feat | Compartir comercio (share + deep link) | — | Open | `docs/feat-comments-2.0/` |
 
 ---
 
@@ -680,7 +688,8 @@ Documentacion adicional:
 - Rating: promedio + estrellas del usuario (1-5)
 - Tags predefinidos: vote count + toggle del usuario
 - Tags custom: crear, editar, eliminar (privados por usuario)
-- Comentarios: lista + formulario + eliminar propios (flaggeados ocultos)
+- Comentarios: lista + formulario + editar propios + undo delete + likes (otros) + sorting (Recientes/Antiguos/Utiles). Flaggeados ocultos. Indicador "(editado)"
+- Compartir: boton share (Web Share API con fallback a clipboard). Deep link via `?business={id}`
 - Datos cargados en paralelo (`Promise.all`) con cache client-side (5 min TTL)
 - Escrituras via service layer (`src/services/`)
 
@@ -689,7 +698,7 @@ Documentacion adicional:
 - Header con avatar, nombre, boton editar nombre
 - Secciones:
   - **Favoritos**: lista con filtros (busqueda, categoria, orden). Quitar favorito inline. Click navega al comercio.
-  - **Comentarios**: lista con texto truncado. Eliminar con confirmacion. Click navega al comercio.
+  - **Comentarios**: lista con texto truncado. Eliminar con undo (5s). Click navega al comercio.
   - **Calificaciones**: lista con estrellas y filtros (busqueda, categoria, estrellas minimas, orden). Click navega al comercio.
   - **Feedback**: formulario con categoria (bug/sugerencia/otro) + mensaje (max 1000). Estado de exito.
   - **Estadisticas**: distribucion de ratings (pie), tags mas usados (pie), top 10 favoriteados/comentados/calificados. Usa `usePublicMetrics` + componentes de `stats/`.
@@ -730,7 +739,7 @@ Todas las funciones callable:
 - Validan input (backupId con regex `^[\w.-]+$`)
 - Logging con email enmascarado
 
-**Rate limiting server-side (triggers):** comments (20/dia), customTags (10/business), feedback (5/dia).
+**Rate limiting server-side (triggers):** comments (20/dia), commentLikes (50/dia), customTags (10/business), feedback (5/dia).
 
 **Moderacion de contenido:** banned words con normalizacion de acentos, word boundary matching.
 

--- a/docs/feat-comments-2.0/changelog.md
+++ b/docs/feat-comments-2.0/changelog.md
@@ -1,0 +1,35 @@
+# Changelog — Comentarios 2.0 + Compartir comercio
+
+## Archivos creados
+
+| Archivo | Descripcion |
+|---------|-------------|
+| `src/components/business/ShareButton.tsx` | Boton compartir comercio (Web Share API + clipboard) |
+| `functions/src/triggers/commentLikes.ts` | Triggers onCreate/onDelete para likes (likeCount +/- counters) |
+| `docs/feat-comments-2.0/prd.md` | PRD de la feature |
+| `docs/feat-comments-2.0/specs.md` | Especificaciones tecnicas |
+| `docs/feat-comments-2.0/plan.md` | Plan de implementacion |
+| `docs/feat-comments-2.0/changelog.md` | Este archivo |
+
+## Archivos modificados
+
+| Archivo | Cambios |
+|---------|---------|
+| `src/types/index.ts` | `Comment.updatedAt?`, `Comment.likeCount`, nuevo `CommentLike` interface |
+| `src/config/collections.ts` | Agregado `COMMENT_LIKES` |
+| `src/config/converters.ts` | `commentConverter` con likeCount/updatedAt, nuevo `commentLikeConverter` |
+| `src/services/comments.ts` | `editComment`, `likeComment`, `unlikeComment` |
+| `src/services/index.ts` | Exports de nuevas funciones |
+| `src/hooks/useBusinessData.ts` | Fetch user likes por comentario, retorna `userCommentLikes: Set<string>` |
+| `src/hooks/useBusinessDataCache.ts` | `userCommentLikes` en `BusinessCacheEntry` |
+| `src/components/business/BusinessComments.tsx` | Edicion inline, undo delete, likes optimistas, sorting chips |
+| `src/components/business/BusinessSheet.tsx` | Pasa `userCommentLikes` y renderiza `ShareButton` |
+| `src/components/business/BusinessHeader.tsx` | Prop `shareButton?` |
+| `src/components/layout/AppShell.tsx` | Deep link `?business={id}` via useSearchParams |
+| `src/components/menu/CommentsList.tsx` | Undo delete (reemplaza dialog de confirmacion) |
+| `firestore.rules` | Update rule para comments, nueva coleccion commentLikes |
+| `functions/src/triggers/comments.ts` | `onCommentUpdated` trigger (re-moderacion) |
+| `functions/src/index.ts` | Exports: `onCommentUpdated`, `onCommentLikeCreated`, `onCommentLikeDeleted` |
+| `scripts/seed-admin-data.mjs` | Migrado a firebase-admin SDK, datos de likes y likeCount |
+| `package.json` | Version bump 1.5.1 -> 2.0.0 |
+| `docs/PROJECT_REFERENCE.md` | Actualizado con nuevas features, colecciones, patrones |

--- a/docs/feat-comments-2.0/plan.md
+++ b/docs/feat-comments-2.0/plan.md
@@ -1,0 +1,142 @@
+# Plan de implementación — Comentarios 2.0 + Compartir comercio
+
+**Branch:** `feat/45-comments-2.0`
+**Issues:** #45, #46, cierra #17
+
+---
+
+## Orden de implementación
+
+### Paso 1 — Tipos y config
+
+**Archivos:**
+
+- `src/types/index.ts` — Agregar `updatedAt?`, `likeCount` a Comment. Nuevo `CommentLike`
+- `src/config/collections.ts` — Agregar `COMMENT_LIKES`
+- `src/config/converters.ts` — Actualizar `commentConverter` (likeCount, updatedAt). Nuevo `commentLikeConverter`
+
+**Validación:** `npm run lint` pasa
+
+---
+
+### Paso 2 — Service layer
+
+**Archivos:**
+
+- `src/services/comments.ts` — Agregar `editComment()`, `likeComment()`, `unlikeComment()`
+
+**Validación:** `npm run lint` pasa
+
+---
+
+### Paso 3 — Firestore rules
+
+**Archivos:**
+
+- `firestore.rules` — Agregar `allow update` en comments (owner, text 1-500, updatedAt == request.time, campos inmutables). Nueva colección `commentLikes` (read auth, create owner + timestamp, delete owner)
+
+**Validación:** Sintaxis válida
+
+---
+
+### Paso 4 — Cloud Functions
+
+**Archivos:**
+
+- `functions/src/triggers/comments.ts` — Agregar `onCommentUpdated` (re-moderar si texto cambió, quitar flag si texto limpio)
+- `functions/src/triggers/commentLikes.ts` — Nuevo: `onCommentLikeCreated` (rate limit 50/day, increment likeCount, counters), `onCommentLikeDeleted` (decrement likeCount, counters)
+- `functions/src/index.ts` — Exportar los 3 nuevos triggers
+
+**Validación:** `cd functions && npm run lint` pasa
+
+---
+
+### Paso 5 — Hook useBusinessData (likes query)
+
+**Archivos:**
+
+- `src/hooks/useBusinessData.ts` — Agregar `userCommentLikes: Set<string>` al return. En `fetchBusinessData`, después de obtener comments, hacer `getDoc` por cada comment para verificar si el usuario likeó. En `fetchSingleCollection('comments')`, hacer lo mismo. Agregar `userCommentLikes` al tipo de datos del estado
+- `src/hooks/useBusinessDataCache.ts` — Agregar `userCommentLikes` al tipo `BusinessCacheEntry`
+
+**Validación:** `npm run lint` pasa, tipo correcto
+
+---
+
+### Paso 6 — BusinessComments (edit + undo + likes + sort)
+
+**Archivos:**
+
+- `src/components/business/BusinessComments.tsx` — Reescritura significativa:
+  1. **Sort selector**: chips "Recientes" / "Antiguos" / "Útiles" encima de la lista
+  2. **Edit inline**: si editingId === comment.id, TextField + Save/Cancel en lugar del texto
+  3. **Like button**: corazón + contador en cada comment (no en propios). Optimistic UI
+  4. **Undo delete**: quitar dialog, usar pendingDelete + Snackbar 5s + timer
+  5. **Indicador editado**: "(editado)" gris junto a la fecha si updatedAt existe
+
+**Props nuevos:** `userCommentLikes: Set<string>`
+
+**Validación:** Funciona visualmente en dev
+
+---
+
+### Paso 7 — BusinessSheet (pasar datos)
+
+**Archivos:**
+
+- `src/components/business/BusinessSheet.tsx` — Pasar `userCommentLikes={data.userCommentLikes}` a BusinessComments. Agregar ShareButton al header
+
+**Validación:** Bottom sheet muestra todo correctamente
+
+---
+
+### Paso 8 — CommentsList (undo delete)
+
+**Archivos:**
+
+- `src/components/menu/CommentsList.tsx` — Reemplazar dialog de confirmación por mismo patrón de undo (pendingDelete + Snackbar + timer)
+
+**Validación:** Undo funciona en menu lateral
+
+---
+
+### Paso 9 — ShareButton + deep link
+
+**Archivos:**
+
+- `src/components/business/ShareButton.tsx` — Nuevo componente
+- `src/components/business/BusinessHeader.tsx` — Agregar prop `shareButton`, renderizar junto a favoriteButton
+- `src/components/layout/AppShell.tsx` — Leer `?business=` al montar, seleccionar comercio, limpiar param
+
+**Validación:** Share funciona (clipboard fallback en desktop), deep link abre el comercio
+
+---
+
+### Paso 10 — Tests
+
+**Archivos:**
+
+- `functions/src/triggers/__tests__/commentLikes.test.ts` — Tests del trigger (rate limit, increment, decrement)
+- Verificar que tests existentes pasan
+
+**Validación:** `npm run test:run` pasa, `cd functions && npm run test` pasa
+
+---
+
+### Paso 11 — Test local completo
+
+- `npm run dev:full` — Probar flujo completo con emuladores:
+  1. Crear comentario → editar → verificar "(editado)"
+  2. Dar like a comentario ajeno → verificar contador
+  3. Cambiar ordenamiento → verificar orden
+  4. Eliminar comentario → verificar undo → verificar delete real
+  5. Compartir comercio → verificar deep link
+  6. En menu lateral: eliminar con undo
+
+---
+
+### Paso 12 — Commit, push, PR, merge
+
+- Bump version a 2.0.0 en `package.json`
+- Actualizar `docs/PROJECT_REFERENCE.md`
+- Crear changelog.md
+- Commit + push + PR + merge

--- a/docs/feat-comments-2.0/prd.md
+++ b/docs/feat-comments-2.0/prd.md
@@ -1,0 +1,176 @@
+# PRD — Comentarios 2.0 + Compartir comercio
+
+**Issues:** [#45](https://github.com/benoffi7/modo-mapa/issues/45), [#46](https://github.com/benoffi7/modo-mapa/issues/46), cierra [#17](https://github.com/benoffi7/modo-mapa/issues/17)
+**Version objetivo:** 2.0.0
+**Fase:** 1 del roadmap funcional
+
+---
+
+## Objetivo
+
+Transformar la sección de comentarios de "solo escribir y borrar" a una experiencia interactiva con edición, likes y ordenamiento. Agregar la posibilidad de compartir un comercio via deep link.
+
+---
+
+## F1 — Comentarios 2.0
+
+### F1.1 — Editar comentarios propios
+
+**Como** usuario que escribió un comentario,
+**quiero** poder editarlo,
+**para** corregir errores sin tener que eliminarlo y reescribirlo.
+
+#### Criterios de aceptación
+
+- [ ] Botón "Editar" (icono lápiz) visible **solo** en comentarios del usuario actual
+- [ ] Al tocar editar, el texto se convierte en TextField inline editable
+- [ ] Botones "Guardar" y "Cancelar" reemplazan el botón editar
+- [ ] Guardar actualiza el texto en Firestore y muestra el nuevo texto
+- [ ] Cancelar descarta los cambios y vuelve al modo lectura
+- [ ] Mismas validaciones que creación: 1-500 caracteres
+- [ ] Campo `updatedAt` en Firestore marca la fecha de edición
+- [ ] Indicador visual "editado" (texto gris sutil junto a la fecha)
+- [ ] Moderación server-side en trigger `onUpdate` (re-evalúa flagged)
+- [ ] Firestore rules permiten update solo al owner, validan campos
+
+### F1.2 — Eliminar con undo
+
+**Como** usuario que quiere eliminar un comentario,
+**quiero** poder deshacer la acción,
+**para** no perder mi comentario por un toque accidental.
+
+#### Criterios de aceptación
+
+- [ ] Al tocar eliminar, el comentario desaparece inmediatamente (optimistic)
+- [ ] Snackbar aparece: "Comentario eliminado" con botón "Deshacer" (5 segundos)
+- [ ] Si toca "Deshacer", el comentario reaparece en su posición original
+- [ ] Si no toca deshacer (5s), se ejecuta el delete real en Firestore
+- [ ] Eliminar el dialog de confirmación actual (el undo lo reemplaza)
+- [ ] Mismo comportamiento en BusinessComments y CommentsList
+
+### F1.3 — Likes en comentarios
+
+**Como** usuario,
+**quiero** darle like a comentarios útiles de otros,
+**para** destacar la información valiosa.
+
+#### Criterios de aceptación
+
+- [ ] Botón like (icono corazón o thumbs-up) en cada comentario
+- [ ] **No** visible en comentarios propios (no auto-like)
+- [ ] Toggle: tocar una vez = like, tocar otra vez = unlike
+- [ ] Contador de likes visible junto al botón
+- [ ] Estado del like del usuario actual se carga junto con los comentarios
+- [ ] Cloud Function trigger actualiza `likeCount` atómicamente
+- [ ] Rate limiting: max 50 likes/día por usuario
+
+#### Modelo de datos
+
+```text
+commentLikes/{userId}__{commentId}
+  ├── userId: string
+  ├── commentId: string
+  └── createdAt: Timestamp
+
+Comment (campos nuevos):
+  └── likeCount: number (default 0)
+```
+
+### F1.4 — Ordenamiento de comentarios
+
+**Como** usuario que lee comentarios de un comercio,
+**quiero** ordenarlos por fecha o utilidad,
+**para** encontrar los más relevantes rápido.
+
+#### Criterios de aceptación
+
+- [ ] Selector de orden como chips compactos encima de la lista
+- [ ] Opciones: "Recientes" (default), "Antiguos", "Útiles" (por likes desc)
+- [ ] Orden se aplica client-side sobre los comentarios cargados
+- [ ] Orden persiste mientras el bottom sheet está abierto
+- [ ] Se resetea a "Recientes" al abrir otro comercio
+
+---
+
+## F8 — Compartir comercio
+
+**Como** usuario que encontró un buen comercio,
+**quiero** compartirlo con otros,
+**para** recomendar lugares a mis compañeros.
+
+#### Criterios de aceptación
+
+- [ ] Botón "Compartir" (icono share) en BusinessHeader junto a favorito y direcciones
+- [ ] En dispositivos con Web Share API: abre el sheet nativo del OS
+- [ ] Fallback: copia el link al clipboard + Snackbar "Link copiado"
+- [ ] URL: `https://modo-mapa-app.web.app/?business={businessId}`
+- [ ] Texto compartido: "Mirá {nombre} en Modo Mapa — {dirección}"
+- [ ] Al abrir un deep link, la app centra el mapa y abre el bottom sheet del comercio
+- [ ] El deep link funciona correctamente en PWA y en browser
+
+---
+
+## Fuera de alcance
+
+- Threads / respuestas a comentarios (Fase 4)
+- Notificaciones de likes (Fase 3)
+- Foto de menú (Fase 2)
+- Perfil público de usuario (Fase 3)
+
+---
+
+## Dependencias entre features
+
+```text
+F1.1 (editar) ──────────────── independiente
+F1.2 (undo eliminar) ───────── independiente
+F1.3 (likes) ───┐
+                 ├─── F1.4 depende de F1.3 para "Más útiles"
+F1.4 (orden) ───┘
+F8 (compartir) ──────────────── independiente
+```
+
+---
+
+## Impacto en Firestore
+
+| Feature | Reads | Writes | Nueva colección |
+|---------|-------|--------|-----------------|
+| F1.1 Editar | 0 | +1 update por edit | — |
+| F1.2 Undo | 0 (delayed delete) | 0 (mismo delete) | — |
+| F1.3 Likes | +1 query por comercio (user likes) | +1 toggle por like | `commentLikes` |
+| F1.4 Orden | 0 (client-side sort) | 0 | — |
+| F8 Compartir | 0 | 0 | — |
+
+---
+
+## Archivos afectados (estimación)
+
+### Frontend
+
+| Archivo | Cambio |
+|---------|--------|
+| `src/types/index.ts` | Agregar `updatedAt?`, `likeCount` a Comment. Nuevo tipo `CommentLike` |
+| `src/services/comments.ts` | Nueva `editComment()`, `likeComment()`, `unlikeComment()` |
+| `src/config/collections.ts` | Nueva colección `commentLikes` |
+| `src/config/converters.ts` | Converter para `commentLikes` |
+| `src/components/business/BusinessComments.tsx` | Edit inline, like button, sort selector, undo delete |
+| `src/components/business/BusinessHeader.tsx` | Botón compartir |
+| `src/components/menu/CommentsList.tsx` | Undo delete |
+| `src/hooks/useBusinessData.ts` | Cargar likes del usuario en la query |
+| `src/components/layout/AppShell.tsx` | Leer query param `?business=` para deep link |
+
+### Backend
+
+| Archivo | Cambio |
+|---------|--------|
+| `firestore.rules` | Regla update para comments, reglas para commentLikes |
+| `functions/src/triggers/comments.ts` | Trigger onUpdate para re-moderar |
+| `functions/src/triggers/commentLikes.ts` | Nuevo: counter de likeCount |
+| `functions/src/index.ts` | Exportar nuevos triggers |
+
+### Tests
+
+| Archivo | Cambio |
+|---------|--------|
+| `functions/src/triggers/__tests__/` | Tests para onUpdate y commentLikes triggers |

--- a/docs/feat-comments-2.0/specs.md
+++ b/docs/feat-comments-2.0/specs.md
@@ -1,0 +1,496 @@
+# Technical Specs — Comentarios 2.0 + Compartir comercio
+
+**Issues:** #45, #46, cierra #17
+
+---
+
+## 1. Tipos
+
+### `src/types/index.ts`
+
+```typescript
+// Modificar Comment existente:
+export interface Comment {
+  id: string;
+  userId: string;
+  userName: string;
+  businessId: string;
+  text: string;
+  createdAt: Date;
+  updatedAt?: Date;       // NUEVO — fecha de última edición
+  likeCount: number;       // NUEVO — contador de likes (default 0)
+  flagged?: boolean;
+}
+
+// Nuevo tipo:
+export interface CommentLike {
+  userId: string;
+  commentId: string;
+  createdAt: Date;
+}
+```
+
+---
+
+## 2. Colección Firestore
+
+### `src/config/collections.ts`
+
+```typescript
+export const COLLECTIONS = {
+  // ... existentes ...
+  COMMENT_LIKES: 'commentLikes',   // NUEVO
+} as const;
+```
+
+### Doc ID pattern
+
+`commentLikes/{userId}__{commentId}` — misma convención que favorites/ratings.
+
+---
+
+## 3. Converter
+
+### `src/config/converters.ts`
+
+Modificar `commentConverter` para incluir `updatedAt` y `likeCount`:
+
+```typescript
+fromFirestore(snapshot, options): Comment {
+  const d = snapshot.data(options);
+  return {
+    id: snapshot.id,
+    userId: d.userId,
+    userName: d.userName,
+    businessId: d.businessId,
+    text: d.text,
+    createdAt: toDate(d.createdAt),
+    likeCount: (d.likeCount as number) ?? 0,
+    ...(d.updatedAt ? { updatedAt: toDate(d.updatedAt) } : {}),
+    ...(d.flagged === true ? { flagged: true } : {}),
+  };
+}
+```
+
+Nuevo `commentLikeConverter`:
+
+```typescript
+export const commentLikeConverter: FirestoreDataConverter<CommentLike> = {
+  toFirestore(like: CommentLike) {
+    return { userId: like.userId, commentId: like.commentId, createdAt: like.createdAt };
+  },
+  fromFirestore(snapshot, options): CommentLike {
+    const d = snapshot.data(options);
+    return { userId: d.userId, commentId: d.commentId, createdAt: toDate(d.createdAt) };
+  },
+};
+```
+
+---
+
+## 4. Service layer
+
+### `src/services/comments.ts` — funciones nuevas
+
+```typescript
+// Editar comentario propio
+export async function editComment(commentId: string, userId: string, newText: string): Promise<void> {
+  const trimmed = newText.trim();
+  if (!trimmed || trimmed.length > 500) {
+    throw new Error('Comment text must be 1-500 characters');
+  }
+  await updateDoc(doc(db, COLLECTIONS.COMMENTS, commentId), {
+    text: trimmed,
+    updatedAt: serverTimestamp(),
+  });
+  invalidateQueryCache(COLLECTIONS.COMMENTS, userId);
+}
+
+// Dar like a un comentario
+export async function likeComment(userId: string, commentId: string): Promise<void> {
+  const docId = `${userId}__${commentId}`;
+  await setDoc(doc(db, COLLECTIONS.COMMENT_LIKES, docId), {
+    userId,
+    commentId,
+    createdAt: serverTimestamp(),
+  });
+}
+
+// Quitar like
+export async function unlikeComment(userId: string, commentId: string): Promise<void> {
+  const docId = `${userId}__${commentId}`;
+  await deleteDoc(doc(db, COLLECTIONS.COMMENT_LIKES, docId));
+}
+```
+
+---
+
+## 5. Firestore rules
+
+### Comments — agregar `update`
+
+```text
+match /comments/{docId} {
+  allow read: if request.auth != null;
+  allow create: if request.auth != null
+    && request.resource.data.userId == request.auth.uid
+    && isValidBusinessId(request.resource.data.businessId)
+    && request.resource.data.userName.size() > 0
+    && request.resource.data.userName.size() <= 30
+    && request.resource.data.text.size() > 0
+    && request.resource.data.text.size() <= 500
+    && request.resource.data.createdAt == request.time;
+  allow update: if request.auth != null
+    && resource.data.userId == request.auth.uid
+    && request.resource.data.text.size() > 0
+    && request.resource.data.text.size() <= 500
+    && request.resource.data.updatedAt == request.time
+    // No permitir cambiar userId, businessId, userName, createdAt
+    && request.resource.data.userId == resource.data.userId
+    && request.resource.data.businessId == resource.data.businessId
+    && request.resource.data.userName == resource.data.userName
+    && request.resource.data.createdAt == resource.data.createdAt;
+  allow delete: if request.auth != null
+    && resource.data.userId == request.auth.uid;
+}
+```
+
+### commentLikes — nueva colección
+
+```text
+match /commentLikes/{docId} {
+  allow read: if request.auth != null;
+  allow create: if request.auth != null
+    && request.resource.data.userId == request.auth.uid
+    && request.resource.data.commentId is string
+    && request.resource.data.commentId.size() > 0
+    && request.resource.data.createdAt == request.time;
+  allow delete: if request.auth != null
+    && resource.data.userId == request.auth.uid;
+}
+```
+
+---
+
+## 6. Cloud Functions
+
+### `functions/src/triggers/comments.ts` — agregar onUpdate
+
+```typescript
+export const onCommentUpdated = onDocumentUpdated(
+  'comments/{commentId}',
+  async (event) => {
+    const db = getFirestore();
+    const after = event.data?.after;
+    if (!after) return;
+
+    const data = after.data();
+    const before = event.data?.before.data();
+
+    // Solo re-moderar si el texto cambió
+    if (before && data.text !== before.text) {
+      const flagged = await checkModeration(db, data.text as string);
+      if (flagged && !data.flagged) {
+        await after.ref.update({ flagged: true });
+        await logAbuse(db, {
+          userId: data.userId as string,
+          type: 'flagged',
+          collection: 'comments',
+          detail: `Flagged edited text: "${(data.text as string).slice(0, 100)}"`,
+        });
+      }
+      // Si antes estaba flagged y ahora el texto es limpio, quitar flag
+      if (!flagged && data.flagged) {
+        await after.ref.update({ flagged: false });
+      }
+    }
+  },
+);
+```
+
+### `functions/src/triggers/commentLikes.ts` — nuevo
+
+```typescript
+export const onCommentLikeCreated = onDocumentCreated(
+  'commentLikes/{docId}',
+  async (event) => {
+    const db = getFirestore();
+    const data = event.data?.data();
+    if (!data) return;
+
+    const userId = data.userId as string;
+
+    // Rate limit: 50 likes/day
+    const exceeded = await checkRateLimit(db, {
+      collection: 'commentLikes',
+      limit: 50,
+      windowType: 'daily',
+    }, userId);
+
+    if (exceeded) {
+      await event.data!.ref.delete();
+      return;
+    }
+
+    // Incrementar likeCount en el comentario
+    const commentId = data.commentId as string;
+    await db.doc(`comments/${commentId}`).update({
+      likeCount: FieldValue.increment(1),
+    });
+
+    await incrementCounter(db, 'commentLikes', 1);
+    await trackWrite(db, 'commentLikes');
+  },
+);
+
+export const onCommentLikeDeleted = onDocumentDeleted(
+  'commentLikes/{docId}',
+  async (event) => {
+    const db = getFirestore();
+    const data = event.data?.data();
+    if (!data) return;
+
+    const commentId = data.commentId as string;
+    await db.doc(`comments/${commentId}`).update({
+      likeCount: FieldValue.increment(-1),
+    });
+
+    await incrementCounter(db, 'commentLikes', -1);
+    await trackDelete(db, 'commentLikes');
+  },
+);
+```
+
+---
+
+## 7. Hook `useBusinessData` — cargar likes
+
+Agregar al `UseBusinessDataReturn`:
+
+```typescript
+interface UseBusinessDataReturn {
+  // ... existentes ...
+  userCommentLikes: Set<string>;  // NUEVO — set de commentIds que el usuario likeó
+}
+```
+
+En `fetchBusinessData`, agregar una 6ta query:
+
+```typescript
+// Junto a las otras 5 queries en Promise.all:
+getDocs(query(
+  collection(db, COLLECTIONS.COMMENT_LIKES).withConverter(commentLikeConverter),
+  where('userId', '==', uid),
+  // No filtrar por businessId — los likes son por commentId
+  // Filtramos client-side por los commentIds del business
+))
+```
+
+**Alternativa más eficiente** (para no traer todos los likes del usuario): Después de obtener los comments, hacer queries individuales por cada commentId del usuario:
+
+```typescript
+// Mejor: query los likes del usuario para los comments de este business
+const commentIds = commentsResult.map(c => c.id);
+const likeChecks = commentIds.map(cId =>
+  getDoc(doc(db, COLLECTIONS.COMMENT_LIKES, `${uid}__${cId}`))
+);
+const likeSnaps = await Promise.all(likeChecks);
+const userCommentLikes = new Set(
+  likeSnaps.filter(s => s.exists()).map((s, i) => commentIds[i])
+);
+```
+
+**Nota:** Esto es O(N) getDoc calls donde N = número de comentarios del business. Para la mayoría de comercios (< 20 comments) es aceptable. Si escala, migrar a una single query con `where('commentId', 'in', commentIds)` (max 30 por query).
+
+---
+
+## 8. Componente `BusinessComments.tsx` — cambios
+
+### Props actualizado
+
+```typescript
+interface Props {
+  businessId: string;
+  comments: Comment[];
+  userCommentLikes: Set<string>;   // NUEVO
+  isLoading: boolean;
+  onCommentsChange: () => void;
+}
+```
+
+### Estado interno nuevo
+
+```typescript
+// Edición
+const [editingId, setEditingId] = useState<string | null>(null);
+const [editText, setEditText] = useState('');
+
+// Undo delete
+const [pendingDelete, setPendingDelete] = useState<Comment | null>(null);
+// Timer ref para auto-confirmar delete
+const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+// Ordenamiento
+type SortMode = 'recent' | 'oldest' | 'useful';
+const [sortMode, setSortMode] = useState<SortMode>('recent');
+
+// Likes optimistic
+const [optimisticLikes, setOptimisticLikes] = useState<Map<string, number>>(new Map());
+const [optimisticUserLikes, setOptimisticUserLikes] = useState<Set<string>>(new Set());
+```
+
+### Ordenamiento (client-side)
+
+```typescript
+const sortedComments = useMemo(() => {
+  // Filtrar el comentario pending delete
+  const visible = pendingDelete
+    ? comments.filter(c => c.id !== pendingDelete.id)
+    : comments;
+
+  return [...visible].sort((a, b) => {
+    switch (sortMode) {
+      case 'recent': return b.createdAt.getTime() - a.createdAt.getTime();
+      case 'oldest': return a.createdAt.getTime() - b.createdAt.getTime();
+      case 'useful': return (b.likeCount ?? 0) - (a.likeCount ?? 0);
+    }
+  });
+}, [comments, sortMode, pendingDelete]);
+```
+
+### Flujo de edición inline
+
+1. Click en lápiz → `setEditingId(comment.id)`, `setEditText(comment.text)`
+2. Render: si `editingId === comment.id`, mostrar TextField + Save/Cancel
+3. Save → `editComment(commentId, userId, editText)` → `onCommentsChange()`
+4. Cancel → `setEditingId(null)`
+
+### Flujo de undo delete
+
+1. Click en delete → `setPendingDelete(comment)` (no dialog)
+2. Comentario desaparece de la lista (filtrado en `sortedComments`)
+3. Snackbar con "Comentario eliminado" + botón "Deshacer" (5s)
+4. Si Deshacer → `setPendingDelete(null)` (reaparece)
+5. Si timeout → `deleteComment(id, userId)` → `onCommentsChange()` → `setPendingDelete(null)`
+
+### Flujo de like
+
+1. Click en corazón → optimistic toggle en `optimisticUserLikes` y `optimisticLikes`
+2. Call `likeComment()` o `unlikeComment()`
+3. No necesita refetch — el Cloud Function actualiza `likeCount` server-side, pero UI ya refleja el cambio optimista
+
+---
+
+## 9. Componente `BusinessHeader.tsx` — botón compartir
+
+### Props actualizado
+
+```typescript
+interface Props {
+  business: Business;
+  favoriteButton: ReactNode;
+  shareButton: ReactNode;   // NUEVO
+}
+```
+
+### Componente `ShareButton`
+
+Nuevo archivo `src/components/business/ShareButton.tsx`:
+
+```typescript
+interface Props {
+  business: Business;
+}
+
+export default function ShareButton({ business }: Props) {
+  const [snackOpen, setSnackOpen] = useState(false);
+
+  const handleShare = async () => {
+    const url = `${window.location.origin}/?business=${business.id}`;
+    const text = `Mirá ${business.name} en Modo Mapa — ${business.address}`;
+
+    if (navigator.share) {
+      await navigator.share({ title: business.name, text, url });
+    } else {
+      await navigator.clipboard.writeText(url);
+      setSnackOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <IconButton onClick={handleShare} aria-label="Compartir comercio">
+        <ShareIcon />
+      </IconButton>
+      <Snackbar open={snackOpen} autoHideDuration={3000}
+        onClose={() => setSnackOpen(false)} message="Link copiado" />
+    </>
+  );
+}
+```
+
+---
+
+## 10. Deep link — `AppShell.tsx`
+
+Al montar, leer `?business=` de la URL y seleccionar el comercio:
+
+```typescript
+import { useSearchParams } from 'react-router-dom';
+import { allBusinesses } from '../hooks/useBusinesses';
+
+export default function AppShell() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { setSelectedBusiness } = useMapContext();
+
+  useEffect(() => {
+    const bizId = searchParams.get('business');
+    if (bizId) {
+      const biz = allBusinesses.find(b => b.id === bizId);
+      if (biz) {
+        setSelectedBusiness(biz);
+        // Limpiar query param para no re-abrir en cada render
+        searchParams.delete('business');
+        setSearchParams(searchParams, { replace: true });
+      }
+    }
+  }, []); // solo al montar
+```
+
+---
+
+## 11. `CommentsList.tsx` — undo delete
+
+Mismo patrón de undo que `BusinessComments`:
+
+- Reemplazar dialog de confirmación por pendingDelete + Snackbar
+- Timer de 5s para auto-confirmar
+
+---
+
+## 12. Firestore indexes
+
+No se necesitan índices nuevos compuestos. La query de commentLikes usa doc ID directo (`getDoc`), no query compuesta.
+
+---
+
+## 13. Resumen de archivos
+
+| Archivo | Acción |
+|---------|--------|
+| `src/types/index.ts` | Modificar Comment, agregar CommentLike |
+| `src/config/collections.ts` | Agregar COMMENT_LIKES |
+| `src/config/converters.ts` | Modificar commentConverter, agregar commentLikeConverter |
+| `src/services/comments.ts` | Agregar editComment, likeComment, unlikeComment |
+| `src/hooks/useBusinessData.ts` | Agregar userCommentLikes al return, 6ta query |
+| `src/hooks/useBusinessDataCache.ts` | Agregar userCommentLikes al tipo cache |
+| `src/components/business/BusinessComments.tsx` | Edit inline, likes, sort, undo delete |
+| `src/components/business/BusinessHeader.tsx` | Agregar prop shareButton |
+| `src/components/business/BusinessSheet.tsx` | Pasar userCommentLikes + ShareButton |
+| `src/components/business/ShareButton.tsx` | Nuevo componente |
+| `src/components/menu/CommentsList.tsx` | Undo delete |
+| `src/components/layout/AppShell.tsx` | Deep link ?business= |
+| `firestore.rules` | Update rule para comments, nueva colección commentLikes |
+| `functions/src/triggers/comments.ts` | Agregar onCommentUpdated |
+| `functions/src/triggers/commentLikes.ts` | Nuevo: onCreate + onDeleted |
+| `functions/src/index.ts` | Exportar nuevos triggers |

--- a/firestore.rules
+++ b/firestore.rules
@@ -66,6 +66,7 @@ service cloud.firestore {
 
     // Comentarios — cualquier usuario autenticado puede leer.
     // Owner puede crear con userName (1-30), text (1-500) y timestamp validado.
+    // Owner puede editar solo el texto (1-500) con updatedAt validado.
     // Owner puede eliminar sus propios comentarios.
     match /comments/{docId} {
       allow read: if request.auth != null;
@@ -76,6 +77,28 @@ service cloud.firestore {
         && request.resource.data.userName.size() <= 30
         && request.resource.data.text.size() > 0
         && request.resource.data.text.size() <= 500
+        && request.resource.data.createdAt == request.time;
+      allow update: if request.auth != null
+        && resource.data.userId == request.auth.uid
+        && request.resource.data.text.size() > 0
+        && request.resource.data.text.size() <= 500
+        && request.resource.data.updatedAt == request.time
+        && request.resource.data.userId == resource.data.userId
+        && request.resource.data.businessId == resource.data.businessId
+        && request.resource.data.userName == resource.data.userName
+        && request.resource.data.createdAt == resource.data.createdAt;
+      allow delete: if request.auth != null
+        && resource.data.userId == request.auth.uid;
+    }
+
+    // Likes en comentarios — cualquier usuario autenticado puede leer.
+    // Owner puede crear (con timestamp validado) o eliminar su like.
+    match /commentLikes/{docId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.commentId is string
+        && request.resource.data.commentId.size() > 0
         && request.resource.data.createdAt == request.time;
       allow delete: if request.auth != null
         && resource.data.userId == request.auth.uid;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,7 +5,8 @@ initializeApp();
 initSentry();
 
 // Triggers
-export { onCommentCreated, onCommentDeleted } from './triggers/comments';
+export { onCommentCreated, onCommentUpdated, onCommentDeleted } from './triggers/comments';
+export { onCommentLikeCreated, onCommentLikeDeleted } from './triggers/commentLikes';
 export { onCustomTagCreated, onCustomTagDeleted } from './triggers/customTags';
 export { onFeedbackCreated } from './triggers/feedback';
 export { onRatingWritten } from './triggers/ratings';

--- a/functions/src/triggers/commentLikes.ts
+++ b/functions/src/triggers/commentLikes.ts
@@ -1,0 +1,57 @@
+import { onDocumentCreated, onDocumentDeleted } from 'firebase-functions/v2/firestore';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { checkRateLimit } from '../utils/rateLimiter';
+import { incrementCounter, trackWrite, trackDelete } from '../utils/counters';
+
+export const onCommentLikeCreated = onDocumentCreated(
+  'commentLikes/{docId}',
+  async (event) => {
+    const db = getFirestore();
+    const snap = event.data;
+    if (!snap) return;
+
+    const data = snap.data();
+    const userId = data.userId as string;
+    const commentId = data.commentId as string;
+
+    // Rate limit: 50 likes per day per user
+    const exceeded = await checkRateLimit(
+      db,
+      { collection: 'commentLikes', limit: 50, windowType: 'daily' },
+      userId,
+    );
+
+    if (exceeded) {
+      await snap.ref.delete();
+      return;
+    }
+
+    // Increment likeCount on the comment
+    await db.doc(`comments/${commentId}`).update({
+      likeCount: FieldValue.increment(1),
+    });
+
+    await incrementCounter(db, 'commentLikes', 1);
+    await trackWrite(db, 'commentLikes');
+  },
+);
+
+export const onCommentLikeDeleted = onDocumentDeleted(
+  'commentLikes/{docId}',
+  async (event) => {
+    const db = getFirestore();
+    const snap = event.data;
+    if (!snap) return;
+
+    const data = snap.data();
+    const commentId = data.commentId as string;
+
+    // Decrement likeCount on the comment
+    await db.doc(`comments/${commentId}`).update({
+      likeCount: FieldValue.increment(-1),
+    });
+
+    await incrementCounter(db, 'commentLikes', -1);
+    await trackDelete(db, 'commentLikes');
+  },
+);

--- a/functions/src/triggers/comments.ts
+++ b/functions/src/triggers/comments.ts
@@ -1,4 +1,4 @@
-import { onDocumentCreated, onDocumentDeleted } from 'firebase-functions/v2/firestore';
+import { onDocumentCreated, onDocumentDeleted, onDocumentUpdated } from 'firebase-functions/v2/firestore';
 import { getFirestore } from 'firebase-admin/firestore';
 import { checkRateLimit } from '../utils/rateLimiter';
 import { checkModeration } from '../utils/moderator';
@@ -48,6 +48,37 @@ export const onCommentCreated = onDocumentCreated(
     // 3. Counters
     await incrementCounter(db, 'comments', 1);
     await trackWrite(db, 'comments');
+  },
+);
+
+export const onCommentUpdated = onDocumentUpdated(
+  'comments/{commentId}',
+  async (event) => {
+    const db = getFirestore();
+    const after = event.data?.after;
+    const before = event.data?.before;
+    if (!after || !before) return;
+
+    const afterData = after.data();
+    const beforeData = before.data();
+
+    // Only re-moderate if text changed (ignore likeCount updates from Cloud Functions)
+    if (afterData.text !== beforeData.text) {
+      const flagged = await checkModeration(db, afterData.text as string);
+      if (flagged && !afterData.flagged) {
+        await after.ref.update({ flagged: true });
+        await logAbuse(db, {
+          userId: afterData.userId as string,
+          type: 'flagged',
+          collection: 'comments',
+          detail: `Flagged edited text: "${(afterData.text as string).slice(0, 100)}"`,
+        });
+      }
+      // If text is now clean but was flagged, remove flag
+      if (!flagged && afterData.flagged) {
+        await after.ref.update({ flagged: false });
+      }
+    }
   },
 );
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modo-mapa",
   "private": true,
-  "version": "1.5.1",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/seed-admin-data.mjs
+++ b/scripts/seed-admin-data.mjs
@@ -4,12 +4,24 @@
  * Requires emulators running: npm run emulators
  */
 
-import { initializeApp } from 'firebase/app';
-import { getFirestore, connectFirestoreEmulator, doc, setDoc, collection, addDoc, Timestamp } from 'firebase/firestore';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(join(__dirname, '..', 'functions', 'node_modules', 'x.js'));
+const admin = require('firebase-admin');
+const { Timestamp } = require('firebase-admin/firestore');
 
-const app = initializeApp({ projectId: 'modo-mapa-app', apiKey: 'fake' });
-const db = getFirestore(app);
-connectFirestoreEmulator(db, 'localhost', 8080);
+// Use admin SDK to bypass Firestore rules in emulator
+process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
+admin.initializeApp({ projectId: 'modo-mapa-app' });
+const db = admin.firestore();
+
+// Helper wrappers to match client SDK API used below
+const doc = (_db, col, id) => db.collection(col).doc(id);
+const setDoc = (ref, data) => ref.set(data);
+const addDoc = (colRef, data) => colRef.add(data);
+const collection = (_db, name) => db.collection(name);
 
 const BUSINESS_IDS = [
   'biz_001', 'biz_002', 'biz_003', 'biz_004', 'biz_005',
@@ -78,6 +90,7 @@ async function seed() {
     users: 10,
     customTags: 15,
     userTags: 50,
+    commentLikes: 80,
     dailyReads: 342,
     dailyWrites: 87,
     dailyDeletes: 12,
@@ -176,19 +189,42 @@ async function seed() {
     });
   }
 
-  // 5. Comments (using admin email auth bypass won't work on emulator without auth)
-  // For collections with auth rules, we write directly to emulator
+  // 5. Comments (with likeCount and some with updatedAt for "edited" indicator)
   console.log('Creating comments...');
+  const commentIds = [];
   for (let i = 0; i < 60; i++) {
     const userId = randomFrom(USER_IDS);
     const idx = USER_IDS.indexOf(userId);
-    await addDoc(collection(db, 'comments'), {
+    const createdAt = daysAgo(randomInt(0, 25));
+    const isEdited = i % 10 === 0;
+    const ref = await addDoc(collection(db, 'comments'), {
       userId,
       userName: USER_NAMES[idx],
       businessId: randomFrom(BUSINESS_IDS),
       text: randomFrom(COMMENT_TEXTS),
-      createdAt: daysAgo(randomInt(0, 25)),
+      createdAt,
+      likeCount: randomInt(0, 8),
+      ...(isEdited ? { updatedAt: daysAgo(randomInt(0, 3)) } : {}),
       ...(i % 15 === 0 ? { flagged: true } : {}),
+    });
+    commentIds.push({ id: ref.id, userId });
+  }
+
+  // 5b. Comment likes
+  console.log('Creating comment likes...');
+  const likePairs = new Set();
+  for (let i = 0; i < 80; i++) {
+    const userId = randomFrom(USER_IDS);
+    const comment = randomFrom(commentIds);
+    // Don't self-like
+    if (userId === comment.userId) continue;
+    const key = `${userId}__${comment.id}`;
+    if (likePairs.has(key)) continue;
+    likePairs.add(key);
+    await setDoc(doc(db, 'commentLikes', key), {
+      userId,
+      commentId: comment.id,
+      createdAt: daysAgo(randomInt(0, 15)),
     });
   }
 
@@ -280,7 +316,8 @@ async function seed() {
 
   console.log('\n✅ Seed complete!');
   console.log('- 10 users');
-  console.log('- ~60 comments (4 flagged)');
+  console.log('- ~60 comments (4 flagged, ~6 edited, with likeCount)');
+  console.log('- ~80 comment likes');
   console.log('- ~40 ratings');
   console.log('- ~30 favorites');
   console.log('- ~50 user tags');

--- a/src/components/business/BusinessComments.tsx
+++ b/src/components/business/BusinessComments.tsx
@@ -1,4 +1,4 @@
-import { useState, memo } from 'react';
+import { useState, useMemo, useRef, useCallback, memo } from 'react';
 import {
   Box,
   Typography,
@@ -10,30 +10,51 @@ import {
   Avatar,
   Divider,
   IconButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
+  Snackbar,
+  Chip,
 } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
 import { useAuth } from '../../context/AuthContext';
-import { addComment, deleteComment } from '../../services/comments';
+import { addComment, editComment, deleteComment, likeComment, unlikeComment } from '../../services/comments';
 import { formatDateMedium } from '../../utils/formatDate';
 import type { Comment } from '../../types';
+
+type SortMode = 'recent' | 'oldest' | 'useful';
 
 interface Props {
   businessId: string;
   comments: Comment[];
+  userCommentLikes: Set<string>;
   isLoading: boolean;
   onCommentsChange: () => void;
 }
 
-export default memo(function BusinessComments({ businessId, comments, isLoading, onCommentsChange }: Props) {
+export default memo(function BusinessComments({ businessId, comments, userCommentLikes, isLoading, onCommentsChange }: Props) {
   const { user, displayName } = useAuth();
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  // Sort
+  const [sortMode, setSortMode] = useState<SortMode>('recent');
+
+  // Edit
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState('');
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+
+  // Undo delete
+  const [pendingDelete, setPendingDelete] = useState<Comment | null>(null);
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Optimistic likes
+  const [optimisticLikeToggle, setOptimisticLikeToggle] = useState<Map<string, boolean>>(new Map());
+  const [optimisticLikeDelta, setOptimisticLikeDelta] = useState<Map<string, number>>(new Map());
 
   const MAX_COMMENTS_PER_DAY = 20;
 
@@ -43,14 +64,40 @@ export default memo(function BusinessComments({ businessId, comments, isLoading,
     return c.createdAt.toDateString() === today.toDateString();
   }).length;
 
+  // Sorted and filtered comments
+  const sortedComments = useMemo(() => {
+    const visible = pendingDelete
+      ? comments.filter((c) => c.id !== pendingDelete.id)
+      : comments;
+
+    return [...visible].sort((a, b) => {
+      switch (sortMode) {
+        case 'recent': return b.createdAt.getTime() - a.createdAt.getTime();
+        case 'oldest': return a.createdAt.getTime() - b.createdAt.getTime();
+        case 'useful': return b.likeCount - a.likeCount;
+      }
+    });
+  }, [comments, sortMode, pendingDelete]);
+
+  // Helpers for optimistic likes
+  const isLiked = useCallback((commentId: string) => {
+    const toggled = optimisticLikeToggle.get(commentId);
+    if (toggled !== undefined) return toggled;
+    return userCommentLikes.has(commentId);
+  }, [userCommentLikes, optimisticLikeToggle]);
+
+  const getLikeCount = useCallback((comment: Comment) => {
+    const delta = optimisticLikeDelta.get(comment.id) ?? 0;
+    return Math.max(0, comment.likeCount + delta);
+  }, [optimisticLikeDelta]);
+
+  // Handlers
   const handleSubmit = async () => {
     if (!user || !newComment.trim()) return;
     if (userCommentsToday >= MAX_COMMENTS_PER_DAY) return;
     setIsSubmitting(true);
-    const text = newComment.trim();
-    const userName = displayName || 'Anónimo';
     try {
-      await addComment(user.uid, userName, businessId, text);
+      await addComment(user.uid, displayName || 'Anónimo', businessId, newComment.trim());
       setNewComment('');
       onCommentsChange();
     } catch (error) {
@@ -59,18 +106,106 @@ export default memo(function BusinessComments({ businessId, comments, isLoading,
     setIsSubmitting(false);
   };
 
-  const handleDeleteComment = async () => {
-    if (!confirmDeleteId || !user) return;
-    await deleteComment(confirmDeleteId, user.uid);
-    setConfirmDeleteId(null);
-    onCommentsChange();
+  const handleStartEdit = (comment: Comment) => {
+    setEditingId(comment.id);
+    setEditText(comment.text);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditText('');
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId || !user || !editText.trim()) return;
+    setIsSavingEdit(true);
+    try {
+      await editComment(editingId, user.uid, editText.trim());
+      setEditingId(null);
+      setEditText('');
+      onCommentsChange();
+    } catch (error) {
+      if (import.meta.env.DEV) console.error('Error editing comment:', error);
+    }
+    setIsSavingEdit(false);
+  };
+
+  const handleDelete = (comment: Comment) => {
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+
+    setPendingDelete(comment);
+    deleteTimerRef.current = setTimeout(async () => {
+      if (!user) return;
+      try {
+        await deleteComment(comment.id, user.uid);
+        onCommentsChange();
+      } catch (error) {
+        if (import.meta.env.DEV) console.error('Error deleting comment:', error);
+      }
+      setPendingDelete(null);
+    }, 5000);
+  };
+
+  const handleUndoDelete = () => {
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+    setPendingDelete(null);
+  };
+
+  const handleToggleLike = async (commentId: string) => {
+    if (!user) return;
+    const currentlyLiked = isLiked(commentId);
+
+    // Optimistic update
+    setOptimisticLikeToggle((prev) => new Map(prev).set(commentId, !currentlyLiked));
+    setOptimisticLikeDelta((prev) => {
+      const current = prev.get(commentId) ?? 0;
+      return new Map(prev).set(commentId, currentlyLiked ? current - 1 : current + 1);
+    });
+
+    try {
+      if (currentlyLiked) {
+        await unlikeComment(user.uid, commentId);
+      } else {
+        await likeComment(user.uid, commentId);
+      }
+    } catch (error) {
+      // Revert optimistic update
+      setOptimisticLikeToggle((prev) => {
+        const next = new Map(prev);
+        next.delete(commentId);
+        return next;
+      });
+      setOptimisticLikeDelta((prev) => {
+        const next = new Map(prev);
+        next.delete(commentId);
+        return next;
+      });
+      if (import.meta.env.DEV) console.error('Error toggling like:', error);
+    }
   };
 
   return (
     <Box sx={{ py: 1 }}>
-      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
-        Comentarios ({isLoading ? '...' : comments.length})
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+          Comentarios ({isLoading ? '...' : comments.length})
+        </Typography>
+        {comments.length > 1 && (
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            {(['recent', 'oldest', 'useful'] as const).map((mode) => (
+              <Chip
+                key={mode}
+                label={mode === 'recent' ? 'Recientes' : mode === 'oldest' ? 'Antiguos' : 'Útiles'}
+                size="small"
+                variant={sortMode === mode ? 'filled' : 'outlined'}
+                color={sortMode === mode ? 'primary' : 'default'}
+                onClick={() => setSortMode(mode)}
+                sx={{ height: 24, fontSize: '0.7rem' }}
+              />
+            ))}
+          </Box>
+        )}
+      </Box>
 
       {user && (
         <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
@@ -106,7 +241,7 @@ export default memo(function BusinessComments({ businessId, comments, isLoading,
       )}
 
       <List disablePadding>
-        {comments.map((comment, index) => (
+        {sortedComments.map((comment, index) => (
           <Box key={comment.id}>
             <ListItem alignItems="flex-start" disablePadding sx={{ py: 1 }}>
               <Avatar
@@ -121,30 +256,108 @@ export default memo(function BusinessComments({ businessId, comments, isLoading,
               >
                 {(comment.userName || 'A').charAt(0).toUpperCase()}
               </Avatar>
-              <ListItemText
-                primary={
-                  <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
-                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                      {comment.userName || 'Anónimo'}
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {comment.userName || 'Anónimo'}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {formatDateMedium(comment.createdAt)}
+                  </Typography>
+                  {comment.updatedAt && (
+                    <Typography variant="caption" color="text.disabled" sx={{ fontStyle: 'italic' }}>
+                      (editado)
                     </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {formatDateMedium(comment.createdAt)}
+                  )}
+                </Box>
+
+                {editingId === comment.id ? (
+                  <Box sx={{ mt: 0.5 }}>
+                    <TextField
+                      fullWidth
+                      size="small"
+                      multiline
+                      maxRows={4}
+                      value={editText}
+                      onChange={(e) => setEditText(e.target.value)}
+                      slotProps={{ htmlInput: { maxLength: 500 } }}
+                      helperText={`${editText.length}/500`}
+                    />
+                    <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5 }}>
+                      <IconButton
+                        size="small"
+                        color="primary"
+                        onClick={handleSaveEdit}
+                        disabled={isSavingEdit || !editText.trim()}
+                        aria-label="Guardar edición"
+                      >
+                        <CheckIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton size="small" onClick={handleCancelEdit} disabled={isSavingEdit} aria-label="Cancelar edición">
+                        <CloseIcon fontSize="small" />
+                      </IconButton>
+                    </Box>
+                  </Box>
+                ) : (
+                  <ListItemText
+                    secondary={comment.text}
+                    slotProps={{ secondary: { component: 'span', display: 'block' } }}
+                    sx={{ m: 0 }}
+                  />
+                )}
+
+                {/* Like button + count (not for own comments, not in edit mode) */}
+                {editingId !== comment.id && user && comment.userId !== user.uid && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', mt: 0.5 }}>
+                    <IconButton
+                      size="small"
+                      onClick={() => handleToggleLike(comment.id)}
+                      sx={{ color: isLiked(comment.id) ? '#e91e63' : 'text.secondary', p: 0.5 }}
+                      aria-label={isLiked(comment.id) ? 'Quitar like' : 'Dar like'}
+                    >
+                      {isLiked(comment.id) ? <FavoriteIcon sx={{ fontSize: 16 }} /> : <FavoriteBorderIcon sx={{ fontSize: 16 }} />}
+                    </IconButton>
+                    {getLikeCount(comment) > 0 && (
+                      <Typography variant="caption" color="text.secondary" sx={{ ml: 0.25 }}>
+                        {getLikeCount(comment)}
+                      </Typography>
+                    )}
+                  </Box>
+                )}
+                {/* Show like count for own comments (read-only) */}
+                {editingId !== comment.id && user && comment.userId === user.uid && getLikeCount(comment) > 0 && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', mt: 0.5 }}>
+                    <FavoriteIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
+                    <Typography variant="caption" color="text.disabled" sx={{ ml: 0.25 }}>
+                      {getLikeCount(comment)}
                     </Typography>
                   </Box>
-                }
-                secondary={comment.text}
-              />
-              {user && comment.userId === user.uid && (
-                <IconButton
-                  size="small"
-                  onClick={() => setConfirmDeleteId(comment.id)}
-                  sx={{ color: '#5f6368', mt: 0.5 }}
-                >
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
+                )}
+              </Box>
+
+              {/* Edit + Delete buttons for own comments */}
+              {user && comment.userId === user.uid && editingId !== comment.id && (
+                <Box sx={{ display: 'flex', flexDirection: 'column', ml: 0.5 }}>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleStartEdit(comment)}
+                    sx={{ color: '#5f6368' }}
+                    aria-label="Editar comentario"
+                  >
+                    <EditOutlinedIcon sx={{ fontSize: 18 }} />
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleDelete(comment)}
+                    sx={{ color: '#5f6368' }}
+                    aria-label="Eliminar comentario"
+                  >
+                    <DeleteOutlineIcon sx={{ fontSize: 18 }} />
+                  </IconButton>
+                </Box>
               )}
             </ListItem>
-            {index < comments.length - 1 && <Divider />}
+            {index < sortedComments.length - 1 && <Divider />}
           </Box>
         ))}
         {!isLoading && comments.length === 0 && (
@@ -154,18 +367,15 @@ export default memo(function BusinessComments({ businessId, comments, isLoading,
         )}
       </List>
 
-      <Dialog open={Boolean(confirmDeleteId)} onClose={() => setConfirmDeleteId(null)}>
-        <DialogTitle>Eliminar comentario</DialogTitle>
-        <DialogContent>
-          <Typography>¿Eliminar este comentario?</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmDeleteId(null)}>Cancelar</Button>
-          <Button onClick={handleDeleteComment} color="error" variant="contained">
-            Eliminar
+      <Snackbar
+        open={pendingDelete !== null}
+        message="Comentario eliminado"
+        action={
+          <Button color="primary" size="small" onClick={handleUndoDelete}>
+            Deshacer
           </Button>
-        </DialogActions>
-      </Dialog>
+        }
+      />
     </Box>
   );
 });

--- a/src/components/business/BusinessHeader.tsx
+++ b/src/components/business/BusinessHeader.tsx
@@ -9,9 +9,10 @@ import DirectionsButton from './DirectionsButton';
 interface Props {
   business: Business;
   favoriteButton: ReactNode;
+  shareButton?: ReactNode;
 }
 
-export default function BusinessHeader({ business, favoriteButton }: Props) {
+export default function BusinessHeader({ business, favoriteButton, shareButton }: Props) {
   return (
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
@@ -25,7 +26,10 @@ export default function BusinessHeader({ business, favoriteButton }: Props) {
             sx={{ mt: 0.5, fontSize: '0.75rem', height: 24 }}
           />
         </Box>
-        {favoriteButton}
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          {shareButton}
+          {favoriteButton}
+        </Box>
       </Box>
 
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1, color: 'text.secondary' }}>

--- a/src/components/business/BusinessSheet.tsx
+++ b/src/components/business/BusinessSheet.tsx
@@ -6,6 +6,7 @@ import BusinessRating from './BusinessRating';
 import BusinessTags from './BusinessTags';
 import BusinessComments from './BusinessComments';
 import FavoriteButton from './FavoriteButton';
+import ShareButton from './ShareButton';
 
 export default function BusinessSheet() {
   const { selectedBusiness, setSelectedBusiness } = useMapContext();
@@ -59,6 +60,7 @@ export default function BusinessSheet() {
                   onToggle={() => data.refetch('favorites')}
                 />
               }
+              shareButton={<ShareButton business={selectedBusiness} />}
             />
             <Divider sx={{ my: 1.5 }} />
             <BusinessRating
@@ -80,6 +82,7 @@ export default function BusinessSheet() {
             <BusinessComments
               businessId={selectedBusiness.id}
               comments={data.comments}
+              userCommentLikes={data.userCommentLikes}
               isLoading={data.isLoading}
               onCommentsChange={() => data.refetch('comments')}
             />

--- a/src/components/business/ShareButton.tsx
+++ b/src/components/business/ShareButton.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { IconButton, Snackbar } from '@mui/material';
+import ShareIcon from '@mui/icons-material/Share';
+import type { Business } from '../../types';
+
+interface Props {
+  business: Business;
+}
+
+export default function ShareButton({ business }: Props) {
+  const [snackOpen, setSnackOpen] = useState(false);
+
+  const handleShare = async () => {
+    const url = `${window.location.origin}/?business=${business.id}`;
+    const text = `Mirá ${business.name} en Modo Mapa — ${business.address}`;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: business.name, text, url });
+      } catch {
+        // User cancelled share — ignore
+      }
+    } else {
+      await navigator.clipboard.writeText(url);
+      setSnackOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <IconButton onClick={handleShare} aria-label="Compartir comercio" sx={{ color: '#5f6368' }}>
+        <ShareIcon />
+      </IconButton>
+      <Snackbar
+        open={snackOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackOpen(false)}
+        message="Link copiado"
+      />
+    </>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Box } from '@mui/material';
 import MapView from '../map/MapView';
 import LocationFAB from '../map/LocationFAB';
@@ -8,9 +9,27 @@ import BusinessSheet from '../business/BusinessSheet';
 import NameDialog from '../auth/NameDialog';
 import SideMenu from './SideMenu';
 import { OfflineIndicator } from '../ui/OfflineIndicator';
+import { useMapContext } from '../../context/MapContext';
+import { allBusinesses } from '../../hooks/useBusinesses';
 
 export default function AppShell() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { setSelectedBusiness } = useMapContext();
+
+  // Deep link: ?business=biz_001 opens the business sheet
+  useEffect(() => {
+    const bizId = searchParams.get('business');
+    if (bizId) {
+      const biz = allBusinesses.find((b) => b.id === bizId);
+      if (biz) {
+        setSelectedBusiness(biz);
+      }
+      searchParams.delete('business');
+      setSearchParams(searchParams, { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run only on mount
+  }, []);
 
   return (
     <Box

--- a/src/components/menu/CommentsList.tsx
+++ b/src/components/menu/CommentsList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useRef } from 'react';
 import {
   Box,
   List,
@@ -6,12 +6,9 @@ import {
   ListItemText,
   IconButton,
   Typography,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   Button,
   CircularProgress,
+  Snackbar,
 } from '@mui/material';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
@@ -30,7 +27,10 @@ interface Props {
 export default function CommentsList({ onNavigate }: Props) {
   const { user } = useAuth();
   const { setSelectedBusiness } = useMapContext();
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  // Undo delete
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const collectionRef = useMemo(() => getCommentsCollection(), []);
 
@@ -38,20 +38,36 @@ export default function CommentsList({ onNavigate }: Props) {
     usePaginatedQuery<Comment>(collectionRef, user?.uid, 'createdAt');
 
   const comments = useMemo(() => {
-    return rawItems.map((data) => ({
-      id: data.id,
-      businessId: data.businessId,
-      business: allBusinesses.find((b) => b.id === data.businessId) || null,
-      text: data.text,
-      createdAt: data.createdAt,
-    }));
-  }, [rawItems]);
+    return rawItems
+      .filter((data) => data.id !== pendingDeleteId)
+      .map((data) => ({
+        id: data.id,
+        businessId: data.businessId,
+        business: allBusinesses.find((b) => b.id === data.businessId) || null,
+        text: data.text,
+        createdAt: data.createdAt,
+      }));
+  }, [rawItems, pendingDeleteId]);
 
-  const handleDelete = async () => {
-    if (!confirmDeleteId || !user) return;
-    await deleteComment(confirmDeleteId, user.uid);
-    setConfirmDeleteId(null);
-    reload();
+  const handleDelete = (commentId: string) => {
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+
+    setPendingDeleteId(commentId);
+    deleteTimerRef.current = setTimeout(async () => {
+      if (!user) return;
+      try {
+        await deleteComment(commentId, user.uid);
+        reload();
+      } catch (err) {
+        if (import.meta.env.DEV) console.error('Error deleting comment:', err);
+      }
+      setPendingDeleteId(null);
+    }, 5000);
+  };
+
+  const handleUndoDelete = () => {
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+    setPendingDeleteId(null);
   };
 
   const handleSelectBusiness = (business: Business | null) => {
@@ -85,7 +101,7 @@ export default function CommentsList({ onNavigate }: Props) {
     );
   }
 
-  if (comments.length === 0) {
+  if (comments.length === 0 && !pendingDeleteId) {
     return (
       <Box sx={{ p: 4, textAlign: 'center' }}>
         <ChatBubbleOutlineIcon sx={{ fontSize: 48, color: '#ccc', mb: 1 }} />
@@ -124,9 +140,10 @@ export default function CommentsList({ onNavigate }: Props) {
               edge="end"
               onClick={(e) => {
                 e.stopPropagation();
-                setConfirmDeleteId(comment.id);
+                handleDelete(comment.id);
               }}
               sx={{ color: '#5f6368' }}
+              aria-label="Eliminar comentario"
             >
               <DeleteOutlineIcon fontSize="small" />
             </IconButton>
@@ -143,18 +160,15 @@ export default function CommentsList({ onNavigate }: Props) {
         </Box>
       )}
 
-      <Dialog open={Boolean(confirmDeleteId)} onClose={() => setConfirmDeleteId(null)}>
-        <DialogTitle>Eliminar comentario</DialogTitle>
-        <DialogContent>
-          <Typography>¿Eliminar este comentario?</Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmDeleteId(null)}>Cancelar</Button>
-          <Button onClick={handleDelete} color="error" variant="contained">
-            Eliminar
+      <Snackbar
+        open={pendingDeleteId !== null}
+        message="Comentario eliminado"
+        action={
+          <Button color="primary" size="small" onClick={handleUndoDelete}>
+            Deshacer
           </Button>
-        </DialogActions>
-      </Dialog>
+        }
+      />
     </>
   );
 }

--- a/src/config/collections.ts
+++ b/src/config/collections.ts
@@ -9,4 +9,5 @@ export const COLLECTIONS = {
   CONFIG: 'config',
   DAILY_METRICS: 'dailyMetrics',
   ABUSE_LOGS: 'abuseLogs',
+  COMMENT_LIKES: 'commentLikes',
 } as const;

--- a/src/config/converters.ts
+++ b/src/config/converters.ts
@@ -3,7 +3,7 @@ import type {
   QueryDocumentSnapshot,
   SnapshotOptions,
 } from 'firebase/firestore';
-import type { UserProfile, Rating, Comment, UserTag, CustomTag, Favorite, Feedback, FeedbackCategory } from '../types';
+import type { UserProfile, Rating, Comment, CommentLike, UserTag, CustomTag, Favorite, Feedback, FeedbackCategory } from '../types';
 import { toDate } from '../utils/formatDate';
 
 export const userProfileConverter: FirestoreDataConverter<UserProfile> = {
@@ -57,8 +57,20 @@ export const commentConverter: FirestoreDataConverter<Comment> = {
       businessId: d.businessId,
       text: d.text,
       createdAt: toDate(d.createdAt),
+      likeCount: (d.likeCount as number) ?? 0,
+      ...(d.updatedAt ? { updatedAt: toDate(d.updatedAt) } : {}),
       ...(d.flagged === true ? { flagged: true } : {}),
     };
+  },
+};
+
+export const commentLikeConverter: FirestoreDataConverter<CommentLike> = {
+  toFirestore(like: CommentLike) {
+    return { userId: like.userId, commentId: like.commentId, createdAt: like.createdAt };
+  },
+  fromFirestore(snapshot: QueryDocumentSnapshot, options?: SnapshotOptions): CommentLike {
+    const d = snapshot.data(options);
+    return { userId: d.userId, commentId: d.commentId, createdAt: toDate(d.createdAt) };
   },
 };
 

--- a/src/hooks/useBusinessData.ts
+++ b/src/hooks/useBusinessData.ts
@@ -13,10 +13,13 @@ interface UseBusinessDataReturn {
   comments: Comment[];
   userTags: UserTag[];
   customTags: CustomTag[];
+  userCommentLikes: Set<string>;
   isLoading: boolean;
   error: boolean;
   refetch: (collectionName?: CollectionName) => void;
 }
+
+const EMPTY_LIKES = new Set<string>();
 
 const EMPTY: UseBusinessDataReturn = {
   isFavorite: false,
@@ -24,12 +27,27 @@ const EMPTY: UseBusinessDataReturn = {
   comments: [],
   userTags: [],
   customTags: [],
+  userCommentLikes: EMPTY_LIKES,
   isLoading: false,
   error: false,
   refetch: () => {},
 };
 
 type CollectionName = 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags';
+
+/** Fetch user's likes for a set of comment IDs using individual getDoc calls. */
+async function fetchUserLikes(uid: string, commentIds: string[]): Promise<Set<string>> {
+  if (commentIds.length === 0) return new Set();
+  const checks = commentIds.map((cId) =>
+    getDoc(doc(db, COLLECTIONS.COMMENT_LIKES, `${uid}__${cId}`)),
+  );
+  const snaps = await Promise.all(checks);
+  const liked = new Set<string>();
+  snaps.forEach((s, i) => {
+    if (s.exists()) liked.add(commentIds[i]);
+  });
+  return liked;
+}
 
 async function fetchSingleCollection(bId: string, uid: string, col: CollectionName) {
   switch (col) {
@@ -51,7 +69,8 @@ async function fetchSingleCollection(bId: string, uid: string, col: CollectionNa
       ));
       const result = snap.docs.map((d) => d.data()).filter((c) => !c.flagged);
       result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-      return { comments: result };
+      const userCommentLikes = await fetchUserLikes(uid, result.map((c) => c.id));
+      return { comments: result, userCommentLikes };
     }
     case 'userTags': {
       const snap = await getDocs(query(
@@ -102,12 +121,16 @@ async function fetchBusinessData(bId: string, uid: string) {
   const customTagsResult = customTagsSnap.docs.map((d) => d.data());
   customTagsResult.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
+  // Fetch user likes for comments (after we know comment IDs)
+  const userCommentLikes = await fetchUserLikes(uid, commentsResult.map((c) => c.id));
+
   return {
     isFavorite: favSnap.exists(),
     ratings: ratingsSnap.docs.map((d) => d.data()),
     comments: commentsResult,
     userTags: userTagsSnap.docs.map((d) => d.data()),
     customTags: customTagsResult,
+    userCommentLikes,
   };
 }
 
@@ -119,7 +142,8 @@ export function useBusinessData(businessId: string | null): UseBusinessDataRetur
     comments: Comment[];
     userTags: UserTag[];
     customTags: CustomTag[];
-  }>({ isFavorite: false, ratings: [], comments: [], userTags: [], customTags: [] });
+    userCommentLikes: Set<string>;
+  }>({ isFavorite: false, ratings: [], comments: [], userTags: [], customTags: [], userCommentLikes: EMPTY_LIKES });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
   const fetchIdRef = useRef(0);

--- a/src/hooks/useBusinessDataCache.ts
+++ b/src/hooks/useBusinessDataCache.ts
@@ -6,6 +6,7 @@ export interface BusinessCacheEntry {
   comments: Comment[];
   userTags: UserTag[];
   customTags: CustomTag[];
+  userCommentLikes: Set<string>;
   timestamp: number;
 }
 

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -1,7 +1,7 @@
 /**
  * Firestore service for the `comments` collection.
  */
-import { collection, addDoc, deleteDoc, doc, serverTimestamp } from 'firebase/firestore';
+import { collection, addDoc, deleteDoc, setDoc, updateDoc, doc, serverTimestamp } from 'firebase/firestore';
 import type { CollectionReference } from 'firebase/firestore';
 import { db } from '../config/firebase';
 import { COLLECTIONS } from '../config/collections';
@@ -38,7 +38,33 @@ export async function addComment(
   invalidateQueryCache(COLLECTIONS.COMMENTS, userId);
 }
 
+export async function editComment(commentId: string, userId: string, newText: string): Promise<void> {
+  const trimmed = newText.trim();
+  if (!trimmed || trimmed.length > 500) {
+    throw new Error('Comment text must be 1-500 characters');
+  }
+  await updateDoc(doc(db, COLLECTIONS.COMMENTS, commentId), {
+    text: trimmed,
+    updatedAt: serverTimestamp(),
+  });
+  invalidateQueryCache(COLLECTIONS.COMMENTS, userId);
+}
+
 export async function deleteComment(commentId: string, userId: string): Promise<void> {
   await deleteDoc(doc(db, COLLECTIONS.COMMENTS, commentId));
   invalidateQueryCache(COLLECTIONS.COMMENTS, userId);
+}
+
+export async function likeComment(userId: string, commentId: string): Promise<void> {
+  const docId = `${userId}__${commentId}`;
+  await setDoc(doc(db, COLLECTIONS.COMMENT_LIKES, docId), {
+    userId,
+    commentId,
+    createdAt: serverTimestamp(),
+  });
+}
+
+export async function unlikeComment(userId: string, commentId: string): Promise<void> {
+  const docId = `${userId}__${commentId}`;
+  await deleteDoc(doc(db, COLLECTIONS.COMMENT_LIKES, docId));
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,5 @@
 export { addFavorite, removeFavorite, getFavoritesCollection } from './favorites';
 export { upsertRating, getRatingsCollection } from './ratings';
-export { addComment, deleteComment, getCommentsCollection } from './comments';
+export { addComment, editComment, deleteComment, likeComment, unlikeComment, getCommentsCollection } from './comments';
 export { addUserTag, removeUserTag, createCustomTag, updateCustomTag, deleteCustomTag } from './tags';
 export { sendFeedback } from './feedback';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,7 +38,15 @@ export interface Comment {
   businessId: string;
   text: string;
   createdAt: Date;
+  updatedAt?: Date;
+  likeCount: number;
   flagged?: boolean;
+}
+
+export interface CommentLike {
+  userId: string;
+  commentId: string;
+  createdAt: Date;
 }
 
 export interface UserTag {


### PR DESCRIPTION
## Summary
- **Comment editing**: inline TextField with server-side re-moderation via onUpdate trigger
- **Undo delete**: 5s Snackbar replaces confirmation dialog (BusinessComments + CommentsList)
- **Comment likes**: optimistic UI with Maps, Cloud Function triggers for atomic likeCount, rate limit 50/day
- **Comment sorting**: Recientes/Antiguos/Útiles chips (client-side)
- **Share button**: Web Share API with clipboard fallback, deep link via `?business={id}`
- New `commentLikes` Firestore collection with security rules
- Updated seed script (migrated to firebase-admin SDK)
- Version bump to 2.0.0

Closes #45, closes #46, closes #17

## Test plan
- [x] Edit own comment inline, verify "(editado)" indicator appears
- [x] Delete comment, verify Snackbar with "Deshacer" appears, undo works
- [x] Like another user's comment, verify heart toggles and count updates
- [x] Sort comments by Recientes/Antiguos/Útiles
- [x] Share button opens native share or copies link to clipboard
- [x] Deep link `?business=biz_001` opens correct business sheet
- [x] Cannot like own comments (heart not shown)
- [x] Undo delete in menu CommentsList works correctly
- [x] Seed script runs successfully with new data structures

🤖 Generated with [Claude Code](https://claude.com/claude-code)