### PR TITLE
feat: menu photos, visit history, price levels (#48, #49, #50)

### DIFF
--- a/docs/PROJECT_REFERENCE.md
+++ b/docs/PROJECT_REFERENCE.md
@@ -1,6 +1,6 @@
 # Modo Mapa — Referencia completa del proyecto
 
-**Version:** 2.0.0
+**Version:** 2.1.0
 **Repo:** <https://github.com/benoffi7/modo-mapa>
 **Produccion:** <https://modo-mapa-app.web.app>
 **Ultima actualizacion:** 2026-03-12
@@ -46,7 +46,7 @@ main.tsx
             ├─ [/dev/theme] ThemePlayground (lazy, DEV only)
             ├─ [/admin/*] AdminDashboard (lazy loaded)
        │    ├─ AdminGuard (Google Sign-In + email verification)
-       │    └─ AdminLayout (tabs: Overview, Actividad, Feedback, Tendencias, Usuarios, Firebase Usage, Alertas, Backups)
+       │    └─ AdminLayout (tabs: Overview, Actividad, Feedback, Tendencias, Usuarios, Firebase Usage, Alertas, Backups, Fotos)
        │         ├─ DashboardOverview (StatCards + PieCharts + TopLists + Custom Tags ranking)
        │         ├─ ActivityFeed (tabs: comentarios, ratings, favoritos, tags)
        │         ├─ FeedbackList (tabla de feedback con categoria y estado)
@@ -54,25 +54,29 @@ main.tsx
        │         ├─ UsersPanel (rankings por usuario + stats)
        │         ├─ FirebaseUsage (LineCharts + PieCharts + barras cuota)
        │         ├─ AbuseAlerts (tabla de logs de abuso)
-       │         └─ BackupsPanel (crear, listar, restaurar, eliminar backups Firestore)
+       │         ├─ BackupsPanel (crear, listar, restaurar, eliminar backups Firestore)
+       │         └─ PhotoReviewPanel (revisar, aprobar, rechazar fotos de menu)
        └─ [/*] MapProvider + APIProvider
             └─ AppShell.tsx
                  ├─ OfflineIndicator (chip offline, PWA)
                  ├─ SearchBar (busqueda + menu hamburguesa)
-                 ├─ FilterChips (tags predefinidos)
+                 ├─ FilterChips (tags predefinidos + nivel de gasto $/$$/$$)
                  ├─ MapView (Google Maps + markers)
                  ├─ LocationFAB (geolocalizacion)
                  ├─ BusinessSheet (bottom sheet con detalle)
                  │    ├─ BusinessHeader (nombre, direccion, favorito, share, direcciones)
                  │    ├─ BusinessRating (estrellas promedio + calificar)
+                 │    ├─ BusinessPriceLevel (nivel de gasto $/$$/$$$ + votar)
                  │    ├─ BusinessTags (tags predefinidos + custom)
+                 │    ├─ MenuPhotoSection (foto de menu + upload + viewer)
                  │    ├─ BusinessComments (lista + formulario + editar + undo delete + likes + sorting)
                  │    └─ ShareButton (Web Share API + clipboard fallback)
                  ├─ NameDialog (nombre de usuario, primera visita)
                  └─ SideMenu (drawer lateral)
                       ├─ Header (avatar + nombre + editar)
-                      ├─ Nav (Favoritos, Comentarios, Calificaciones, Feedback, Agregar comercio)
+                      ├─ Nav (Favoritos, Recientes, Comentarios, Calificaciones, Feedback, Agregar comercio)
                       ├─ FavoritesList + ListFilters
+                      ├─ RecentVisits (historial localStorage)
                       ├─ CommentsList
                       ├─ RatingsList + ListFilters
                       ├─ FeedbackForm
@@ -101,7 +105,8 @@ functions/
 ├── src/
 │   ├── index.ts              → exports de todas las functions
 │   ├── admin/
-│   │   └── backups.ts        → createBackup, listBackups, restoreBackup, deleteBackup (callable)
+│   │   ├── backups.ts        → createBackup, listBackups, restoreBackup, deleteBackup (callable)
+│   │   └── menuPhotos.ts     → approveMenuPhoto, rejectMenuPhoto (callable, admin only)
 │   ├── triggers/
 │   │   ├── comments.ts       → rate limit + moderacion + counters + onUpdate re-moderation
 │   │   ├── commentLikes.ts   → likeCount increment/decrement + rate limit + counters
@@ -109,9 +114,12 @@ functions/
 │   │   ├── feedback.ts       → rate limit + moderacion + counters
 │   │   ├── ratings.ts        → counters (create/update/delete)
 │   │   ├── favorites.ts      → counters (create/delete)
-│   │   └── users.ts          → counters (create)
+│   │   ├── users.ts          → counters (create)
+│   │   ├── menuPhotos.ts     → thumbnail generation con sharp + counters
+│   │   └── priceLevels.ts    → counters (create/update)
 │   ├── scheduled/
-│   │   └── dailyMetrics.ts   → cron diario: distribucion, tops, active users
+│   │   ├── dailyMetrics.ts   → cron diario: distribucion, tops, active users
+│   │   └── cleanupPhotos.ts  → cron diario: elimina fotos rechazadas > 7 dias
 │   └── utils/
 │       ├── rateLimiter.ts    → rate limiting (daily/per-entity)
 │       ├── moderator.ts      → filtro de palabras prohibidas (cache 5 min)
@@ -126,9 +134,9 @@ functions/
 ### Flujo de datos
 
 1. **Datos estaticos**: `businesses.json` (40 comercios) se carga como import estatico. No hay fetch.
-2. **Datos dinamicos**: Firestore (favoritos, ratings, comentarios, tags, feedback). El hook `useBusinessData` orquesta las 5 queries en paralelo con `Promise.all` y cache client-side. `refetch(collectionName)` recarga selectivamente una sola coleccion.
+2. **Datos dinamicos**: Firestore (favoritos, ratings, comentarios, tags, feedback, priceLevels, menuPhotos). El hook `useBusinessData` orquesta las 7 queries en paralelo con `Promise.all` y cache client-side. `refetch(collectionName)` recarga selectivamente una sola coleccion.
 3. **Service layer**: Componentes llaman funciones de `src/services/` para operaciones CRUD. Los servicios encapsulan Firestore SDK e invalidan caches internamente.
-4. **Estado global**: `AuthContext` (user, displayName, signInWithGoogle, signOut) + `MapContext` (selectedBusiness, searchQuery, filters, userLocation).
+4. **Estado global**: `AuthContext` (user, displayName, signInWithGoogle, signOut) + `MapContext` (selectedBusiness, searchQuery, filters, activePriceFilter, userLocation).
 5. **Estado local**: Cada seccion del menu carga sus datos al montarse y los filtra client-side con `useListFilters`.
 6. **Cache de datos**: Dos capas de cache client-side reducen lecturas Firestore:
    - `useBusinessDataCache`: cache de vista de negocio (5 min TTL) para las 5 queries del bottom sheet.
@@ -373,6 +381,8 @@ return (
 | `config` | `counters`, `moderation` | counters: totales + daily reads/writes/deletes; moderation: bannedWords | Admin read; Functions write |
 | `dailyMetrics` | `YYYY-MM-DD` | ratingDistribution, tops, activeUsers, daily ops, byCollection | Auth read; Functions write |
 | `abuseLogs` | auto-generated | userId, type, collection, detail, timestamp | Admin read; Functions write |
+| `menuPhotos` | auto-generated | userId, businessId, storagePath, thumbnailPath, status (pending/approved/rejected), rejectionReason?, reviewedBy?, reviewedAt?, createdAt, reportCount | Read auth; create owner (pending only); update/delete: Functions only |
+| `priceLevels` | `{userId}__{businessId}` | userId, businessId, level (1-3), createdAt, updatedAt | Read auth; create/update owner, level 1-3 |
 | `_rateLimits` | `backup_{userId}` | count, resetAt | No client access; Functions write (admin SDK) |
 
 ---
@@ -401,8 +411,14 @@ PREDEFINED_TAGS: barato, apto_celiacos, apto_veganos, rapido, delivery, buena_at
 CATEGORY_LABELS: restaurant→Restaurante, cafe→Cafe, bakery→Panaderia, bar→Bar,
                  fastfood→Comida rapida, icecream→Heladeria, pizza→Pizzeria
 
+// Menu Photos & Price Levels
+type MenuPhotoStatus = 'pending' | 'approved' | 'rejected';
+interface MenuPhoto { id, userId, businessId, storagePath, thumbnailPath, status, rejectionReason?, reviewedBy?, reviewedAt?, createdAt, reportCount }
+interface PriceLevel { userId, businessId, level (1-3), createdAt, updatedAt }
+PRICE_LEVEL_LABELS: 1→Economico, 2→Moderado, 3→Caro
+
 // Admin types
-interface AdminCounters { comments, ratings, favorites, feedback, users, customTags, userTags, commentLikes, dailyReads, dailyWrites, dailyDeletes }
+interface AdminCounters { comments, ratings, favorites, feedback, users, customTags, userTags, commentLikes, priceLevels, menuPhotos, dailyReads, dailyWrites, dailyDeletes }
 interface DailyMetrics { date, ratingDistribution, topFavorited, topCommented, topRated, topTags, dailyReads/Writes/Deletes, byCollection, activeUsers }
 interface AbuseLog { id, userId, type, collection, detail, timestamp }
 ```

--- a/docs/feat-menu-photos-history/changelog.md
+++ b/docs/feat-menu-photos-history/changelog.md
@@ -1,0 +1,44 @@
+# Changelog — Fase 2: Fotos de menú + Historial de visitas + Nivel de gasto
+
+## Archivos creados
+
+- `storage.rules` — reglas de Firebase Storage para fotos de menú
+- `src/services/menuPhotos.ts` — servicio upload/query de fotos
+- `src/services/priceLevels.ts` — servicio upsert de nivel de gasto
+- `src/hooks/useVisitHistory.ts` — hook localStorage para historial de visitas
+- `src/hooks/usePriceLevelFilter.ts` — cache global de promedios de precio para filtro
+- `src/components/business/BusinessPriceLevel.tsx` — sección nivel de gasto en BusinessSheet
+- `src/components/business/MenuPhotoSection.tsx` — sección foto de menú en BusinessSheet
+- `src/components/business/MenuPhotoUpload.tsx` — dialog de upload con preview y progress
+- `src/components/business/MenuPhotoViewer.tsx` — dialog fullscreen para ver foto
+- `src/components/menu/RecentVisits.tsx` — lista de comercios visitados recientemente
+- `src/components/admin/PhotoReviewPanel.tsx` — panel admin para revisar fotos pendientes
+- `src/components/admin/PhotoReviewCard.tsx` — card individual de revisión
+- `functions/src/triggers/menuPhotos.ts` — trigger thumbnail generation
+- `functions/src/triggers/priceLevels.ts` — triggers counters
+- `functions/src/admin/menuPhotos.ts` — callables approve/reject
+- `functions/src/scheduled/cleanupPhotos.ts` — cron cleanup rejected photos
+
+## Archivos modificados
+
+- `package.json` — version bump a 2.1.0, dep: browser-image-compression
+- `firebase.json` — storage config + emulator port 9199
+- `firestore.rules` — reglas menuPhotos + priceLevels
+- `firestore.indexes.json` — índices menuPhotos + priceLevels
+- `src/config/firebase.ts` — getStorage + connectStorageEmulator
+- `src/config/collections.ts` — MENU_PHOTOS, PRICE_LEVELS
+- `src/config/converters.ts` — menuPhotoConverter, priceLevelConverter
+- `src/types/index.ts` — MenuPhoto, MenuPhotoStatus, PriceLevel, PRICE_LEVEL_LABELS
+- `src/services/index.ts` — nuevos exports
+- `src/services/admin.ts` — fetchPendingPhotos
+- `src/hooks/useBusinessData.ts` — priceLevels + menuPhoto en data flow
+- `src/hooks/useBusinessDataCache.ts` — nuevos campos cache
+- `src/hooks/useBusinesses.ts` — filtro por precio
+- `src/context/MapContext.tsx` — activePriceFilter state
+- `src/components/business/BusinessSheet.tsx` — nuevas secciones + visit tracking
+- `src/components/layout/SideMenu.tsx` — sección "Recientes"
+- `src/components/search/FilterChips.tsx` — chips de precio $/$$/$$
+- `src/components/admin/AdminLayout.tsx` — tab "Fotos"
+- `functions/src/index.ts` — nuevos exports
+- `functions/package.json` — dep: sharp
+- `scripts/seed-admin-data.mjs` — seed priceLevels + menuPhotos

--- a/docs/feat-menu-photos-history/plan.md
+++ b/docs/feat-menu-photos-history/plan.md
@@ -1,0 +1,207 @@
+# Plan de implementación — Fase 2
+
+---
+
+## Paso 1 — Tipos, colecciones y converters
+
+**Archivos:**
+
+- `src/types/index.ts` — agregar `MenuPhoto`, `MenuPhotoStatus`, `PriceLevel`, `PRICE_LEVEL_LABELS`
+- `src/config/collections.ts` — agregar `MENU_PHOTOS`, `PRICE_LEVELS`
+- `src/config/converters.ts` — agregar `menuPhotoConverter`, `priceLevelConverter`
+
+**Verificación:** `npx tsc --noEmit`
+
+---
+
+## Paso 2 — Firebase Storage setup
+
+**Archivos:**
+
+- `src/config/firebase.ts` — agregar `getStorage`, `connectStorageEmulator`, exportar `storage`
+- `firebase.json` — agregar `storage` emulator (port 9199)
+- `storage.rules` (nuevo) — reglas de acceso para `/menus/{businessId}/{fileName}`
+
+**Verificación:** `npx tsc --noEmit`, emuladores arrancan con storage
+
+---
+
+## Paso 3 — Firestore rules + indexes
+
+**Archivos:**
+
+- `firestore.rules` — agregar rules para `menuPhotos` y `priceLevels`
+- `firestore.indexes.json` — agregar índices compuestos para menuPhotos y priceLevels
+
+**Verificación:** emuladores arrancan sin errores de rules
+
+---
+
+## Paso 4 — Service layer: priceLevels
+
+**Archivos:**
+
+- `src/services/priceLevels.ts` (nuevo) — `upsertPriceLevel`, `getPriceLevelsCollection`
+- `src/services/index.ts` — agregar exports
+
+**Verificación:** `npx tsc --noEmit`
+
+---
+
+## Paso 5 — Service layer: menuPhotos
+
+**Archivos:**
+
+- `src/services/menuPhotos.ts` (nuevo) — `uploadMenuPhoto`, `getApprovedMenuPhoto`, `getUserPendingPhotos`
+- `src/services/index.ts` — agregar exports
+
+**Dependencia:** Instalar `browser-image-compression` en root
+
+**Verificación:** `npx tsc --noEmit`
+
+---
+
+## Paso 6 — Hook: useBusinessData + cache (priceLevels + menuPhoto)
+
+**Archivos:**
+
+- `src/hooks/useBusinessData.ts` — agregar `priceLevels` y `menuPhoto` al data flow (Promise.all + fetchSingleCollection)
+- `src/hooks/useBusinessDataCache.ts` — agregar campos al tipo cache
+
+**Verificación:** `npx tsc --noEmit`
+
+---
+
+## Paso 7 — Componente: BusinessPriceLevel
+
+**Archivos:**
+
+- `src/components/business/BusinessPriceLevel.tsx` (nuevo) — UI de nivel de gasto con $ / $$ / $$$
+- `src/components/business/BusinessSheet.tsx` — renderizar BusinessPriceLevel entre Rating y Tags
+
+**Verificación:** `npm run dev:full`, abrir comercio, ver sección de precio
+
+---
+
+## Paso 8 — Componentes: MenuPhoto (Section + Upload + Viewer)
+
+**Archivos:**
+
+- `src/components/business/MenuPhotoSection.tsx` (nuevo) — sección en BusinessSheet
+- `src/components/business/MenuPhotoUpload.tsx` (nuevo) — dialog upload con preview + progress
+- `src/components/business/MenuPhotoViewer.tsx` (nuevo) — dialog fullscreen
+- `src/components/business/BusinessSheet.tsx` — renderizar MenuPhotoSection entre Tags y Comments
+
+**Verificación:** `npm run dev:full`, subir foto, ver preview, ver estado pendiente
+
+---
+
+## Paso 9 — Hook: useVisitHistory + componente RecentVisits
+
+**Archivos:**
+
+- `src/hooks/useVisitHistory.ts` (nuevo) — localStorage visit tracking
+- `src/components/menu/RecentVisits.tsx` (nuevo) — lista de recientes
+- `src/components/layout/SideMenu.tsx` — agregar sección "Recientes"
+- `src/components/business/BusinessSheet.tsx` — llamar `recordVisit` al abrir comercio
+
+**Verificación:** abrir comercios, verificar que aparecen en "Recientes"
+
+---
+
+## Paso 10 — Filtros: nivel de gasto en mapa
+
+**Archivos:**
+
+- `src/context/MapContext.tsx` — agregar `activePriceFilter` state
+- `src/hooks/usePriceLevelFilter.ts` (nuevo) — cache global de promedios de precio
+- `src/hooks/useBusinesses.ts` — filtrar por precio usando cache
+- `src/components/search/FilterChips.tsx` — agregar chips $ / $$ / $$$
+
+**Verificación:** activar filtro de precio, verificar que filtra comercios en mapa
+
+---
+
+## Paso 11 — Cloud Functions: priceLevels triggers
+
+**Archivos:**
+
+- `functions/src/triggers/priceLevels.ts` (nuevo) — onCreate/onUpdate counters
+- `functions/src/index.ts` — agregar exports
+
+**Verificación:** `cd functions && npx tsc --noEmit`
+
+---
+
+## Paso 12 — Cloud Functions: menuPhotos trigger + callables + cleanup
+
+**Archivos:**
+
+- `functions/src/triggers/menuPhotos.ts` (nuevo) — thumbnail generation con sharp
+- `functions/src/admin/menuPhotos.ts` (nuevo) — approveMenuPhoto, rejectMenuPhoto callables
+- `functions/src/scheduled/cleanupPhotos.ts` (nuevo) — cron cleanup
+- `functions/src/index.ts` — agregar exports
+
+**Dependencia:** Instalar `sharp` en functions/
+
+**Verificación:** `cd functions && npx tsc --noEmit`
+
+---
+
+## Paso 13 — Admin: PhotoReviewPanel
+
+**Archivos:**
+
+- `src/services/admin.ts` — agregar `fetchPendingPhotos`
+- `src/components/admin/PhotoReviewPanel.tsx` (nuevo) — tab de review
+- `src/components/admin/PhotoReviewCard.tsx` (nuevo) — card individual
+- `src/components/admin/AdminLayout.tsx` — agregar tab "Fotos"
+
+**Verificación:** `npm run dev:full`, ir a /admin, ver tab Fotos
+
+---
+
+## Paso 14 — Seed script + test local
+
+**Archivos:**
+
+- `scripts/seed-admin-data.mjs` — agregar menuPhotos, priceLevels, actualizar counters
+
+**Verificación:** correr seed, verificar datos en emulator UI, probar todos los flujos
+
+---
+
+## Paso 15 — Lint, type-check, documentación
+
+**Acciones:**
+
+- `npm run lint`
+- `npx tsc --noEmit`
+- `cd functions && npx tsc --noEmit`
+- Actualizar `docs/PROJECT_REFERENCE.md`
+- Crear `docs/feat-menu-photos-history/changelog.md`
+- Bump version a 2.1.0
+
+---
+
+## Orden de dependencias
+
+```text
+1 (tipos) → 2 (storage) → 3 (rules) → 4 (service PL) → 5 (service photos)
+                                          ↓                    ↓
+                                     6 (hook data) ←──────────┘
+                                          ↓
+                              7 (PriceLevel UI) → 8 (MenuPhoto UI)
+                                                        ↓
+                                                   9 (Recientes)
+                                                        ↓
+                                                  10 (Filtros mapa)
+                                                        ↓
+                                            11 (CF priceLevels) → 12 (CF photos)
+                                                                       ↓
+                                                                  13 (Admin)
+                                                                       ↓
+                                                                  14 (Seed)
+                                                                       ↓
+                                                                  15 (Docs)
+```

--- a/docs/feat-menu-photos-history/prd.md
+++ b/docs/feat-menu-photos-history/prd.md
@@ -1,0 +1,290 @@
+# PRD — Fase 2: Fotos de menú + Historial de visitas + Nivel de gasto
+
+**Issues:** [#48](https://github.com/benoffi7/modo-mapa/issues/48), [#49](https://github.com/benoffi7/modo-mapa/issues/49), [#50](https://github.com/benoffi7/modo-mapa/issues/50)
+**Version objetivo:** 2.1.0
+**Fecha:** 2026-03-12
+
+---
+
+## Objetivo
+
+Agregar contenido visual a los comercios (fotos de menú con validación admin), un historial de visitas client-side, y un sistema de calificación de nivel de gasto para mejorar la utilidad, la información disponible y el engagement.
+
+---
+
+## F2 — Fotos de menú
+
+### Problema
+
+Los usuarios no tienen forma de ver el menú de un comercio antes de ir. La única información disponible es nombre, dirección, categoría y comentarios.
+
+### Solución
+
+Permitir a cualquier usuario subir una foto del menú. El admin la revisa desde el dashboard. Si se aprueba, todos los usuarios ven un botón "Ver menú" en el comercio con la fecha de aprobación visible.
+
+### Flujo de usuario
+
+```text
+1. Usuario abre comercio → ve botón "Subir foto del menú" (ícono cámara)
+2. Selecciona imagen (máx 5 MB, JPG/PNG/WebP)
+3. Preview de la imagen antes de enviar
+4. Compresión client-side (max 2 MB con browser-image-compression)
+5. Envía → se sube a Cloud Storage → doc en Firestore con status 'pending'
+6. Usuario ve estado "Pendiente de revisión" en el comercio
+7. Admin ve en dashboard → tab "Fotos" → lista de fotos pendientes con preview
+8. Admin aprueba o rechaza (con motivo opcional)
+9. Si aprueba → botón "Ver menú" aparece para todos con fecha de aprobación
+10. Si rechaza → el usuario que subió ve estado "Rechazada" (con motivo)
+```
+
+### Reglas de negocio
+
+- Máximo 1 foto aprobada por comercio (la más reciente aprobada reemplaza la anterior)
+- Máximo 3 fotos pendientes por usuario (rate limit para evitar spam)
+- Formatos aceptados: JPG, PNG, WebP
+- Tamaño máximo: 5 MB (antes de compresión client-side)
+- Tamaño post-compresión: max 2 MB
+- Thumbnail generado server-side: 400px de ancho
+- Fotos rechazadas se eliminan automáticamente después de 7 días
+- Cualquier usuario autenticado puede subir
+- Solo el admin puede aprobar/rechazar
+- El usuario puede ver el estado de sus fotos subidas
+- **Fecha de aprobación visible**: tanto en la app pública como en el admin, porque los menús cambian con el tiempo. Permite al usuario evaluar qué tan actualizada está la foto
+
+### Modelo de datos — Firestore
+
+```text
+menuPhotos/{autoId}
+  ├── userId: string
+  ├── businessId: string
+  ├── storagePath: string          # ruta en Cloud Storage (original)
+  ├── thumbnailPath: string        # thumbnail generado por Cloud Function
+  ├── status: 'pending' | 'approved' | 'rejected'
+  ├── rejectionReason?: string
+  ├── reviewedBy?: string          # admin userId
+  ├── reviewedAt?: Timestamp       # fecha de aprobación/rechazo (visible en UI)
+  ├── createdAt: Timestamp
+  └── reportCount: number          # para reportes futuros
+```
+
+### UI — Fecha de aprobación
+
+- **En el comercio (app pública)**: debajo del botón "Ver menú" se muestra "Menú actualizado: 12 mar 2026" usando `reviewedAt`
+- **En el admin**: la tabla de fotos muestra `createdAt` (cuándo se subió) y `reviewedAt` (cuándo se revisó)
+- Si la foto tiene más de 6 meses se muestra un indicador sutil "Menú posiblemente desactualizado"
+
+### Cloud Storage
+
+```text
+gs://modo-mapa-app.appspot.com/menus/
+  ├── {businessId}/
+  │   ├── {photoId}_original.jpg
+  │   └── {photoId}_thumb.jpg     # 400px, generado server-side
+```
+
+### Componentes UI
+
+| Componente | Ubicación | Descripción |
+|-----------|-----------|-------------|
+| `MenuPhotoSection` | `business/` | Sección en BusinessSheet: "Ver menú" (con fecha) si hay foto aprobada, "Subir foto" si no |
+| `MenuPhotoUpload` | `business/` | Dialog de upload con preview + barra de progreso |
+| `MenuPhotoViewer` | `business/` | Dialog fullscreen/lightbox para ver la foto aprobada |
+| `PhotoReviewPanel` | `admin/` | Tab nueva en AdminLayout: lista de fotos pendientes |
+| `PhotoReviewCard` | `admin/` | Card individual con preview, info del usuario, fechas, botones aprobar/rechazar |
+
+### Cloud Functions
+
+| Función | Tipo | Descripción |
+|---------|------|-------------|
+| `onMenuPhotoCreated` | trigger (onCreate) | Genera thumbnail con sharp, actualiza contador |
+| `approveMenuPhoto` | callable | Cambia status a 'approved', marca anteriores como reemplazadas |
+| `rejectMenuPhoto` | callable | Cambia status a 'rejected' con motivo, programa cleanup |
+| `cleanupRejectedPhotos` | scheduled (diario) | Elimina fotos rechazadas con más de 7 días |
+
+### Firestore Rules
+
+- `menuPhotos`: read auth, create owner (max 3 pending), admin update (status changes)
+- Storage rules: upload solo auth + carpeta correcta, read público para aprobadas
+
+### Dependencias nuevas
+
+- `browser-image-compression` — compresión client-side antes de upload
+- `sharp` — generación de thumbnails en Cloud Functions (ya disponible en Node runtime)
+
+---
+
+## F9 — Historial de visitas
+
+### Problema
+
+Los usuarios no tienen forma de recordar qué comercios visitaron recientemente en la app.
+
+### Solución
+
+Registro automático en localStorage cada vez que un usuario abre un comercio (bottom sheet). Sección "Recientes" en el menú lateral.
+
+### Reglas de negocio
+
+- Se guarda automáticamente al abrir un comercio (setSelectedBusiness)
+- Máximo 50 entradas (las más antiguas se descartan)
+- Se actualiza la fecha si el comercio ya estaba en la lista
+- Datos en localStorage, NO en Firestore (zero cost)
+- Sección nueva "Recientes" en el menú lateral (entre Favoritos y Comentarios)
+- Click en un item navega al comercio en el mapa
+
+### Modelo de datos — localStorage
+
+```typescript
+interface VisitEntry {
+  businessId: string;
+  lastVisited: string;  // ISO date string
+  visitCount: number;
+}
+
+// Key: 'modo-mapa-visits'
+// Value: VisitEntry[] (max 50, sorted by lastVisited desc)
+```
+
+### Componentes UI
+
+| Componente | Ubicación | Descripción |
+|-----------|-----------|-------------|
+| `RecentVisits` | `menu/` | Lista de comercios visitados recientemente |
+
+### Hook
+
+| Hook | Descripción |
+|------|-------------|
+| `useVisitHistory` | Lee/escribe localStorage, expone `visits`, `recordVisit(businessId)`, `clearHistory()` |
+
+### Integración
+
+- `BusinessSheet.tsx` llama `recordVisit(business.id)` cuando se abre un comercio
+- `SideMenu.tsx` agrega sección "Recientes" con ícono de historial
+
+---
+
+## F10b — Nivel de gasto
+
+### Problema
+
+Los usuarios no tienen información sobre el rango de precios de un comercio. El tag "barato" es binario y subjetivo.
+
+### Solución
+
+Sistema de calificación de nivel de gasto con 3 niveles representados por el emoji de $. Los usuarios votan el nivel que les parece y se muestra el promedio.
+
+### Niveles
+
+| Nivel | Emoji | Significado |
+|-------|-------|-------------|
+| 1 | $ | Económico |
+| 2 | $$ | Moderado |
+| 3 | $$$ | Caro |
+
+### Flujo de usuario
+
+```text
+1. Usuario abre comercio → ve sección "Nivel de gasto" debajo del rating
+2. Muestra el promedio actual: "$$" con texto "Moderado" y cantidad de votos
+3. Si el usuario no votó, los $ son clickeables (como las estrellas del rating)
+4. Al tocar un nivel, se guarda el voto y se muestra el nuevo promedio
+5. El usuario puede cambiar su voto (update, no crear nuevo)
+```
+
+### Reglas de negocio
+
+- Cada usuario puede votar 1 vez por comercio (igual que rating)
+- El voto es editable (se puede cambiar de $ a $$$ en cualquier momento)
+- Se muestra el promedio redondeado al nivel más cercano
+- Texto descriptivo: "$" → "Económico", "$$" → "Moderado", "$$$" → "Caro"
+- Mínimo 1 voto para mostrar el promedio (si no hay votos, mostrar "Sin votos aún")
+
+### Modelo de datos — Firestore
+
+Reutilizar el patrón de doc ID compuesto:
+
+```text
+priceLevels/{userId}__{businessId}
+  ├── userId: string
+  ├── businessId: string
+  ├── level: number              # 1, 2, o 3
+  ├── createdAt: Timestamp
+  └── updatedAt: Timestamp
+```
+
+### Datos agregados
+
+Para evitar queries de todos los votos al abrir un comercio, usar un campo agregado. Dos opciones:
+
+**Opción A — Campo en businessData (Cloud Function trigger):** Un trigger en `priceLevels` actualiza un doc en `businessStats/{businessId}` con `{ avgPriceLevel, priceLevelCount }`. El hook `useBusinessData` lo lee.
+
+**Opción B — Leer todos los votos client-side:** Similar a como se leen los ratings. El hook `useBusinessData` agrega una query más para `priceLevels` filtrada por `businessId`.
+
+Dado que el patrón ya existe para ratings (se leen todos y se calcula promedio client-side), se recomienda **Opción B** para consistencia.
+
+### Componentes UI
+
+| Componente | Ubicación | Descripción |
+|-----------|-----------|-------------|
+| `BusinessPriceLevel` | `business/` | Sección "$  $$  $$$" con promedio + voto del usuario |
+
+### Integración con filtros y ordenamiento
+
+- **FilterChips**: agregar chip de filtro por nivel de gasto (como los tags predefinidos)
+- **Mapa**: filtrar comercios por nivel de gasto seleccionado
+- **FavoritesList / RatingsList**: agregar opción de ordenar por nivel de gasto
+- **ListFilters**: agregar selector de nivel de gasto mínimo/máximo
+
+### Service layer
+
+| Función | Descripción |
+|---------|-------------|
+| `upsertPriceLevel(userId, businessId, level)` | Crea o actualiza el voto de nivel de gasto |
+| `getPriceLevelsCollection()` | Retorna collection ref para queries |
+
+### Firestore Rules
+
+- `priceLevels`: read auth, create/update owner, level 1-3, timestamps server-side
+- Mismo patrón que `ratings`
+
+### Cloud Functions
+
+| Función | Tipo | Descripción |
+|---------|------|-------------|
+| `onPriceLevelCreated` | trigger (onCreate) | Counters |
+| `onPriceLevelUpdated` | trigger (onUpdate) | (solo counters si cambia) |
+
+---
+
+## Fuera de alcance
+
+- Múltiples fotos por comercio (solo 1 aprobada)
+- Crop/rotate de imagen (solo preview)
+- Notificaciones al usuario cuando su foto es revisada (viene en Fase 3)
+- Reportar foto inapropiada (futuro)
+- Sync del historial entre dispositivos (es localStorage only)
+- Nivel de gasto con decimales (solo 3 niveles discretos)
+
+---
+
+## Impacto en quota Firebase
+
+| Feature | Reads | Writes | Storage |
+|---------|-------|--------|---------|
+| Fotos de menú | +1 query por comercio (foto aprobada) | +upload (bajo, rate limited) | +Cloud Storage (~2 MB/foto) |
+| Historial visitas | 0 (localStorage) | 0 | 0 |
+| Nivel de gasto | +1 query por comercio (priceLevels) | +1 write por voto (bajo, toggle) | 0 |
+
+**Storage estimado:** Con 40 comercios y 1 foto aprobada cada uno = ~80 MB. Bien dentro del free tier de 5 GB.
+
+---
+
+## Métricas de éxito
+
+- % de comercios con foto de menú aprobada
+- Tiempo promedio de revisión (pendiente → aprobada/rechazada)
+- Clicks en "Ver menú"
+- Uso de la sección "Recientes" en el menú lateral
+- % de comercios con al menos 1 voto de nivel de gasto
+- Uso de filtros por nivel de gasto

--- a/docs/feat-menu-photos-history/specs.md
+++ b/docs/feat-menu-photos-history/specs.md
@@ -1,0 +1,1057 @@
+# Specs — Fase 2: Fotos de menú + Historial de visitas + Nivel de gasto
+
+---
+
+## 1. Tipos nuevos (`src/types/index.ts`)
+
+```typescript
+export type MenuPhotoStatus = 'pending' | 'approved' | 'rejected';
+
+export interface MenuPhoto {
+  id: string;
+  userId: string;
+  businessId: string;
+  storagePath: string;
+  thumbnailPath: string;
+  status: MenuPhotoStatus;
+  rejectionReason?: string;
+  reviewedBy?: string;
+  reviewedAt?: Date;
+  createdAt: Date;
+  reportCount: number;
+}
+
+export interface PriceLevel {
+  userId: string;
+  businessId: string;
+  level: number;          // 1, 2, o 3
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export const PRICE_LEVEL_LABELS: Record<number, string> = {
+  1: 'Económico',
+  2: 'Moderado',
+  3: 'Caro',
+};
+```
+
+### Tipo para visit history (no Firestore, localStorage)
+
+```typescript
+// En src/hooks/useVisitHistory.ts (no en types/index.ts)
+interface VisitEntry {
+  businessId: string;
+  lastVisited: string;  // ISO date string
+  visitCount: number;
+}
+```
+
+---
+
+## 2. Colecciones nuevas (`src/config/collections.ts`)
+
+```typescript
+export const COLLECTIONS = {
+  // ... existentes
+  MENU_PHOTOS: 'menuPhotos',
+  PRICE_LEVELS: 'priceLevels',
+} as const;
+```
+
+---
+
+## 3. Converters nuevos (`src/config/converters.ts`)
+
+### menuPhotoConverter
+
+```typescript
+export const menuPhotoConverter: FirestoreDataConverter<MenuPhoto> = {
+  toFirestore(photo: MenuPhoto) {
+    return {
+      userId: photo.userId,
+      businessId: photo.businessId,
+      storagePath: photo.storagePath,
+      thumbnailPath: photo.thumbnailPath,
+      status: photo.status,
+      createdAt: photo.createdAt,
+      reportCount: photo.reportCount,
+    };
+  },
+  fromFirestore(snapshot: QueryDocumentSnapshot, options?: SnapshotOptions): MenuPhoto {
+    const d = snapshot.data(options);
+    return {
+      id: snapshot.id,
+      userId: d.userId,
+      businessId: d.businessId,
+      storagePath: d.storagePath ?? '',
+      thumbnailPath: d.thumbnailPath ?? '',
+      status: d.status ?? 'pending',
+      rejectionReason: d.rejectionReason,
+      reviewedBy: d.reviewedBy,
+      reviewedAt: d.reviewedAt ? toDate(d.reviewedAt) : undefined,
+      createdAt: toDate(d.createdAt),
+      reportCount: (d.reportCount as number) ?? 0,
+    };
+  },
+};
+```
+
+### priceLevelConverter
+
+```typescript
+export const priceLevelConverter: FirestoreDataConverter<PriceLevel> = {
+  toFirestore(pl: PriceLevel) {
+    return {
+      userId: pl.userId,
+      businessId: pl.businessId,
+      level: pl.level,
+      createdAt: pl.createdAt,
+      updatedAt: pl.updatedAt,
+    };
+  },
+  fromFirestore(snapshot: QueryDocumentSnapshot, options?: SnapshotOptions): PriceLevel {
+    const d = snapshot.data(options);
+    return {
+      userId: d.userId,
+      businessId: d.businessId,
+      level: d.level,
+      createdAt: toDate(d.createdAt),
+      updatedAt: toDate(d.updatedAt),
+    };
+  },
+};
+```
+
+---
+
+## 4. Service layer
+
+### `src/services/menuPhotos.ts` (nuevo)
+
+```typescript
+import { collection, doc, setDoc, getDocs, query, where, serverTimestamp } from 'firebase/firestore';
+import { ref, uploadBytesResumable, getDownloadURL } from 'firebase/storage';
+import { db, storage } from '../config/firebase';
+import { COLLECTIONS } from '../config/collections';
+import { menuPhotoConverter } from '../config/converters';
+import { invalidateBusinessCache } from '../hooks/useBusinessDataCache';
+import type { CollectionReference, UploadTask } from 'firebase/firestore';
+import type { MenuPhoto } from '../types';
+
+export function getMenuPhotosCollection(): CollectionReference<MenuPhoto> {
+  return collection(db, COLLECTIONS.MENU_PHOTOS)
+    .withConverter(menuPhotoConverter) as CollectionReference<MenuPhoto>;
+}
+
+/**
+ * Upload a menu photo. Returns the upload task for progress tracking.
+ * After upload completes, creates a Firestore doc with status 'pending'.
+ */
+export async function uploadMenuPhoto(
+  userId: string,
+  businessId: string,
+  file: File,
+): Promise<{ uploadTask: UploadTask; docId: string }> {
+  // Validate
+  const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    throw new Error('Formato no soportado. Usa JPG, PNG o WebP.');
+  }
+  if (file.size > 5 * 1024 * 1024) {
+    throw new Error('La imagen es muy grande. Máximo 5 MB.');
+  }
+
+  // Check pending count for this user
+  const pendingSnap = await getDocs(query(
+    collection(db, COLLECTIONS.MENU_PHOTOS),
+    where('userId', '==', userId),
+    where('status', '==', 'pending'),
+  ));
+  if (pendingSnap.size >= 3) {
+    throw new Error('Ya tenés 3 fotos pendientes de revisión. Esperá a que se revisen.');
+  }
+
+  // Create Firestore doc first to get ID
+  const docRef = doc(collection(db, COLLECTIONS.MENU_PHOTOS));
+  const storagePath = `menus/${businessId}/${docRef.id}_original`;
+
+  // Upload to Storage
+  const storageRef = ref(storage, storagePath);
+  const uploadTask = uploadBytesResumable(storageRef, file);
+
+  // After upload completes, create Firestore doc
+  return new Promise((resolve, reject) => {
+    uploadTask.on('state_changed', null,
+      (error) => reject(error),
+      async () => {
+        try {
+          await setDoc(docRef, {
+            userId,
+            businessId,
+            storagePath,
+            thumbnailPath: '', // Will be set by Cloud Function
+            status: 'pending',
+            createdAt: serverTimestamp(),
+            reportCount: 0,
+          });
+          invalidateBusinessCache(businessId);
+          resolve({ uploadTask, docId: docRef.id });
+        } catch (err) {
+          reject(err);
+        }
+      },
+    );
+  });
+}
+
+/**
+ * Get the approved menu photo for a business (if any).
+ */
+export async function getApprovedMenuPhoto(businessId: string): Promise<MenuPhoto | null> {
+  const snap = await getDocs(query(
+    collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+    where('businessId', '==', businessId),
+    where('status', '==', 'approved'),
+  ));
+  if (snap.empty) return null;
+  return snap.docs[0].data();
+}
+
+/**
+ * Get user's pending photos for a business.
+ */
+export async function getUserPendingPhotos(
+  userId: string,
+  businessId: string,
+): Promise<MenuPhoto[]> {
+  const snap = await getDocs(query(
+    collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+    where('userId', '==', userId),
+    where('businessId', '==', businessId),
+    where('status', '==', 'pending'),
+  ));
+  return snap.docs.map((d) => d.data());
+}
+```
+
+### `src/services/priceLevels.ts` (nuevo)
+
+```typescript
+import { collection, doc, getDoc, setDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import type { CollectionReference } from 'firebase/firestore';
+import { db } from '../config/firebase';
+import { COLLECTIONS } from '../config/collections';
+import { priceLevelConverter } from '../config/converters';
+import { invalidateQueryCache } from '../hooks/usePaginatedQuery';
+import type { PriceLevel } from '../types';
+
+export function getPriceLevelsCollection(): CollectionReference<PriceLevel> {
+  return collection(db, COLLECTIONS.PRICE_LEVELS)
+    .withConverter(priceLevelConverter) as CollectionReference<PriceLevel>;
+}
+
+export async function upsertPriceLevel(
+  userId: string,
+  businessId: string,
+  level: number,
+): Promise<void> {
+  if (!Number.isInteger(level) || level < 1 || level > 3) {
+    throw new Error('Level must be 1, 2, or 3');
+  }
+
+  const docId = `${userId}__${businessId}`;
+  const plRef = doc(db, COLLECTIONS.PRICE_LEVELS, docId);
+  const existing = await getDoc(plRef);
+
+  if (existing.exists()) {
+    await updateDoc(plRef, {
+      level,
+      updatedAt: serverTimestamp(),
+    });
+  } else {
+    await setDoc(plRef, {
+      userId,
+      businessId,
+      level,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    });
+  }
+
+  invalidateQueryCache(COLLECTIONS.PRICE_LEVELS, userId);
+}
+```
+
+### `src/services/index.ts` — agregar exports
+
+```typescript
+export { uploadMenuPhoto, getApprovedMenuPhoto, getUserPendingPhotos } from './menuPhotos';
+export { upsertPriceLevel } from './priceLevels';
+```
+
+---
+
+## 5. Firebase config changes
+
+### `src/config/firebase.ts` — agregar Storage
+
+```typescript
+import { getStorage, connectStorageEmulator } from 'firebase/storage';
+
+// After app init:
+export const storage = getStorage(app);
+
+// In DEV block:
+if (import.meta.env.DEV) {
+  // ... existing emulators
+  connectStorageEmulator(storage, 'localhost', 9199);
+}
+```
+
+### `firebase.json` — agregar Storage emulator
+
+```json
+{
+  "emulators": {
+    // ... existing
+    "storage": {
+      "port": 9199
+    }
+  }
+}
+```
+
+### `storage.rules` (nuevo)
+
+```rules
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /menus/{businessId}/{fileName} {
+      // Anyone authenticated can upload (rate limited in Firestore rules)
+      allow create: if request.auth != null
+        && request.resource.size < 5 * 1024 * 1024
+        && request.resource.contentType.matches('image/(jpeg|png|webp)');
+
+      // Anyone can read (approved photos are public)
+      allow read: if request.auth != null;
+
+      // Only Cloud Functions can delete (admin SDK bypasses rules)
+      allow delete: if false;
+    }
+  }
+}
+```
+
+---
+
+## 6. Firestore Rules (`firestore.rules`)
+
+### menuPhotos
+
+```rules
+match /menuPhotos/{docId} {
+  allow read: if request.auth != null;
+  allow create: if request.auth != null
+    && request.resource.data.userId == request.auth.uid
+    && isValidBusinessId(request.resource.data.businessId)
+    && request.resource.data.status == 'pending'
+    && request.resource.data.createdAt == request.time
+    && request.resource.data.reportCount == 0;
+  // Only admin can update (approve/reject) — via callable Cloud Functions with admin SDK
+  allow update: if false;
+  allow delete: if false;
+}
+```
+
+### priceLevels
+
+```rules
+match /priceLevels/{docId} {
+  allow read: if request.auth != null;
+  allow create: if request.auth != null
+    && request.resource.data.userId == request.auth.uid
+    && isValidBusinessId(request.resource.data.businessId)
+    && request.resource.data.level is int
+    && request.resource.data.level >= 1
+    && request.resource.data.level <= 3
+    && request.resource.data.createdAt == request.time
+    && request.resource.data.updatedAt == request.time;
+  allow update: if request.auth != null
+    && request.resource.data.userId == request.auth.uid
+    && request.resource.data.level is int
+    && request.resource.data.level >= 1
+    && request.resource.data.level <= 3
+    && request.resource.data.updatedAt == request.time;
+}
+```
+
+---
+
+## 7. Cloud Functions
+
+### `functions/src/triggers/menuPhotos.ts` (nuevo)
+
+```typescript
+import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+import { getStorage } from 'firebase-admin/storage';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import * as sharp from 'sharp';
+import { incrementCounter, trackWrite } from '../utils/counters';
+
+// Generate thumbnail on photo creation
+export const onMenuPhotoCreated = onDocumentCreated(
+  'menuPhotos/{photoId}',
+  async (event) => {
+    const snap = event.data;
+    if (!snap) return;
+    const data = snap.data();
+    const photoId = event.params.photoId;
+
+    // Generate thumbnail
+    const bucket = getStorage().bucket();
+    const originalFile = bucket.file(data.storagePath);
+    const [buffer] = await originalFile.download();
+
+    const thumbBuffer = await sharp(buffer)
+      .resize(400)
+      .jpeg({ quality: 80 })
+      .toBuffer();
+
+    const thumbPath = `menus/${data.businessId}/${photoId}_thumb.jpg`;
+    const thumbFile = bucket.file(thumbPath);
+    await thumbFile.save(thumbBuffer, {
+      metadata: { contentType: 'image/jpeg' },
+    });
+
+    // Update doc with thumbnail path
+    await snap.ref.update({ thumbnailPath: thumbPath });
+
+    // Counters
+    await incrementCounter('menuPhotos');
+    await trackWrite('menuPhotos');
+  },
+);
+```
+
+### `functions/src/admin/menuPhotos.ts` (nuevo)
+
+```typescript
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
+
+// Approve a menu photo
+export const approveMenuPhoto = onCall(
+  { enforceAppCheck: true, timeoutSeconds: 60 },
+  async (request) => {
+    // Verify admin
+    const { auth } = request;
+    if (!auth?.token.email_verified || auth.token.email !== process.env.ADMIN_EMAIL) {
+      throw new HttpsError('permission-denied', 'Admin only');
+    }
+
+    const { photoId } = request.data;
+    if (!photoId || typeof photoId !== 'string') {
+      throw new HttpsError('invalid-argument', 'photoId required');
+    }
+
+    const db = getFirestore();
+    const photoRef = db.collection('menuPhotos').doc(photoId);
+    const photoSnap = await photoRef.get();
+    if (!photoSnap.exists) {
+      throw new HttpsError('not-found', 'Photo not found');
+    }
+
+    const data = photoSnap.data()!;
+    if (data.status !== 'pending') {
+      throw new HttpsError('failed-precondition', 'Photo is not pending');
+    }
+
+    // Mark any existing approved photo for this business as replaced
+    const existingApproved = await db.collection('menuPhotos')
+      .where('businessId', '==', data.businessId)
+      .where('status', '==', 'approved')
+      .get();
+
+    const batch = db.batch();
+    for (const doc of existingApproved.docs) {
+      batch.update(doc.ref, { status: 'replaced' });
+    }
+
+    // Approve the new photo
+    batch.update(photoRef, {
+      status: 'approved',
+      reviewedBy: auth.uid,
+      reviewedAt: FieldValue.serverTimestamp(),
+    });
+
+    await batch.commit();
+    return { success: true };
+  },
+);
+
+// Reject a menu photo
+export const rejectMenuPhoto = onCall(
+  { enforceAppCheck: true, timeoutSeconds: 60 },
+  async (request) => {
+    const { auth } = request;
+    if (!auth?.token.email_verified || auth.token.email !== process.env.ADMIN_EMAIL) {
+      throw new HttpsError('permission-denied', 'Admin only');
+    }
+
+    const { photoId, reason } = request.data;
+    if (!photoId || typeof photoId !== 'string') {
+      throw new HttpsError('invalid-argument', 'photoId required');
+    }
+
+    const db = getFirestore();
+    const photoRef = db.collection('menuPhotos').doc(photoId);
+    const photoSnap = await photoRef.get();
+    if (!photoSnap.exists) {
+      throw new HttpsError('not-found', 'Photo not found');
+    }
+
+    await photoRef.update({
+      status: 'rejected',
+      rejectionReason: reason || '',
+      reviewedBy: auth.uid,
+      reviewedAt: FieldValue.serverTimestamp(),
+    });
+
+    return { success: true };
+  },
+);
+```
+
+### `functions/src/scheduled/cleanupPhotos.ts` (nuevo)
+
+```typescript
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
+
+// Run daily at 4AM — cleanup rejected photos older than 7 days
+export const cleanupRejectedPhotos = onSchedule(
+  { schedule: '0 4 * * *', timeZone: 'America/Argentina/Buenos_Aires' },
+  async () => {
+    const db = getFirestore();
+    const bucket = getStorage().bucket();
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const rejected = await db.collection('menuPhotos')
+      .where('status', '==', 'rejected')
+      .where('reviewedAt', '<', sevenDaysAgo)
+      .get();
+
+    for (const doc of rejected.docs) {
+      const data = doc.data();
+      // Delete files from storage
+      try {
+        await bucket.file(data.storagePath).delete();
+        if (data.thumbnailPath) {
+          await bucket.file(data.thumbnailPath).delete();
+        }
+      } catch { /* file may not exist */ }
+      // Delete Firestore doc
+      await doc.ref.delete();
+    }
+
+    console.log(`Cleaned up ${rejected.size} rejected photos`);
+  },
+);
+```
+
+### `functions/src/triggers/priceLevels.ts` (nuevo)
+
+```typescript
+import { onDocumentCreated, onDocumentUpdated } from 'firebase-functions/v2/firestore';
+import { incrementCounter, trackWrite } from '../utils/counters';
+
+export const onPriceLevelCreated = onDocumentCreated(
+  'priceLevels/{docId}',
+  async () => {
+    await incrementCounter('priceLevels');
+    await trackWrite('priceLevels');
+  },
+);
+
+export const onPriceLevelUpdated = onDocumentUpdated(
+  'priceLevels/{docId}',
+  async () => {
+    await trackWrite('priceLevels');
+  },
+);
+```
+
+### `functions/src/index.ts` — agregar exports
+
+```typescript
+export { onMenuPhotoCreated } from './triggers/menuPhotos';
+export { approveMenuPhoto, rejectMenuPhoto } from './admin/menuPhotos';
+export { cleanupRejectedPhotos } from './scheduled/cleanupPhotos';
+export { onPriceLevelCreated, onPriceLevelUpdated } from './triggers/priceLevels';
+```
+
+---
+
+## 8. Hooks
+
+### `src/hooks/useVisitHistory.ts` (nuevo)
+
+```typescript
+import { useState, useCallback, useEffect } from 'react';
+import { allBusinesses } from './useBusinesses';
+import type { Business } from '../types';
+
+interface VisitEntry {
+  businessId: string;
+  lastVisited: string;
+  visitCount: number;
+}
+
+const STORAGE_KEY = 'modo-mapa-visits';
+const MAX_ENTRIES = 50;
+
+function readVisits(): VisitEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeVisits(visits: VisitEntry[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(visits));
+}
+
+export interface VisitWithBusiness extends VisitEntry {
+  business: Business | null;
+}
+
+export function useVisitHistory() {
+  const [visits, setVisits] = useState<VisitEntry[]>(readVisits);
+
+  const recordVisit = useCallback((businessId: string) => {
+    setVisits((prev) => {
+      const now = new Date().toISOString();
+      const existing = prev.find((v) => v.businessId === businessId);
+      let updated: VisitEntry[];
+
+      if (existing) {
+        updated = [
+          { ...existing, lastVisited: now, visitCount: existing.visitCount + 1 },
+          ...prev.filter((v) => v.businessId !== businessId),
+        ];
+      } else {
+        updated = [
+          { businessId, lastVisited: now, visitCount: 1 },
+          ...prev,
+        ].slice(0, MAX_ENTRIES);
+      }
+
+      writeVisits(updated);
+      return updated;
+    });
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setVisits([]);
+  }, []);
+
+  const visitsWithBusiness: VisitWithBusiness[] = visits.map((v) => ({
+    ...v,
+    business: allBusinesses.find((b) => b.id === v.businessId) || null,
+  }));
+
+  return { visits: visitsWithBusiness, recordVisit, clearHistory };
+}
+```
+
+### `src/hooks/useBusinessData.ts` — cambios
+
+Agregar `priceLevels` y `menuPhoto` al data flow:
+
+```typescript
+// Nuevo en UseBusinessDataReturn:
+priceLevels: PriceLevel[];
+menuPhoto: MenuPhoto | null;
+
+// Nuevo en CollectionName:
+type CollectionName = 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags' | 'priceLevels' | 'menuPhoto';
+
+// En fetchBusinessData: agregar 2 queries más al Promise.all:
+// - priceLevels: getDocs(query(... where('businessId', '==', bId)))
+// - menuPhoto: getDocs(query(... where('businessId', '==', bId), where('status', '==', 'approved')))
+
+// En fetchSingleCollection: agregar cases para 'priceLevels' y 'menuPhoto'
+```
+
+### `src/hooks/useBusinessDataCache.ts` — cambios
+
+```typescript
+// Agregar a BusinessCacheEntry:
+priceLevels: PriceLevel[];
+menuPhoto: MenuPhoto | null;
+```
+
+---
+
+## 9. Componentes — Business Sheet
+
+### `src/components/business/MenuPhotoSection.tsx` (nuevo)
+
+Sección en BusinessSheet que muestra:
+
+- **Si hay foto aprobada**: Thumbnail clickeable + "Menú actualizado: 12 mar 2026" (usando `reviewedAt`). Si `reviewedAt` > 6 meses: chip sutil "Posiblemente desactualizado". Click abre `MenuPhotoViewer`.
+- **Si no hay foto**: Botón "Subir foto del menú" (ícono cámara). Si el usuario ya tiene foto pendiente para ese comercio, mostrar "Tu foto está en revisión".
+- **Props**: `menuPhoto: MenuPhoto | null`, `businessId: string`, `isLoading: boolean`, `onPhotoChange: () => void`
+
+### `src/components/business/MenuPhotoUpload.tsx` (nuevo)
+
+Dialog para subir foto:
+
+- Input file (accept: image/jpeg, image/png, image/webp)
+- Preview de la imagen seleccionada
+- Compresión con `browser-image-compression` (maxSizeMB: 2, maxWidthOrHeight: 2048)
+- Barra de progreso durante upload (usando `uploadTask.on('state_changed')`)
+- Botones "Cancelar" / "Enviar"
+- **Props**: `open: boolean`, `businessId: string`, `onClose: () => void`, `onSuccess: () => void`
+
+### `src/components/business/MenuPhotoViewer.tsx` (nuevo)
+
+Dialog fullscreen para ver la foto:
+
+- Imagen a ancho completo
+- Fecha de aprobación
+- Botón cerrar
+- **Props**: `open: boolean`, `photoUrl: string`, `reviewedAt: Date | undefined`, `onClose: () => void`
+
+### `src/components/business/BusinessPriceLevel.tsx` (nuevo)
+
+Sección "Nivel de gasto" similar a BusinessRating:
+
+- Muestra promedio: "$" / "$$" / "$$$" con label "Económico" / "Moderado" / "Caro"
+- Cantidad de votos: "(12 votos)"
+- Si no hay votos: "Sin votos aún"
+- Si el usuario está logueado: 3 botones "$", "$$", "$$$" clickeables (toggle)
+- El voto del usuario se resalta (filled vs outlined)
+- Optimistic UI: muestra el nuevo voto inmediatamente (pendingLevel state)
+- **Props**: `businessId: string`, `priceLevels: PriceLevel[]`, `isLoading: boolean`, `onPriceLevelChange: () => void`
+
+### `src/components/business/BusinessSheet.tsx` — cambios
+
+```tsx
+// Agregar entre BusinessRating y BusinessTags:
+<Divider sx={{ my: 1.5 }} />
+<BusinessPriceLevel
+  businessId={selectedBusiness.id}
+  priceLevels={data.priceLevels}
+  isLoading={data.isLoading}
+  onPriceLevelChange={() => data.refetch('priceLevels')}
+/>
+
+// Agregar entre BusinessTags y BusinessComments:
+<Divider sx={{ my: 1.5 }} />
+<MenuPhotoSection
+  menuPhoto={data.menuPhoto}
+  businessId={selectedBusiness.id}
+  isLoading={data.isLoading}
+  onPhotoChange={() => data.refetch('menuPhoto')}
+/>
+```
+
+---
+
+## 10. Componentes — Menu lateral
+
+### `src/components/menu/RecentVisits.tsx` (nuevo)
+
+Lista de comercios visitados recientemente:
+
+- Usa `useVisitHistory()` para obtener datos
+- Cada item muestra nombre, categoría, "Visitado hace X" (formateo relativo), y visitCount si > 1
+- Click navega al comercio (`setSelectedBusiness` + `onNavigate`)
+- Botón "Limpiar historial" al final
+- Empty state: ícono de historial + "No visitaste comercios todavía"
+- **Props**: `onNavigate: () => void`
+
+### `src/components/layout/SideMenu.tsx` — cambios
+
+```typescript
+// Agregar Section:
+type Section = 'nav' | 'favorites' | 'recent' | 'comments' | 'ratings' | 'feedback' | 'stats';
+
+// Agregar título:
+const SECTION_TITLES = { ..., recent: 'Recientes' };
+
+// Agregar nav item (entre Favoritos y Comentarios):
+import HistoryIcon from '@mui/icons-material/History';
+import RecentVisits from '../menu/RecentVisits';
+
+<ListItemButton onClick={() => setActiveSection('recent')}>
+  <ListItemIcon>
+    <HistoryIcon sx={{ color: '#ff9800' }} />
+  </ListItemIcon>
+  <ListItemText primary="Recientes" />
+</ListItemButton>
+
+// Agregar render:
+{activeSection === 'recent' && <RecentVisits onNavigate={handleClose} />}
+```
+
+### `src/components/business/BusinessSheet.tsx` — visit tracking
+
+```typescript
+import { useVisitHistory } from '../../hooks/useVisitHistory';
+
+// Inside component:
+const { recordVisit } = useVisitHistory();
+
+// In useEffect or when business opens:
+useEffect(() => {
+  if (selectedBusiness) {
+    recordVisit(selectedBusiness.id);
+  }
+}, [selectedBusiness, recordVisit]);
+```
+
+---
+
+## 11. Componentes — Admin
+
+### `src/components/admin/PhotoReviewPanel.tsx` (nuevo)
+
+Tab nueva en AdminLayout para revisar fotos pendientes:
+
+- Usa `useAsyncData` + `AdminPanelWrapper` (patrón existente)
+- Fetches all photos with `status == 'pending'` ordered by `createdAt`
+- Grid de `PhotoReviewCard` components
+- Empty state: "No hay fotos pendientes"
+
+### `src/components/admin/PhotoReviewCard.tsx` (nuevo)
+
+Card individual:
+
+- Thumbnail de la foto (usando download URL de `thumbnailPath`)
+- Nombre del comercio (usando `getBusinessName`)
+- Nombre del usuario (usando `userId` → fetch displayName)
+- Fecha de subida (createdAt formateada)
+- Botón "Aprobar" (verde) → llama `approveMenuPhoto` callable
+- Botón "Rechazar" (rojo) → abre input para motivo, luego llama `rejectMenuPhoto`
+- Loading state durante aprobación/rechazo
+
+### `src/components/admin/AdminLayout.tsx` — cambios
+
+```tsx
+// Agregar tab:
+<Tab label="Fotos" />
+
+// Agregar render (index 8):
+{tab === 8 && <PhotoReviewPanel />}
+```
+
+### `src/services/admin.ts` — agregar
+
+```typescript
+export async function fetchPendingPhotos(): Promise<MenuPhoto[]> {
+  const snap = await getDocs(query(
+    collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+    where('status', '==', 'pending'),
+    orderBy('createdAt', 'asc'),
+  ));
+  return snap.docs.map((d) => d.data());
+}
+```
+
+---
+
+## 12. Filtros — Nivel de gasto
+
+### `src/context/MapContext.tsx` — cambios
+
+```typescript
+// Agregar al contexto:
+activePriceFilter: number | null;  // null = sin filtro, 1/2/3 = nivel específico
+setPriceFilter: (level: number | null) => void;
+```
+
+### `src/components/search/FilterChips.tsx` — cambios
+
+Agregar 3 chips de nivel de gasto al final de la fila, después de los tags predefinidos:
+
+```tsx
+// Separador visual (Divider vertical o espaciado)
+// Chip "$" / "$$" / "$$$" con toggle
+{[1, 2, 3].map((level) => (
+  <Chip
+    key={`price-${level}`}
+    label={'$'.repeat(level)}
+    onClick={() => setPriceFilter(activePriceFilter === level ? null : level)}
+    variant={activePriceFilter === level ? 'filled' : 'outlined'}
+    color={activePriceFilter === level ? 'warning' : 'default'}
+    // ... same sx as existing chips
+  />
+))}
+```
+
+### `src/hooks/useBusinesses.ts` — cambios
+
+El filtro de precio NO se puede aplicar aquí directamente porque los datos de `priceLevels` están en Firestore, no en `businesses.json`. Dos opciones:
+
+**Opción elegida: Filtro lazy con cache global.**
+
+Cuando el usuario activa un filtro de precio, se necesita conocer el promedio de precio de cada comercio. Esto requeriría leer todos los `priceLevels` de Firestore — costoso.
+
+**Alternativa práctica:** El filtro de precio funciona a nivel de mapa haciendo una query global de `priceLevels` agrupada por businessId. Se cachea en memoria y se recalcula cada 5 minutos.
+
+```typescript
+// Nuevo hook: src/hooks/usePriceLevelFilter.ts
+// Fetches ALL priceLevels, groups by businessId, computes averages
+// Returns Map<businessId, averageLevel>
+// Se usa en useBusinesses para filtrar
+```
+
+Esto agrega ~1 query global de priceLevels (todos los docs). Con 40 comercios y ~10 usuarios, serían ~400 docs máximo — aceptable.
+
+### `src/hooks/useListFilters.ts` — cambios
+
+Agregar opción de filtro por nivel de gasto a `useListFilters`. Esto requiere que las listas (FavoritesList, RatingsList) pasen la info de precio del comercio.
+
+Para el menú lateral, el filtro de precio es un `Select` adicional en `ListFilters.tsx`:
+
+```typescript
+// Agregar prop opcional:
+priceFilter?: number | null;
+onPriceFilterChange?: (level: number | null) => void;
+```
+
+---
+
+## 13. Dependencias
+
+### Frontend (`package.json`)
+
+```bash
+npm install browser-image-compression
+```
+
+### Functions (`functions/package.json`)
+
+```bash
+cd functions && npm install sharp
+```
+
+`sharp` requiere compilación nativa. En Cloud Functions v2 (Node 22) está disponible nativamente.
+
+---
+
+## 14. Seed script changes (`scripts/seed-admin-data.mjs`)
+
+Agregar datos de prueba:
+
+- ~15 menuPhotos (10 approved, 3 pending, 2 rejected) con storagePath/thumbnailPath simulados
+- ~30 priceLevels (votos de precio aleatorios nivel 1-3)
+- Actualizar counters con `menuPhotos` y `priceLevels`
+
+---
+
+## 15. Firestore indexes (`firestore.indexes.json`)
+
+Agregar índices compuestos:
+
+```json
+{
+  "collectionGroup": "menuPhotos",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "businessId", "order": "ASCENDING" },
+    { "fieldPath": "status", "order": "ASCENDING" }
+  ]
+},
+{
+  "collectionGroup": "menuPhotos",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "status", "order": "ASCENDING" },
+    { "fieldPath": "createdAt", "order": "ASCENDING" }
+  ]
+},
+{
+  "collectionGroup": "menuPhotos",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "userId", "order": "ASCENDING" },
+    { "fieldPath": "status", "order": "ASCENDING" }
+  ]
+},
+{
+  "collectionGroup": "menuPhotos",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "status", "order": "ASCENDING" },
+    { "fieldPath": "reviewedAt", "order": "ASCENDING" }
+  ]
+},
+{
+  "collectionGroup": "priceLevels",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "businessId", "order": "ASCENDING" }
+  ]
+}
+```
+
+---
+
+## 16. Resumen de archivos
+
+### Archivos nuevos
+
+| Archivo | Descripción |
+|---------|-------------|
+| `src/services/menuPhotos.ts` | Service: upload, get approved/pending photos |
+| `src/services/priceLevels.ts` | Service: upsert price level vote |
+| `src/hooks/useVisitHistory.ts` | Hook: localStorage visit tracking |
+| `src/hooks/usePriceLevelFilter.ts` | Hook: global price level cache for map filter |
+| `src/components/business/MenuPhotoSection.tsx` | Sección menú foto en BusinessSheet |
+| `src/components/business/MenuPhotoUpload.tsx` | Dialog upload con preview + progress |
+| `src/components/business/MenuPhotoViewer.tsx` | Dialog fullscreen para ver foto |
+| `src/components/business/BusinessPriceLevel.tsx` | Sección nivel de gasto |
+| `src/components/menu/RecentVisits.tsx` | Lista de visitas recientes |
+| `src/components/admin/PhotoReviewPanel.tsx` | Tab admin: revisar fotos |
+| `src/components/admin/PhotoReviewCard.tsx` | Card review individual |
+| `functions/src/triggers/menuPhotos.ts` | Trigger: thumbnail generation |
+| `functions/src/triggers/priceLevels.ts` | Triggers: counters |
+| `functions/src/admin/menuPhotos.ts` | Callables: approve/reject |
+| `functions/src/scheduled/cleanupPhotos.ts` | Cron: cleanup rejected photos |
+| `storage.rules` | Reglas de Cloud Storage |
+
+### Archivos modificados
+
+| Archivo | Cambios |
+|---------|---------|
+| `src/types/index.ts` | MenuPhoto, PriceLevel, PRICE_LEVEL_LABELS |
+| `src/config/collections.ts` | MENU_PHOTOS, PRICE_LEVELS |
+| `src/config/converters.ts` | menuPhotoConverter, priceLevelConverter |
+| `src/config/firebase.ts` | Storage init + emulator |
+| `src/services/index.ts` | Exports nuevos |
+| `src/services/admin.ts` | fetchPendingPhotos |
+| `src/hooks/useBusinessData.ts` | priceLevels + menuPhoto en data flow |
+| `src/hooks/useBusinessDataCache.ts` | priceLevels + menuPhoto en cache |
+| `src/hooks/useBusinesses.ts` | Filtro por precio |
+| `src/hooks/useListFilters.ts` | Opción filtro precio |
+| `src/context/MapContext.tsx` | activePriceFilter state |
+| `src/components/business/BusinessSheet.tsx` | Render PriceLevel + MenuPhoto + visit tracking |
+| `src/components/search/FilterChips.tsx` | Chips de precio |
+| `src/components/layout/SideMenu.tsx` | Sección "Recientes" |
+| `src/components/admin/AdminLayout.tsx` | Tab "Fotos" |
+| `firestore.rules` | menuPhotos + priceLevels rules |
+| `firestore.indexes.json` | Índices compuestos |
+| `firebase.json` | Storage emulator |
+| `functions/src/index.ts` | Exports nuevos |
+| `scripts/seed-admin-data.mjs` | Datos de prueba |

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "storage": {
+    "rules": "storage.rules"
+  },
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
@@ -40,6 +43,9 @@
     },
     "functions": {
       "port": 5001
+    },
+    "storage": {
+      "port": 9199
     },
     "ui": {
       "enabled": true,

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -23,6 +23,38 @@
         { "fieldPath": "userId", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "menuPhotos",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "businessId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "menuPhotos",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "menuPhotos",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "priceLevels",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "businessId", "order": "ASCENDING" },
+        { "fieldPath": "level", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -175,6 +175,41 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Fotos de menú — cualquier usuario autenticado puede leer.
+    // Owner puede crear con status 'pending' y timestamp validado.
+    // Solo Cloud Functions (admin SDK) puede update/delete.
+    match /menuPhotos/{docId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null
+        && request.resource.data.userId == request.auth.uid
+        && isValidBusinessId(request.resource.data.businessId)
+        && request.resource.data.status == 'pending'
+        && request.resource.data.createdAt == request.time
+        && request.resource.data.reportCount == 0;
+      allow update: if false;
+      allow delete: if false;
+    }
+
+    // Nivel de gasto — cualquier usuario autenticado puede leer.
+    // Owner puede crear (con level 1-3 y timestamps validados) o actualizar level.
+    match /priceLevels/{docId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null
+        && request.resource.data.userId == request.auth.uid
+        && isValidBusinessId(request.resource.data.businessId)
+        && request.resource.data.level is int
+        && request.resource.data.level >= 1
+        && request.resource.data.level <= 3
+        && request.resource.data.createdAt == request.time
+        && request.resource.data.updatedAt == request.time;
+      allow update: if request.auth != null
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.level is int
+        && request.resource.data.level >= 1
+        && request.resource.data.level <= 3
+        && request.resource.data.updatedAt == request.time;
+    }
+
     // Rate limits — solo Cloud Functions (admin SDK) lee/escribe.
     match /_rateLimits/{docId} {
       allow read, write: if false;

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,9 +10,11 @@
         "@google-cloud/storage": "^7.19.0",
         "@sentry/node": "^10.43.0",
         "firebase-admin": "^13.0.0",
-        "firebase-functions": "^6.3.0"
+        "firebase-functions": "^6.3.0",
+        "sharp": "^0.34.5"
       },
       "devDependencies": {
+        "@types/sharp": "^0.31.1",
         "@typescript-eslint/eslint-plugin": "^8.48.0",
         "@typescript-eslint/parser": "^8.48.0",
         "eslint": "^9.39.1",
@@ -21,6 +23,16 @@
       },
       "engines": {
         "node": "22"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1032,6 +1044,471 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2478,6 +2955,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/sharp": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-5nWwamN9ZFHXaYEincMSuza8nNfOof8nmO+mcI+Agx1uMUk4/pQnNIcix+9rLPXzKrm1pS34+6WRDbDV0Jn7ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
@@ -3343,6 +3830,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -6104,6 +6600,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,9 +17,11 @@
     "@google-cloud/storage": "^7.19.0",
     "@sentry/node": "^10.43.0",
     "firebase-admin": "^13.0.0",
-    "firebase-functions": "^6.3.0"
+    "firebase-functions": "^6.3.0",
+    "sharp": "^0.34.5"
   },
   "devDependencies": {
+    "@types/sharp": "^0.31.1",
     "@typescript-eslint/eslint-plugin": "^8.48.0",
     "@typescript-eslint/parser": "^8.48.0",
     "eslint": "^9.39.1",

--- a/functions/src/admin/backups.ts
+++ b/functions/src/admin/backups.ts
@@ -7,6 +7,8 @@ import { getFirestore } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
 import { captureException } from '../utils/sentry';
 
+const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === 'true';
+
 // ── Constants ──────────────────────────────────────────────────────────
 
 const ADMIN_EMAIL_PARAM = defineString('ADMIN_EMAIL', {
@@ -161,7 +163,7 @@ function clampPageSize(requested: unknown): number {
 export const createBackup = onCall<unknown, Promise<CreateBackupResponse>>({
   timeoutSeconds: 300,
   memory: '256MiB',
-  enforceAppCheck: true,
+  enforceAppCheck: !IS_EMULATOR,
 }, async (request) => {
   await verifyAdmin(request);
 
@@ -193,7 +195,7 @@ export const createBackup = onCall<unknown, Promise<CreateBackupResponse>>({
 export const listBackups = onCall<ListBackupsRequest, Promise<ListBackupsResponse>>({
   timeoutSeconds: 60,
   memory: '256MiB',
-  enforceAppCheck: true,
+  enforceAppCheck: !IS_EMULATOR,
 }, async (request) => {
   await verifyAdmin(request);
 
@@ -246,7 +248,7 @@ export const listBackups = onCall<ListBackupsRequest, Promise<ListBackupsRespons
 export const restoreBackup = onCall<RestoreBackupRequest, Promise<{ success: true; safetyBackupId: string }>>({
   timeoutSeconds: 300,
   memory: '256MiB',
-  enforceAppCheck: true,
+  enforceAppCheck: !IS_EMULATOR,
 }, async (request) => {
   await verifyAdmin(request);
 
@@ -290,7 +292,7 @@ export const restoreBackup = onCall<RestoreBackupRequest, Promise<{ success: tru
 export const deleteBackup = onCall<DeleteBackupRequest, Promise<{ success: true }>>({
   timeoutSeconds: 120,
   memory: '256MiB',
-  enforceAppCheck: true,
+  enforceAppCheck: !IS_EMULATOR,
 }, async (request) => {
   await verifyAdmin(request);
 

--- a/functions/src/admin/menuPhotos.ts
+++ b/functions/src/admin/menuPhotos.ts
@@ -1,0 +1,163 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
+
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'benoffi11@gmail.com';
+const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === 'true';
+
+export const approveMenuPhoto = onCall(
+  { enforceAppCheck: !IS_EMULATOR, timeoutSeconds: 60 },
+  async (request) => {
+    const { auth } = request;
+    if (!auth?.token.email_verified || auth.token.email !== ADMIN_EMAIL) {
+      throw new HttpsError('permission-denied', 'Admin only');
+    }
+
+    const { photoId } = request.data;
+    if (!photoId || typeof photoId !== 'string') {
+      throw new HttpsError('invalid-argument', 'photoId required');
+    }
+
+    const db = getFirestore();
+    const photoRef = db.collection('menuPhotos').doc(photoId);
+    const photoSnap = await photoRef.get();
+    if (!photoSnap.exists) {
+      throw new HttpsError('not-found', 'Photo not found');
+    }
+
+    const data = photoSnap.data()!;
+    if (data.status !== 'pending' && data.status !== 'rejected') {
+      throw new HttpsError('failed-precondition', 'Photo must be pending or rejected');
+    }
+
+    // Mark any existing approved photo for this business as replaced
+    const existingApproved = await db.collection('menuPhotos')
+      .where('businessId', '==', data.businessId)
+      .where('status', '==', 'approved')
+      .get();
+
+    const batch = db.batch();
+    for (const doc of existingApproved.docs) {
+      batch.update(doc.ref, { status: 'replaced' });
+    }
+
+    // Approve the new photo
+    batch.update(photoRef, {
+      status: 'approved',
+      reviewedBy: auth.uid,
+      reviewedAt: FieldValue.serverTimestamp(),
+    });
+
+    await batch.commit();
+    return { success: true };
+  },
+);
+
+export const rejectMenuPhoto = onCall(
+  { enforceAppCheck: !IS_EMULATOR, timeoutSeconds: 60 },
+  async (request) => {
+    const { auth } = request;
+    if (!auth?.token.email_verified || auth.token.email !== ADMIN_EMAIL) {
+      throw new HttpsError('permission-denied', 'Admin only');
+    }
+
+    const { photoId, reason } = request.data;
+    if (!photoId || typeof photoId !== 'string') {
+      throw new HttpsError('invalid-argument', 'photoId required');
+    }
+
+    const db = getFirestore();
+    const photoRef = db.collection('menuPhotos').doc(photoId);
+    const photoSnap = await photoRef.get();
+    if (!photoSnap.exists) {
+      throw new HttpsError('not-found', 'Photo not found');
+    }
+
+    await photoRef.update({
+      status: 'rejected',
+      rejectionReason: reason || '',
+      reviewedBy: auth.uid,
+      reviewedAt: FieldValue.serverTimestamp(),
+    });
+
+    return { success: true };
+  },
+);
+
+export const deleteMenuPhoto = onCall(
+  { enforceAppCheck: !IS_EMULATOR, timeoutSeconds: 60 },
+  async (request) => {
+    const { auth } = request;
+    if (!auth?.token.email_verified || auth.token.email !== ADMIN_EMAIL) {
+      throw new HttpsError('permission-denied', 'Admin only');
+    }
+
+    const { photoId } = request.data;
+    if (!photoId || typeof photoId !== 'string') {
+      throw new HttpsError('invalid-argument', 'photoId required');
+    }
+
+    const db = getFirestore();
+    const photoRef = db.collection('menuPhotos').doc(photoId);
+    const photoSnap = await photoRef.get();
+    if (!photoSnap.exists) {
+      throw new HttpsError('not-found', 'Photo not found');
+    }
+
+    const data = photoSnap.data()!;
+
+    // Delete files from Storage
+    const bucket = getStorage().bucket();
+    const filesToDelete = [data.storagePath, data.thumbnailPath].filter(Boolean);
+    await Promise.allSettled(
+      filesToDelete.map((path: string) => bucket.file(path).delete().catch(() => {})),
+    );
+
+    // Delete Firestore doc
+    await photoRef.delete();
+    return { success: true };
+  },
+);
+
+/**
+ * Any authenticated user can report an approved photo (once per user).
+ * Increments reportCount. Uses a subcollection to prevent duplicate reports.
+ */
+export const reportMenuPhoto = onCall(
+  { enforceAppCheck: !IS_EMULATOR, timeoutSeconds: 30 },
+  async (request) => {
+    const { auth } = request;
+    if (!auth) {
+      throw new HttpsError('unauthenticated', 'Must be signed in');
+    }
+
+    const { photoId } = request.data;
+    if (!photoId || typeof photoId !== 'string') {
+      throw new HttpsError('invalid-argument', 'photoId required');
+    }
+
+    const db = getFirestore();
+    const photoRef = db.collection('menuPhotos').doc(photoId);
+    const photoSnap = await photoRef.get();
+    if (!photoSnap.exists) {
+      throw new HttpsError('not-found', 'Photo not found');
+    }
+
+    const data = photoSnap.data()!;
+    if (data.status !== 'approved') {
+      throw new HttpsError('failed-precondition', 'Only approved photos can be reported');
+    }
+
+    // Prevent duplicate reports using a subcollection
+    const reportRef = photoRef.collection('reports').doc(auth.uid);
+    const reportSnap = await reportRef.get();
+    if (reportSnap.exists) {
+      throw new HttpsError('already-exists', 'Ya reportaste esta foto');
+    }
+
+    await reportRef.set({ createdAt: FieldValue.serverTimestamp() });
+    await photoRef.update({ reportCount: FieldValue.increment(1) });
+
+    return { success: true };
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,9 +12,13 @@ export { onFeedbackCreated } from './triggers/feedback';
 export { onRatingWritten } from './triggers/ratings';
 export { onFavoriteCreated, onFavoriteDeleted } from './triggers/favorites';
 export { onUserCreated } from './triggers/users';
+export { onMenuPhotoCreated } from './triggers/menuPhotos';
+export { onPriceLevelCreated, onPriceLevelUpdated } from './triggers/priceLevels';
 
 // Scheduled
 export { dailyMetrics } from './scheduled/dailyMetrics';
+export { cleanupRejectedPhotos } from './scheduled/cleanupPhotos';
 
 // Admin
 export { createBackup, listBackups, restoreBackup, deleteBackup } from './admin/backups';
+export { approveMenuPhoto, rejectMenuPhoto, deleteMenuPhoto, reportMenuPhoto } from './admin/menuPhotos';

--- a/functions/src/scheduled/cleanupPhotos.ts
+++ b/functions/src/scheduled/cleanupPhotos.ts
@@ -1,0 +1,31 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
+
+export const cleanupRejectedPhotos = onSchedule(
+  { schedule: '0 4 * * *', timeZone: 'America/Argentina/Buenos_Aires' },
+  async () => {
+    const db = getFirestore();
+    const bucket = getStorage().bucket();
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const rejected = await db.collection('menuPhotos')
+      .where('status', '==', 'rejected')
+      .where('reviewedAt', '<', sevenDaysAgo)
+      .get();
+
+    for (const doc of rejected.docs) {
+      const data = doc.data();
+      try {
+        await bucket.file(data.storagePath).delete();
+        if (data.thumbnailPath) {
+          await bucket.file(data.thumbnailPath).delete();
+        }
+      } catch { /* file may not exist */ }
+      await doc.ref.delete();
+    }
+
+    console.log(`Cleaned up ${rejected.size} rejected photos`);
+  },
+);

--- a/functions/src/triggers/menuPhotos.ts
+++ b/functions/src/triggers/menuPhotos.ts
@@ -1,0 +1,43 @@
+import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+import { getStorage } from 'firebase-admin/storage';
+import { getFirestore } from 'firebase-admin/firestore';
+import sharp from 'sharp';
+import { incrementCounter, trackWrite } from '../utils/counters';
+
+export const onMenuPhotoCreated = onDocumentCreated(
+  'menuPhotos/{photoId}',
+  async (event) => {
+    const snap = event.data;
+    if (!snap) return;
+    const data = snap.data();
+    const photoId = event.params.photoId;
+    const db = getFirestore();
+
+    // Generate thumbnail
+    try {
+      const bucket = getStorage().bucket();
+      const originalFile = bucket.file(data.storagePath);
+      const [buffer] = await originalFile.download();
+
+      const thumbBuffer = await sharp(buffer)
+        .resize(400)
+        .jpeg({ quality: 80 })
+        .toBuffer();
+
+      const thumbPath = `menus/${data.businessId}/${photoId}_thumb.jpg`;
+      const thumbFile = bucket.file(thumbPath);
+      await thumbFile.save(thumbBuffer, {
+        metadata: { contentType: 'image/jpeg' },
+      });
+
+      // Update doc with thumbnail path
+      await snap.ref.update({ thumbnailPath: thumbPath });
+    } catch (err) {
+      console.error('Failed to generate thumbnail:', err);
+    }
+
+    // Counters
+    await incrementCounter(db, 'menuPhotos', 1);
+    await trackWrite(db, 'menuPhotos');
+  },
+);

--- a/functions/src/triggers/priceLevels.ts
+++ b/functions/src/triggers/priceLevels.ts
@@ -1,0 +1,20 @@
+import { onDocumentCreated, onDocumentUpdated } from 'firebase-functions/v2/firestore';
+import { getFirestore } from 'firebase-admin/firestore';
+import { incrementCounter, trackWrite } from '../utils/counters';
+
+export const onPriceLevelCreated = onDocumentCreated(
+  'priceLevels/{docId}',
+  async () => {
+    const db = getFirestore();
+    await incrementCounter(db, 'priceLevels', 1);
+    await trackWrite(db, 'priceLevels');
+  },
+);
+
+export const onPriceLevelUpdated = onDocumentUpdated(
+  'priceLevels/{docId}',
+  async () => {
+    const db = getFirestore();
+    await trackWrite(db, 'priceLevels');
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modo-mapa",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modo-mapa",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -15,6 +15,7 @@
         "@sentry/react": "^10.43.0",
         "@sentry/vite-plugin": "^5.1.1",
         "@vis.gl/react-google-maps": "^1.7.1",
+        "browser-image-compression": "^2.0.2",
         "firebase": "^12.10.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -5551,6 +5552,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -11183,6 +11193,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "modo-mapa",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:full": "firebase emulators:exec --only auth,firestore,functions 'npm run dev'",
-    "emulators": "firebase emulators:start --only auth,firestore,functions",
+    "dev:full": "firebase emulators:exec --only auth,firestore,functions,storage 'npm run dev'",
+    "emulators": "firebase emulators:start --only auth,firestore,functions,storage",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -29,6 +29,7 @@
     "@sentry/react": "^10.43.0",
     "@sentry/vite-plugin": "^5.1.1",
     "@vis.gl/react-google-maps": "^1.7.1",
+    "browser-image-compression": "^2.0.2",
     "firebase": "^12.10.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+#
+# Dev environment manager for modo-mapa.
+# Manages Firebase emulators, Vite dev server, and seed data.
+#
+# Usage:
+#   ./scripts/dev-env.sh status    — Check what's running
+#   ./scripts/dev-env.sh start     — Start emulators + Vite (if not already running)
+#   ./scripts/dev-env.sh stop      — Stop emulators + Vite
+#   ./scripts/dev-env.sh restart   — Stop + Start
+#   ./scripts/dev-env.sh seed      — Seed test data (emulators must be running)
+#   ./scripts/dev-env.sh health    — Full health check (ports, auth, firestore, storage)
+#   ./scripts/dev-env.sh logs      — Show emulator logs (last 50 lines)
+#
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Ports used by the dev environment
+PORT_VITE=5173
+PORT_FIRESTORE=8080
+PORT_AUTH=9099
+PORT_STORAGE=9199
+PORT_FUNCTIONS=5001
+PORT_EMULATOR_UI=4000
+
+ALL_EMULATOR_PORTS="$PORT_FIRESTORE $PORT_AUTH $PORT_STORAGE $PORT_FUNCTIONS $PORT_EMULATOR_UI"
+ALL_PORTS="$PORT_VITE $ALL_EMULATOR_PORTS"
+
+LOG_DIR="$PROJECT_ROOT/.dev-logs"
+EMULATOR_LOG="$LOG_DIR/emulators.log"
+VITE_LOG="$LOG_DIR/vite.log"
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+_color() {
+  local color="$1"; shift
+  case "$color" in
+    red)    echo -e "\033[31m$*\033[0m" ;;
+    green)  echo -e "\033[32m$*\033[0m" ;;
+    yellow) echo -e "\033[33m$*\033[0m" ;;
+    cyan)   echo -e "\033[36m$*\033[0m" ;;
+    *)      echo "$*" ;;
+  esac
+}
+
+_port_pid() {
+  lsof -ti :"$1" 2>/dev/null | head -1
+}
+
+_port_is_up() {
+  lsof -ti :"$1" >/dev/null 2>&1
+}
+
+_wait_for_port() {
+  local port="$1" label="$2" timeout="${3:-30}"
+  local elapsed=0
+  while ! _port_is_up "$port"; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+    if [ "$elapsed" -ge "$timeout" ]; then
+      _color red "  TIMEOUT: $label (port $port) did not start after ${timeout}s"
+      return 1
+    fi
+  done
+  _color green "  OK: $label (port $port) — ${elapsed}s"
+}
+
+# ── Commands ─────────────────────────────────────────────────────────────
+
+cmd_status() {
+  echo ""
+  _color cyan "=== Dev Environment Status ==="
+  echo ""
+
+  local all_up=true
+  for pair in \
+    "$PORT_VITE:Vite" \
+    "$PORT_AUTH:Auth Emulator" \
+    "$PORT_FIRESTORE:Firestore Emulator" \
+    "$PORT_STORAGE:Storage Emulator" \
+    "$PORT_FUNCTIONS:Functions Emulator" \
+    "$PORT_EMULATOR_UI:Emulator UI"; do
+
+    local port="${pair%%:*}"
+    local label="${pair#*:}"
+    local pid
+    pid=$(_port_pid "$port")
+    if [ -n "$pid" ]; then
+      _color green "  UP   $label (port $port, pid $pid)"
+    else
+      _color red   "  DOWN $label (port $port)"
+      all_up=false
+    fi
+  done
+
+  echo ""
+  if $all_up; then
+    _color green "All services running."
+    echo "  App:          http://localhost:$PORT_VITE"
+    echo "  Emulator UI:  http://localhost:$PORT_EMULATOR_UI"
+    echo "  Admin:        http://localhost:$PORT_VITE/admin"
+  else
+    _color yellow "Some services are down. Run: ./scripts/dev-env.sh start"
+  fi
+  echo ""
+}
+
+cmd_stop() {
+  _color cyan "Stopping dev environment..."
+
+  # Kill Vite
+  local vite_pid
+  vite_pid=$(_port_pid "$PORT_VITE")
+  if [ -n "$vite_pid" ]; then
+    kill "$vite_pid" 2>/dev/null || true
+    _color yellow "  Killed Vite (pid $vite_pid)"
+  fi
+
+  # Kill emulators — find the java process that owns the emulator ports
+  for port in $ALL_EMULATOR_PORTS; do
+    local pid
+    pid=$(_port_pid "$port")
+    if [ -n "$pid" ]; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+
+  # Wait a moment for ports to free
+  sleep 2
+
+  # Verify
+  local still_running=false
+  for port in $ALL_PORTS; do
+    if _port_is_up "$port"; then
+      local pid
+      pid=$(_port_pid "$port")
+      _color red "  Port $port still in use (pid $pid) — force killing"
+      kill -9 "$pid" 2>/dev/null || true
+      still_running=true
+    fi
+  done
+
+  if $still_running; then
+    sleep 1
+  fi
+
+  _color green "  Dev environment stopped."
+}
+
+cmd_start() {
+  mkdir -p "$LOG_DIR"
+
+  # Check if already running
+  local emulators_up=true
+  for port in $PORT_AUTH $PORT_FIRESTORE $PORT_STORAGE $PORT_FUNCTIONS; do
+    if ! _port_is_up "$port"; then
+      emulators_up=false
+      break
+    fi
+  done
+
+  if $emulators_up; then
+    _color green "Emulators already running."
+  else
+    # Kill any partial emulator state
+    for port in $ALL_EMULATOR_PORTS; do
+      local pid
+      pid=$(_port_pid "$port")
+      if [ -n "$pid" ]; then
+        kill "$pid" 2>/dev/null || true
+      fi
+    done
+    sleep 2
+
+    _color cyan "Starting Firebase emulators..."
+
+    # Build functions first
+    if [ -f functions/package.json ]; then
+      _color yellow "  Building Cloud Functions..."
+      (cd functions && npm run build) >> "$EMULATOR_LOG" 2>&1
+    fi
+
+    npx firebase emulators:start --only auth,firestore,functions,storage \
+      >> "$EMULATOR_LOG" 2>&1 &
+
+    echo ""
+    _color yellow "Waiting for emulators..."
+    _wait_for_port "$PORT_AUTH"      "Auth"      30
+    _wait_for_port "$PORT_FIRESTORE" "Firestore" 30
+    _wait_for_port "$PORT_STORAGE"   "Storage"   30
+    _wait_for_port "$PORT_FUNCTIONS" "Functions"  30
+    echo ""
+
+    # Auto-seed on fresh emulator start
+    _color cyan "Seeding test data..."
+    node scripts/seed-admin-data.mjs 2>&1 | tail -5
+    echo ""
+  fi
+
+  # Vite
+  if _port_is_up "$PORT_VITE"; then
+    _color green "Vite already running."
+  else
+    _color cyan "Starting Vite dev server..."
+    npx vite --host >> "$VITE_LOG" 2>&1 &
+    _wait_for_port "$PORT_VITE" "Vite" 15
+  fi
+
+  echo ""
+  _color green "Dev environment ready!"
+  echo "  App:          http://localhost:$PORT_VITE"
+  echo "  Emulator UI:  http://localhost:$PORT_EMULATOR_UI"
+  echo "  Admin:        http://localhost:$PORT_VITE/admin"
+  echo ""
+}
+
+cmd_seed() {
+  # Verify Firestore emulator is running
+  if ! _port_is_up "$PORT_FIRESTORE"; then
+    _color red "Firestore emulator is not running. Start it first: ./scripts/dev-env.sh start"
+    exit 1
+  fi
+
+  _color cyan "Seeding test data..."
+  node scripts/seed-admin-data.mjs
+  echo ""
+  _color green "Seed complete!"
+}
+
+cmd_health() {
+  echo ""
+  _color cyan "=== Health Check ==="
+  echo ""
+
+  local ok=true
+
+  # 1. Port checks
+  _color yellow "1. Port availability:"
+  for pair in \
+    "$PORT_VITE:Vite" \
+    "$PORT_AUTH:Auth" \
+    "$PORT_FIRESTORE:Firestore" \
+    "$PORT_STORAGE:Storage" \
+    "$PORT_FUNCTIONS:Functions"; do
+
+    local port="${pair%%:*}"
+    local label="${pair#*:}"
+    if _port_is_up "$port"; then
+      _color green "   OK: $label (port $port)"
+    else
+      _color red "   FAIL: $label (port $port)"
+      ok=false
+    fi
+  done
+
+  # 2. Auth emulator responds
+  echo ""
+  _color yellow "2. Auth emulator HTTP check:"
+  if curl -sf "http://localhost:$PORT_AUTH/" >/dev/null 2>&1; then
+    _color green "   OK: Auth emulator responds"
+  else
+    _color red "   FAIL: Auth emulator not responding"
+    ok=false
+  fi
+
+  # 3. Firestore emulator responds
+  _color yellow "3. Firestore emulator HTTP check:"
+  if curl -sf "http://localhost:$PORT_FIRESTORE/" >/dev/null 2>&1; then
+    _color green "   OK: Firestore emulator responds"
+  else
+    _color red "   FAIL: Firestore emulator not responding"
+    ok=false
+  fi
+
+  # 4. Storage emulator responds
+  _color yellow "4. Storage emulator HTTP check:"
+  if curl -sf "http://localhost:$PORT_STORAGE/" >/dev/null 2>&1; then
+    _color green "   OK: Storage emulator responds"
+  else
+    _color red "   FAIL: Storage emulator not responding"
+    ok=false
+  fi
+
+  # 5. Vite responds
+  _color yellow "5. Vite dev server HTTP check:"
+  if curl -sf "http://localhost:$PORT_VITE/" >/dev/null 2>&1; then
+    _color green "   OK: Vite responds"
+  else
+    _color red "   FAIL: Vite not responding"
+    ok=false
+  fi
+
+  # 6. Check if seed data exists
+  echo ""
+  _color yellow "6. Seed data check (config/counters doc):"
+  local counters_check
+  counters_check=$(curl -sf "http://localhost:$PORT_FIRESTORE/emulator/v1/projects/modo-mapa-app/databases/(default)/documents/config/counters" 2>/dev/null || echo "FAIL")
+  if echo "$counters_check" | grep -q "fields"; then
+    _color green "   OK: Seed data found"
+  else
+    _color yellow "   WARN: No seed data. Run: ./scripts/dev-env.sh seed"
+  fi
+
+  echo ""
+  if $ok; then
+    _color green "All checks passed!"
+  else
+    _color red "Some checks failed. Review above."
+  fi
+  echo ""
+}
+
+cmd_logs() {
+  local lines="${1:-50}"
+  if [ -f "$EMULATOR_LOG" ]; then
+    _color cyan "=== Emulator Logs (last $lines lines) ==="
+    tail -n "$lines" "$EMULATOR_LOG"
+  else
+    _color yellow "No emulator log file found."
+  fi
+  echo ""
+  if [ -f "$VITE_LOG" ]; then
+    _color cyan "=== Vite Logs (last $lines lines) ==="
+    tail -n "$lines" "$VITE_LOG"
+  else
+    _color yellow "No Vite log file found."
+  fi
+}
+
+cmd_restart() {
+  cmd_stop
+  cmd_start
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+case "${1:-help}" in
+  status)  cmd_status ;;
+  start)   cmd_start ;;
+  stop)    cmd_stop ;;
+  restart) cmd_restart ;;
+  seed)    cmd_seed ;;
+  health)  cmd_health ;;
+  logs)    cmd_logs "${2:-50}" ;;
+  *)
+    echo "Usage: $0 {status|start|stop|restart|seed|health|logs [lines]}"
+    exit 1
+    ;;
+esac

--- a/scripts/seed-admin-data.mjs
+++ b/scripts/seed-admin-data.mjs
@@ -314,6 +314,55 @@ async function seed() {
     });
   }
 
+  // 12. PriceLevels
+  console.log('Creating price levels...');
+  const plPairs = new Set();
+  for (let i = 0; i < 35; i++) {
+    const userId = randomFrom(USER_IDS);
+    const businessId = randomFrom(BUSINESS_IDS);
+    const key = `${userId}__${businessId}`;
+    if (plPairs.has(key)) continue;
+    plPairs.add(key);
+    const now = daysAgo(randomInt(0, 20));
+    await setDoc(doc(db, 'priceLevels', key), {
+      userId,
+      businessId,
+      level: randomInt(1, 3),
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  // 13. MenuPhotos (pending, approved, rejected)
+  console.log('Creating menu photos...');
+  const statuses = ['pending', 'pending', 'approved', 'approved', 'rejected'];
+  for (let i = 0; i < 5; i++) {
+    const status = statuses[i];
+    const data = {
+      userId: randomFrom(USER_IDS),
+      businessId: BUSINESS_IDS[i],
+      storagePath: `menus/${BUSINESS_IDS[i]}/seed_${i}_original`,
+      thumbnailPath: `menus/${BUSINESS_IDS[i]}/seed_${i}_thumb.jpg`,
+      status,
+      createdAt: daysAgo(randomInt(1, 15)),
+      reportCount: 0,
+    };
+    if (status === 'approved' || status === 'rejected') {
+      data.reviewedBy = 'admin_seed';
+      data.reviewedAt = daysAgo(randomInt(0, 5));
+    }
+    if (status === 'rejected') {
+      data.rejectionReason = 'Foto borrosa o de baja calidad';
+    }
+    await addDoc(collection(db, 'menuPhotos'), data);
+  }
+
+  // Update counters with new collections
+  await db.doc('config/counters').set({
+    priceLevels: plPairs.size,
+    menuPhotos: 5,
+  }, { merge: true });
+
   console.log('\n✅ Seed complete!');
   console.log('- 10 users');
   console.log('- ~60 comments (4 flagged, ~6 edited, with likeCount)');
@@ -325,6 +374,8 @@ async function seed() {
   console.log('- 8 feedback (1 flagged)');
   console.log('- 15 days of daily metrics');
   console.log('- 12 abuse logs');
+  console.log(`- ${plPairs.size} price levels`);
+  console.log('- 5 menu photos (2 pending, 2 approved, 1 rejected)');
   console.log('- Counters and moderation config');
   console.log('\nOpen http://localhost:4000 to see data in Emulator UI');
   console.log('Open http://localhost:5173/admin to see the dashboard');

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -15,6 +15,7 @@ import FeedbackList from './FeedbackList';
 import TrendsPanel from './TrendsPanel';
 import UsersPanel from './UsersPanel';
 import BackupsPanel from './BackupsPanel';
+import PhotoReviewPanel from './PhotoReviewPanel';
 
 export default function AdminLayout() {
   const [tab, setTab] = useState(0);
@@ -41,6 +42,7 @@ export default function AdminLayout() {
         <Tab label="Firebase Usage" />
         <Tab label="Alertas" />
         <Tab label="Backups" />
+        <Tab label="Fotos" />
       </Tabs>
       <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
         {tab === 0 && <DashboardOverview />}
@@ -51,6 +53,7 @@ export default function AdminLayout() {
         {tab === 5 && <FirebaseUsage />}
         {tab === 6 && <AbuseAlerts />}
         {tab === 7 && <BackupsPanel />}
+        {tab === 8 && <PhotoReviewPanel />}
       </Box>
     </Box>
   );

--- a/src/components/admin/PhotoReviewCard.tsx
+++ b/src/components/admin/PhotoReviewCard.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect } from 'react';
+import { Card, CardMedia, CardContent, CardActions, Typography, Button, TextField, Box, Chip } from '@mui/material';
+import ReportIcon from '@mui/icons-material/Report';
+import { ref, getDownloadURL } from 'firebase/storage';
+import { httpsCallable } from 'firebase/functions';
+import { storage, functions } from '../../config/firebase';
+import { allBusinesses } from '../../hooks/useBusinesses';
+import { formatDateShort } from '../../utils/formatDate';
+import type { MenuPhoto } from '../../types';
+
+const STATUS_CHIP: Record<string, { label: string; color: 'warning' | 'success' | 'error' }> = {
+  pending: { label: 'Pendiente', color: 'warning' },
+  approved: { label: 'Aprobada', color: 'success' },
+  rejected: { label: 'Rechazada', color: 'error' },
+};
+
+interface Props {
+  photo: MenuPhoto;
+  onAction: () => void;
+}
+
+export default function PhotoReviewCard({ photo, onAction }: Props) {
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [rejecting, setRejecting] = useState(false);
+  const [reason, setReason] = useState('');
+
+  const businessName = allBusinesses.find((b) => b.id === photo.businessId)?.name ?? photo.businessId;
+  const chipInfo = STATUS_CHIP[photo.status] ?? { label: photo.status, color: 'default' as const };
+
+  useEffect(() => {
+    const path = photo.thumbnailPath || photo.storagePath;
+    if (!path) return;
+    getDownloadURL(ref(storage, path))
+      .then(setImageUrl)
+      .catch(() => setImageUrl(null));
+  }, [photo]);
+
+  const handleApprove = async () => {
+    setLoading(true);
+    try {
+      const approve = httpsCallable(functions, 'approveMenuPhoto');
+      await approve({ photoId: photo.id });
+      onAction();
+    } catch (err) {
+      console.error('Error approving photo:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReject = async () => {
+    setLoading(true);
+    try {
+      const reject = httpsCallable(functions, 'rejectMenuPhoto');
+      await reject({ photoId: photo.id, reason });
+      onAction();
+    } catch (err) {
+      console.error('Error rejecting photo:', err);
+    } finally {
+      setLoading(false);
+      setRejecting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setLoading(true);
+    try {
+      const del = httpsCallable(functions, 'deleteMenuPhoto');
+      await del({ photoId: photo.id });
+      onAction();
+    } catch (err) {
+      console.error('Error deleting photo:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderActions = () => {
+    if (rejecting) {
+      return (
+        <Box sx={{ width: '100%', px: 1, pb: 1 }}>
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Motivo de rechazo"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            sx={{ mb: 1 }}
+          />
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button size="small" onClick={() => setRejecting(false)} disabled={loading}>
+              Cancelar
+            </Button>
+            <Button size="small" color="error" variant="contained" onClick={handleReject} disabled={loading}>
+              Confirmar rechazo
+            </Button>
+          </Box>
+        </Box>
+      );
+    }
+
+    switch (photo.status) {
+      case 'pending':
+        return (
+          <>
+            <Button size="small" color="success" variant="contained" onClick={handleApprove} disabled={loading}>
+              Aprobar
+            </Button>
+            <Button size="small" color="error" onClick={() => setRejecting(true)} disabled={loading}>
+              Rechazar
+            </Button>
+          </>
+        );
+      case 'rejected':
+        return (
+          <>
+            <Button size="small" color="success" variant="contained" onClick={handleApprove} disabled={loading}>
+              Aprobar
+            </Button>
+            <Button size="small" color="error" onClick={handleDelete} disabled={loading}>
+              Eliminar
+            </Button>
+          </>
+        );
+      case 'approved':
+        return (
+          <>
+            <Button size="small" color="error" onClick={() => setRejecting(true)} disabled={loading}>
+              Rechazar
+            </Button>
+            <Button size="small" color="error" variant="outlined" onClick={handleDelete} disabled={loading}>
+              Eliminar
+            </Button>
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Card sx={{ maxWidth: 345 }}>
+      {imageUrl && (
+        <CardMedia
+          component="img"
+          height="200"
+          image={imageUrl}
+          alt={`Menú de ${businessName}`}
+          sx={{ objectFit: 'cover' }}
+        />
+      )}
+      <CardContent sx={{ pb: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+          <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>{businessName}</Typography>
+          <Chip label={chipInfo.label} color={chipInfo.color} size="small" />
+        </Box>
+        <Typography variant="caption" color="text.secondary" display="block">
+          {`Usuario: ${photo.userId.slice(0, 8)}...`}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" display="block">
+          {`Subida: ${formatDateShort(photo.createdAt)}`}
+        </Typography>
+        {photo.reviewedAt && (
+          <Typography variant="caption" color="text.secondary" display="block">
+            {`Revisada: ${formatDateShort(photo.reviewedAt)}`}
+          </Typography>
+        )}
+        {photo.rejectionReason && (
+          <Typography variant="caption" color="error" display="block">
+            {`Motivo: ${photo.rejectionReason}`}
+          </Typography>
+        )}
+        {photo.reportCount > 0 && (
+          <Chip
+            icon={<ReportIcon />}
+            label={`${photo.reportCount} reporte${photo.reportCount > 1 ? 's' : ''}`}
+            color="warning"
+            size="small"
+            sx={{ mt: 0.5 }}
+          />
+        )}
+      </CardContent>
+      <CardActions>
+        {renderActions()}
+      </CardActions>
+    </Card>
+  );
+}

--- a/src/components/admin/PhotoReviewPanel.tsx
+++ b/src/components/admin/PhotoReviewPanel.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { fetchAllPhotos } from '../../services/admin';
+import { useAsyncData } from '../../hooks/useAsyncData';
+import type { MenuPhoto, MenuPhotoStatus } from '../../types';
+import AdminPanelWrapper from './AdminPanelWrapper';
+import PhotoReviewCard from './PhotoReviewCard';
+
+type StatusFilter = 'all' | MenuPhotoStatus;
+
+const STATUS_LABELS: Record<StatusFilter, string> = {
+  all: 'Todas',
+  pending: 'Pendientes',
+  approved: 'Aprobadas',
+  rejected: 'Rechazadas',
+};
+
+export default function PhotoReviewPanel() {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [filter, setFilter] = useState<StatusFilter>('all');
+  const fetcher = useCallback(() => fetchAllPhotos(), [refreshKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  const { data: photos, loading, error } = useAsyncData<MenuPhoto[]>(fetcher);
+
+  const handleRefresh = () => setRefreshKey((k) => k + 1);
+
+  const filtered = useMemo(() => {
+    if (!photos) return [];
+    if (filter === 'all') return photos;
+    return photos.filter((p) => p.status === filter);
+  }, [photos, filter]);
+
+  const counts = useMemo(() => {
+    if (!photos) return { all: 0, pending: 0, approved: 0, rejected: 0 };
+    return {
+      all: photos.length,
+      pending: photos.filter((p) => p.status === 'pending').length,
+      approved: photos.filter((p) => p.status === 'approved').length,
+      rejected: photos.filter((p) => p.status === 'rejected').length,
+    };
+  }, [photos]);
+
+  return (
+    <AdminPanelWrapper loading={loading} error={error} errorMessage="Error cargando fotos.">
+      <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography variant="h6">
+          {`Fotos (${filtered.length})`}
+        </Typography>
+        <Button startIcon={<RefreshIcon />} onClick={handleRefresh} size="small">
+          Refrescar
+        </Button>
+      </Box>
+      <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
+        {(Object.keys(STATUS_LABELS) as StatusFilter[]).map((status) => (
+          <Chip
+            key={status}
+            label={`${STATUS_LABELS[status]} (${counts[status]})`}
+            color={filter === status ? 'primary' : 'default'}
+            variant={filter === status ? 'filled' : 'outlined'}
+            onClick={() => setFilter(status)}
+          />
+        ))}
+      </Box>
+      {filtered.length === 0 && (
+        <Typography color="text.secondary">No hay fotos en esta categoría.</Typography>
+      )}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+        {filtered.map((photo) => (
+          <PhotoReviewCard key={photo.id} photo={photo} onAction={handleRefresh} />
+        ))}
+      </Box>
+    </AdminPanelWrapper>
+  );
+}

--- a/src/components/business/BusinessPriceLevel.tsx
+++ b/src/components/business/BusinessPriceLevel.tsx
@@ -1,0 +1,100 @@
+import { useMemo, useState, memo } from 'react';
+import { Box, Typography, Button } from '@mui/material';
+import { useAuth } from '../../context/AuthContext';
+import { upsertPriceLevel } from '../../services/priceLevels';
+import { PRICE_LEVEL_LABELS } from '../../types';
+import type { PriceLevel } from '../../types';
+
+interface Props {
+  businessId: string;
+  priceLevels: PriceLevel[];
+  isLoading: boolean;
+  onPriceLevelChange: () => void;
+}
+
+const LEVELS = [1, 2, 3] as const;
+const LEVEL_SYMBOLS: Record<number, string> = { 1: '$', 2: '$$', 3: '$$$' };
+
+export default memo(function BusinessPriceLevel({ businessId, priceLevels, isLoading, onPriceLevelChange }: Props) {
+  const { user } = useAuth();
+
+  const { averageLevel, totalVotes, serverMyLevel } = useMemo(() => {
+    let sum = 0;
+    let myLevel: number | null = null;
+    for (const pl of priceLevels) {
+      sum += pl.level;
+      if (user && pl.userId === user.uid) {
+        myLevel = pl.level;
+      }
+    }
+    return {
+      averageLevel: priceLevels.length > 0 ? Math.round(sum / priceLevels.length) : 0,
+      totalVotes: priceLevels.length,
+      serverMyLevel: myLevel,
+    };
+  }, [priceLevels, user]);
+
+  const [pendingLevel, setPendingLevel] = useState<number | null>(null);
+  const myLevel = pendingLevel ?? serverMyLevel;
+
+  const handleVote = async (level: number) => {
+    if (!user) return;
+    setPendingLevel(level);
+    try {
+      await upsertPriceLevel(user.uid, businessId, level);
+      onPriceLevelChange();
+    } catch {
+      // Revert optimistic update on failure
+      setPendingLevel(null);
+    }
+  };
+
+  if (!isLoading && priceLevels.length === 0 && !user) {
+    return (
+      <Box sx={{ py: 1 }}>
+        <Typography variant="body2" color="text.secondary">Sin votos de nivel de gasto</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ py: 1 }}>
+      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>Nivel de gasto</Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+        {averageLevel > 0 ? (
+          <>
+            <Typography variant="h6" sx={{ fontWeight: 600, fontSize: '1.1rem' }}>
+              {LEVEL_SYMBOLS[averageLevel]}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {PRICE_LEVEL_LABELS[averageLevel]}
+            </Typography>
+          </>
+        ) : (
+          <Typography variant="body2" color="text.secondary">{'\u2014'}</Typography>
+        )}
+        <Typography variant="body2">
+          ({totalVotes} {totalVotes === 1 ? 'voto' : 'votos'})
+        </Typography>
+      </Box>
+      {user && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+            Tu voto:
+          </Typography>
+          {LEVELS.map((level) => (
+            <Button
+              key={level}
+              size="small"
+              variant={myLevel === level ? 'contained' : 'outlined'}
+              onClick={() => handleVote(level)}
+              sx={{ minWidth: 'auto', px: 1.5 }}
+            >
+              {LEVEL_SYMBOLS[level]}
+            </Button>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+});

--- a/src/components/business/BusinessSheet.tsx
+++ b/src/components/business/BusinessSheet.tsx
@@ -1,9 +1,13 @@
+import { useEffect } from 'react';
 import { SwipeableDrawer, Box, Divider } from '@mui/material';
 import { useMapContext } from '../../context/MapContext';
 import { useBusinessData } from '../../hooks/useBusinessData';
+import { useVisitHistory } from '../../hooks/useVisitHistory';
 import BusinessHeader from './BusinessHeader';
 import BusinessRating from './BusinessRating';
+import BusinessPriceLevel from './BusinessPriceLevel';
 import BusinessTags from './BusinessTags';
+import MenuPhotoSection from './MenuPhotoSection';
 import BusinessComments from './BusinessComments';
 import FavoriteButton from './FavoriteButton';
 import ShareButton from './ShareButton';
@@ -13,6 +17,13 @@ export default function BusinessSheet() {
   const isOpen = selectedBusiness !== null;
   const businessId = selectedBusiness?.id ?? null;
   const data = useBusinessData(businessId);
+  const { recordVisit } = useVisitHistory();
+
+  useEffect(() => {
+    if (selectedBusiness) {
+      recordVisit(selectedBusiness.id);
+    }
+  }, [selectedBusiness, recordVisit]);
 
   const handleClose = () => setSelectedBusiness(null);
   const handleOpen = () => {};
@@ -70,6 +81,14 @@ export default function BusinessSheet() {
               onRatingChange={() => data.refetch('ratings')}
             />
             <Divider sx={{ my: 1.5 }} />
+            <BusinessPriceLevel
+              key={selectedBusiness.id}
+              businessId={selectedBusiness.id}
+              priceLevels={data.priceLevels}
+              isLoading={data.isLoading}
+              onPriceLevelChange={() => data.refetch('priceLevels')}
+            />
+            <Divider sx={{ my: 1.5 }} />
             <BusinessTags
               businessId={selectedBusiness.id}
               seedTags={selectedBusiness.tags}
@@ -77,6 +96,13 @@ export default function BusinessSheet() {
               customTags={data.customTags}
               isLoading={data.isLoading}
               onTagsChange={() => data.refetch('userTags')}
+            />
+            <Divider sx={{ my: 1.5 }} />
+            <MenuPhotoSection
+              menuPhoto={data.menuPhoto}
+              businessId={selectedBusiness.id}
+              isLoading={data.isLoading}
+              onPhotoChange={() => data.refetch('menuPhotos')}
             />
             <Divider sx={{ my: 1.5 }} />
             <BusinessComments

--- a/src/components/business/MenuPhotoSection.tsx
+++ b/src/components/business/MenuPhotoSection.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from 'react';
+import { Box, Typography, Button, Chip } from '@mui/material';
+import CameraAltIcon from '@mui/icons-material/CameraAlt';
+import { ref, getDownloadURL } from 'firebase/storage';
+import { storage } from '../../config/firebase';
+import { useAuth } from '../../context/AuthContext';
+import { getUserPendingPhotos } from '../../services/menuPhotos';
+import { formatDateMedium } from '../../utils/formatDate';
+import MenuPhotoUpload from './MenuPhotoUpload';
+import MenuPhotoViewer from './MenuPhotoViewer';
+import type { MenuPhoto } from '../../types';
+
+interface Props {
+  menuPhoto: MenuPhoto | null;
+  businessId: string;
+  isLoading: boolean;
+  onPhotoChange: () => void;
+}
+
+const SIX_MONTHS_MS = 6 * 30 * 24 * 60 * 60 * 1000;
+
+export default function MenuPhotoSection({ menuPhoto, businessId, isLoading, onPhotoChange }: Props) {
+  const { user } = useAuth();
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [photoUrl, setPhotoUrl] = useState<string | null>(null);
+  const [hasPending, setHasPending] = useState(false);
+
+  // Load photo URL from Storage
+  useEffect(() => {
+    if (!menuPhoto) {
+      setPhotoUrl(null); // eslint-disable-line react-hooks/set-state-in-effect -- guard clause
+      return;
+    }
+    const path = menuPhoto.thumbnailPath || menuPhoto.storagePath;
+    if (!path) return;
+    getDownloadURL(ref(storage, path))
+      .then(setPhotoUrl)
+      .catch(() => setPhotoUrl(null));
+  }, [menuPhoto]);
+
+  // Check if user has pending photos
+  useEffect(() => {
+    if (!user) {
+      setHasPending(false); // eslint-disable-line react-hooks/set-state-in-effect -- guard clause
+      return;
+    }
+    getUserPendingPhotos(user.uid, businessId)
+      .then((photos) => setHasPending(photos.length > 0))
+      .catch(() => setHasPending(false));
+  }, [user, businessId]);
+
+  // Staleness is based on reviewedAt which is stable per photo — safe to derive
+  const isStale = menuPhoto?.reviewedAt
+    ? menuPhoto.reviewedAt.getTime() < (new Date().getTime() - SIX_MONTHS_MS)
+    : false;
+
+  if (isLoading) return null;
+
+  return (
+    <Box sx={{ py: 1 }}>
+      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>Foto del menú</Typography>
+
+      {menuPhoto && photoUrl ? (
+        <Box>
+          <Box
+            onClick={() => setViewerOpen(true)}
+            sx={{ cursor: 'pointer', borderRadius: 1, overflow: 'hidden', mb: 0.5 }}
+          >
+            <img
+              src={photoUrl}
+              alt="Menú"
+              style={{ width: '100%', maxHeight: 200, objectFit: 'cover', borderRadius: 4 }}
+            />
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            {menuPhoto.reviewedAt && (
+              <Typography variant="caption" color="text.secondary">
+                {`Menú actualizado: ${formatDateMedium(menuPhoto.reviewedAt)}`}
+              </Typography>
+            )}
+            {isStale && (
+              <Chip label="Posiblemente desactualizado" size="small" color="warning" variant="outlined" />
+            )}
+          </Box>
+        </Box>
+      ) : (
+        <Box>
+          {hasPending ? (
+            <Typography variant="body2" color="text.secondary">
+              Tu foto está en revisión
+            </Typography>
+          ) : user ? (
+            <Button
+              startIcon={<CameraAltIcon />}
+              size="small"
+              onClick={() => setUploadOpen(true)}
+            >
+              Subir foto del menú
+            </Button>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              No hay foto del menú
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      {user && menuPhoto && !hasPending && (
+        <Button
+          startIcon={<CameraAltIcon />}
+          size="small"
+          onClick={() => setUploadOpen(true)}
+          sx={{ mt: 0.5 }}
+        >
+          Actualizar foto
+        </Button>
+      )}
+
+      <MenuPhotoUpload
+        open={uploadOpen}
+        businessId={businessId}
+        onClose={() => setUploadOpen(false)}
+        onSuccess={() => {
+          setUploadOpen(false);
+          setHasPending(true);
+          onPhotoChange();
+        }}
+      />
+
+      {photoUrl && menuPhoto && (
+        <MenuPhotoViewer
+          open={viewerOpen}
+          photoUrl={photoUrl}
+          photoId={menuPhoto.id}
+          reviewedAt={menuPhoto.reviewedAt}
+          onClose={() => setViewerOpen(false)}
+        />
+      )}
+    </Box>
+  );
+}

--- a/src/components/business/MenuPhotoUpload.tsx
+++ b/src/components/business/MenuPhotoUpload.tsx
@@ -1,0 +1,145 @@
+import { useState, useRef } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, Typography, LinearProgress } from '@mui/material';
+import imageCompression from 'browser-image-compression';
+import { useAuth } from '../../context/AuthContext';
+import { uploadMenuPhoto } from '../../services/menuPhotos';
+
+interface Props {
+  open: boolean;
+  businessId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function MenuPhotoUpload({ open, businessId, onClose, onSuccess }: Props) {
+  const { user } = useAuth();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setSelectedFile(file);
+    setError(null);
+
+    const reader = new FileReader();
+    reader.onload = () => setPreview(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handleSubmit = async () => {
+    if (!user || !selectedFile) return;
+    setUploading(true);
+    setError(null);
+    const abort = new AbortController();
+    abortRef.current = abort;
+
+    try {
+      const compressed = await imageCompression(selectedFile, {
+        maxSizeMB: 2,
+        maxWidthOrHeight: 2048,
+        useWebWorker: false,
+      });
+
+      await uploadMenuPhoto(user.uid, businessId, compressed, setProgress, abort.signal);
+      onSuccess();
+      handleReset();
+    } catch (err) {
+      if (import.meta.env.DEV) console.error('MenuPhotoUpload error:', err);
+      if (!abort.signal.aborted) {
+        setError(err instanceof Error ? err.message : 'Error al subir la foto');
+      }
+    } finally {
+      setUploading(false);
+      setProgress(0);
+      abortRef.current = null;
+    }
+  };
+
+  const handleCancel = () => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    handleReset();
+  };
+
+  const handleReset = () => {
+    setSelectedFile(null);
+    setPreview(null);
+    setError(null);
+    setProgress(0);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>Subir foto del menú</DialogTitle>
+      <DialogContent>
+        {!preview && (
+          <Box
+            sx={{
+              border: '2px dashed',
+              borderColor: 'divider',
+              borderRadius: 2,
+              p: 4,
+              textAlign: 'center',
+              cursor: 'pointer',
+            }}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Typography color="text.secondary">
+              Tocá para seleccionar una imagen
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              JPG, PNG o WebP. Máximo 5 MB.
+            </Typography>
+          </Box>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          hidden
+          onChange={handleFileSelect}
+        />
+        {preview && (
+          <Box sx={{ mt: 1, textAlign: 'center' }}>
+            <img
+              src={preview}
+              alt="Preview"
+              style={{ maxWidth: '100%', maxHeight: 300, objectFit: 'contain', borderRadius: 8 }}
+            />
+          </Box>
+        )}
+        {uploading && (
+          <Box sx={{ mt: 2 }}>
+            <LinearProgress variant="determinate" value={progress} />
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+              {`Subiendo... ${Math.round(progress)}%`}
+            </Typography>
+          </Box>
+        )}
+        {error && (
+          <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+            {error}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel}>Cancelar</Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          disabled={!selectedFile || uploading}
+        >
+          Enviar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/business/MenuPhotoViewer.tsx
+++ b/src/components/business/MenuPhotoViewer.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Dialog, IconButton, Typography, Box, Button } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import ReportIcon from '@mui/icons-material/Report';
+import { httpsCallable } from 'firebase/functions';
+import { functions } from '../../config/firebase';
+import { useAuth } from '../../context/AuthContext';
+import { formatDateMedium } from '../../utils/formatDate';
+
+interface Props {
+  open: boolean;
+  photoUrl: string;
+  photoId: string;
+  reviewedAt: Date | undefined;
+  onClose: () => void;
+}
+
+export default function MenuPhotoViewer({ open, photoUrl, photoId, reviewedAt, onClose }: Props) {
+  const { user } = useAuth();
+  const [reported, setReported] = useState(false);
+  const [reporting, setReporting] = useState(false);
+
+  const handleReport = async () => {
+    setReporting(true);
+    try {
+      const report = httpsCallable(functions, 'reportMenuPhoto');
+      await report({ photoId });
+      setReported(true);
+    } catch (err) {
+      if (import.meta.env.DEV) console.error('Error reporting photo:', err);
+    } finally {
+      setReporting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullScreen>
+      <Box sx={{ position: 'relative', height: '100%', bgcolor: 'black', display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', p: 1 }}>
+          {reviewedAt && (
+            <Typography variant="body2" sx={{ color: 'white', pl: 1 }}>
+              {`Menú actualizado: ${formatDateMedium(reviewedAt)}`}
+            </Typography>
+          )}
+          <Box sx={{ display: 'flex', alignItems: 'center', ml: 'auto', gap: 0.5 }}>
+            {user && (
+              <Button
+                size="small"
+                startIcon={<ReportIcon />}
+                onClick={handleReport}
+                disabled={reported || reporting}
+                sx={{ color: reported ? 'grey.500' : 'warning.main' }}
+              >
+                {reported ? 'Reportada' : 'Reportar'}
+              </Button>
+            )}
+            <IconButton onClick={onClose} sx={{ color: 'white' }}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </Box>
+        <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', p: 1 }}>
+          <img
+            src={photoUrl}
+            alt="Foto del menú"
+            style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+          />
+        </Box>
+      </Box>
+    </Dialog>
+  );
+}

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -31,7 +31,9 @@ import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import { useAuth } from '../../context/AuthContext';
 import { useColorMode } from '../../hooks/useColorMode';
+import HistoryIcon from '@mui/icons-material/History';
 import FavoritesList from '../menu/FavoritesList';
+import RecentVisits from '../menu/RecentVisits';
 import CommentsList from '../menu/CommentsList';
 import RatingsList from '../menu/RatingsList';
 import FeedbackForm from '../menu/FeedbackForm';
@@ -47,10 +49,11 @@ interface Props {
   onClose: () => void;
 }
 
-type Section = 'nav' | 'favorites' | 'comments' | 'ratings' | 'feedback' | 'stats';
+type Section = 'nav' | 'favorites' | 'recent' | 'comments' | 'ratings' | 'feedback' | 'stats';
 
 const SECTION_TITLES: Record<Exclude<Section, 'nav'>, string> = {
   favorites: 'Favoritos',
+  recent: 'Recientes',
   comments: 'Comentarios',
   ratings: 'Calificaciones',
   feedback: 'Feedback',
@@ -127,6 +130,13 @@ export default function SideMenu({ open, onClose }: Props) {
                     <FavoriteIcon sx={{ color: '#ea4335' }} />
                   </ListItemIcon>
                   <ListItemText primary="Favoritos" />
+                </ListItemButton>
+
+                <ListItemButton onClick={() => setActiveSection('recent')}>
+                  <ListItemIcon>
+                    <HistoryIcon sx={{ color: '#ff9800' }} />
+                  </ListItemIcon>
+                  <ListItemText primary="Recientes" />
                 </ListItemButton>
 
                 <ListItemButton onClick={() => setActiveSection('comments')}>
@@ -220,6 +230,7 @@ export default function SideMenu({ open, onClose }: Props) {
               {/* Section content */}
               <Box sx={{ flex: 1, overflow: 'auto' }}>
                 {activeSection === 'favorites' && <FavoritesList onNavigate={handleClose} />}
+                {activeSection === 'recent' && <RecentVisits onNavigate={handleClose} />}
                 {activeSection === 'comments' && <CommentsList onNavigate={handleClose} />}
                 {activeSection === 'ratings' && <RatingsList onNavigate={handleClose} />}
                 {activeSection === 'feedback' && <FeedbackForm key={feedbackKey} />}

--- a/src/components/menu/RecentVisits.tsx
+++ b/src/components/menu/RecentVisits.tsx
@@ -1,0 +1,81 @@
+import { Box, List, ListItemButton, ListItemText, Typography, Button } from '@mui/material';
+import HistoryIcon from '@mui/icons-material/History';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { useMapContext } from '../../context/MapContext';
+import { useVisitHistory } from '../../hooks/useVisitHistory';
+import { CATEGORY_LABELS } from '../../types';
+
+interface Props {
+  onNavigate: () => void;
+}
+
+function formatRelativeTime(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'Hace un momento';
+  if (minutes < 60) return `Hace ${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `Hace ${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'Ayer';
+  if (days < 30) return `Hace ${days} días`;
+  return `Hace más de un mes`;
+}
+
+export default function RecentVisits({ onNavigate }: Props) {
+  const { setSelectedBusiness } = useMapContext();
+  const { visits, clearHistory } = useVisitHistory();
+
+  const validVisits = visits.filter((v) => v.business !== null);
+
+  if (validVisits.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: 'center' }}>
+        <HistoryIcon sx={{ fontSize: 48, color: 'text.disabled', mb: 1 }} />
+        <Typography color="text.secondary">
+          No visitaste comercios todavía
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <List disablePadding>
+        {validVisits.map((visit) => (
+          <ListItemButton
+            key={visit.businessId}
+            onClick={() => {
+              if (visit.business) {
+                setSelectedBusiness(visit.business);
+                onNavigate();
+              }
+            }}
+          >
+            <ListItemText
+              primary={visit.business!.name}
+              secondary={
+                <>
+                  {CATEGORY_LABELS[visit.business!.category]}
+                  {' · '}
+                  {formatRelativeTime(visit.lastVisited)}
+                  {visit.visitCount > 1 && ` · ${visit.visitCount} visitas`}
+                </>
+              }
+            />
+          </ListItemButton>
+        ))}
+      </List>
+      <Box sx={{ p: 2, textAlign: 'center' }}>
+        <Button
+          size="small"
+          startIcon={<DeleteOutlineIcon />}
+          onClick={clearHistory}
+          color="inherit"
+        >
+          Limpiar historial
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/search/FilterChips.tsx
+++ b/src/components/search/FilterChips.tsx
@@ -1,9 +1,24 @@
-import { Box, Chip } from '@mui/material';
+import { Box, Chip, Divider } from '@mui/material';
 import { useMapContext } from '../../context/MapContext';
 import { PREDEFINED_TAGS } from '../../types';
 
+const PRICE_CHIPS = [
+  { level: 1, label: '$' },
+  { level: 2, label: '$$' },
+  { level: 3, label: '$$$' },
+] as const;
+
 export default function FilterChips() {
-  const { activeFilters, toggleFilter } = useMapContext();
+  const { activeFilters, toggleFilter, activePriceFilter, setPriceFilter } = useMapContext();
+
+  const chipSx = (isActive: boolean) => ({
+    backgroundColor: isActive ? undefined : '#fff',
+    boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+    flexShrink: 0,
+    '&:hover': {
+      boxShadow: '0 1px 4px rgba(0,0,0,0.25)',
+    },
+  });
 
   return (
     <Box
@@ -32,14 +47,23 @@ export default function FilterChips() {
             onClick={() => toggleFilter(tag.id)}
             variant={isActive ? 'filled' : 'outlined'}
             color={isActive ? 'primary' : 'default'}
-            sx={{
-              backgroundColor: isActive ? undefined : '#fff',
-              boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
-              flexShrink: 0,
-              '&:hover': {
-                boxShadow: '0 1px 4px rgba(0,0,0,0.25)',
-              },
-            }}
+            sx={chipSx(isActive)}
+          />
+        );
+      })}
+
+      <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+
+      {PRICE_CHIPS.map((chip) => {
+        const isActive = activePriceFilter === chip.level;
+        return (
+          <Chip
+            key={`price-${chip.level}`}
+            label={chip.label}
+            onClick={() => setPriceFilter(chip.level)}
+            variant={isActive ? 'filled' : 'outlined'}
+            color={isActive ? 'secondary' : 'default'}
+            sx={chipSx(isActive)}
           />
         );
       })}

--- a/src/config/collections.ts
+++ b/src/config/collections.ts
@@ -10,4 +10,6 @@ export const COLLECTIONS = {
   DAILY_METRICS: 'dailyMetrics',
   ABUSE_LOGS: 'abuseLogs',
   COMMENT_LIKES: 'commentLikes',
+  MENU_PHOTOS: 'menuPhotos',
+  PRICE_LEVELS: 'priceLevels',
 } as const;

--- a/src/config/converters.ts
+++ b/src/config/converters.ts
@@ -3,7 +3,7 @@ import type {
   QueryDocumentSnapshot,
   SnapshotOptions,
 } from 'firebase/firestore';
-import type { UserProfile, Rating, Comment, CommentLike, UserTag, CustomTag, Favorite, Feedback, FeedbackCategory } from '../types';
+import type { UserProfile, Rating, Comment, CommentLike, UserTag, CustomTag, Favorite, Feedback, FeedbackCategory, MenuPhoto, PriceLevel } from '../types';
 import { toDate } from '../utils/formatDate';
 
 export const userProfileConverter: FirestoreDataConverter<UserProfile> = {
@@ -151,6 +151,58 @@ export const favoriteConverter: FirestoreDataConverter<Favorite> = {
       userId: d.userId,
       businessId: d.businessId,
       createdAt: toDate(d.createdAt),
+    };
+  },
+};
+
+export const menuPhotoConverter: FirestoreDataConverter<MenuPhoto> = {
+  toFirestore(photo: MenuPhoto) {
+    return {
+      userId: photo.userId,
+      businessId: photo.businessId,
+      storagePath: photo.storagePath,
+      thumbnailPath: photo.thumbnailPath,
+      status: photo.status,
+      createdAt: photo.createdAt,
+      reportCount: photo.reportCount,
+    };
+  },
+  fromFirestore(snapshot: QueryDocumentSnapshot, options?: SnapshotOptions): MenuPhoto {
+    const d = snapshot.data(options);
+    return {
+      id: snapshot.id,
+      userId: d.userId,
+      businessId: d.businessId,
+      storagePath: d.storagePath ?? '',
+      thumbnailPath: d.thumbnailPath ?? '',
+      status: d.status ?? 'pending',
+      rejectionReason: d.rejectionReason,
+      reviewedBy: d.reviewedBy,
+      reviewedAt: d.reviewedAt ? toDate(d.reviewedAt) : undefined,
+      createdAt: toDate(d.createdAt),
+      reportCount: (d.reportCount as number) ?? 0,
+    };
+  },
+};
+
+export const priceLevelConverter: FirestoreDataConverter<PriceLevel> = {
+  toFirestore(pl: PriceLevel) {
+    return {
+      userId: pl.userId,
+      businessId: pl.businessId,
+      level: pl.level,
+      createdAt: pl.createdAt,
+      updatedAt: pl.updatedAt,
+    };
+  },
+  fromFirestore(snapshot: QueryDocumentSnapshot, options?: SnapshotOptions): PriceLevel {
+    const d = snapshot.data(options);
+    return {
+      userId: d.userId,
+      businessId: d.businessId,
+      level: d.level,
+      createdAt: toDate(d.createdAt),
+      updatedAt: toDate(d.updatedAt),
     };
   },
 };

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -8,6 +8,7 @@ import {
   persistentMultipleTabManager,
 } from 'firebase/firestore';
 import { getFunctions, connectFunctionsEmulator } from 'firebase/functions';
+import { getStorage, connectStorageEmulator } from 'firebase/storage';
 import { initializeAppCheck, ReCaptchaEnterpriseProvider } from 'firebase/app-check';
 
 const requiredEnvVars = [
@@ -34,6 +35,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const functions = getFunctions(app);
+export const storage = getStorage(app);
 
 // DEV: getFirestore estándar (emuladores no soportan persistent cache)
 // PROD: persistent cache en IndexedDB para reducir reads de Firestore
@@ -49,6 +51,7 @@ if (import.meta.env.DEV) {
   connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
   connectFirestoreEmulator(db, 'localhost', 8080);
   connectFunctionsEmulator(functions, 'localhost', 5001);
+  connectStorageEmulator(storage, 'localhost', 9199);
 } else {
   // App Check obligatorio en producción — los emuladores no lo necesitan.
   // Requiere configurar reCAPTCHA Enterprise en Firebase Console (ver docs/SECURITY_GUIDELINES.md).

--- a/src/context/MapContext.tsx
+++ b/src/context/MapContext.tsx
@@ -9,6 +9,8 @@ interface MapContextType {
   setSearchQuery: (query: string) => void;
   activeFilters: string[];
   toggleFilter: (tagId: string) => void;
+  activePriceFilter: number | null;
+  setPriceFilter: (level: number | null) => void;
   userLocation: { lat: number; lng: number } | null;
   setUserLocation: (location: { lat: number; lng: number } | null) => void;
 }
@@ -20,6 +22,8 @@ const MapContext = createContext<MapContextType>({
   setSearchQuery: () => {},
   activeFilters: [],
   toggleFilter: () => {},
+  activePriceFilter: null,
+  setPriceFilter: () => {},
   userLocation: null,
   setUserLocation: () => {},
 });
@@ -28,12 +32,17 @@ export function MapProvider({ children }: { children: ReactNode }) {
   const [selectedBusiness, setSelectedBusiness] = useState<Business | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
+  const [activePriceFilter, setActivePriceFilter] = useState<number | null>(null);
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
 
   const toggleFilter = useCallback((tagId: string) => {
     setActiveFilters((prev) =>
       prev.includes(tagId) ? prev.filter((f) => f !== tagId) : [...prev, tagId]
     );
+  }, []);
+
+  const setPriceFilter = useCallback((level: number | null) => {
+    setActivePriceFilter((prev) => prev === level ? null : level);
   }, []);
 
   const value = useMemo<MapContextType>(() => ({
@@ -43,9 +52,11 @@ export function MapProvider({ children }: { children: ReactNode }) {
     setSearchQuery,
     activeFilters,
     toggleFilter,
+    activePriceFilter,
+    setPriceFilter,
     userLocation,
     setUserLocation,
-  }), [selectedBusiness, searchQuery, activeFilters, toggleFilter, userLocation]);
+  }), [selectedBusiness, searchQuery, activeFilters, toggleFilter, activePriceFilter, setPriceFilter, userLocation]);
 
   return (
     <MapContext.Provider value={value}>

--- a/src/hooks/useBusinessData.ts
+++ b/src/hooks/useBusinessData.ts
@@ -2,10 +2,10 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
 import { db } from '../config/firebase';
 import { COLLECTIONS } from '../config/collections';
-import { ratingConverter, commentConverter, userTagConverter, customTagConverter } from '../config/converters';
+import { ratingConverter, commentConverter, userTagConverter, customTagConverter, priceLevelConverter, menuPhotoConverter } from '../config/converters';
 import { useAuth } from '../context/AuthContext';
 import { getBusinessCache, setBusinessCache, invalidateBusinessCache, patchBusinessCache } from './useBusinessDataCache';
-import type { Rating, Comment, UserTag, CustomTag } from '../types';
+import type { Rating, Comment, UserTag, CustomTag, PriceLevel, MenuPhoto } from '../types';
 
 interface UseBusinessDataReturn {
   isFavorite: boolean;
@@ -14,6 +14,8 @@ interface UseBusinessDataReturn {
   userTags: UserTag[];
   customTags: CustomTag[];
   userCommentLikes: Set<string>;
+  priceLevels: PriceLevel[];
+  menuPhoto: MenuPhoto | null;
   isLoading: boolean;
   error: boolean;
   refetch: (collectionName?: CollectionName) => void;
@@ -28,12 +30,14 @@ const EMPTY: UseBusinessDataReturn = {
   userTags: [],
   customTags: [],
   userCommentLikes: EMPTY_LIKES,
+  priceLevels: [],
+  menuPhoto: null,
   isLoading: false,
   error: false,
   refetch: () => {},
 };
 
-type CollectionName = 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags';
+type CollectionName = 'favorites' | 'ratings' | 'comments' | 'userTags' | 'customTags' | 'priceLevels' | 'menuPhotos';
 
 /** Fetch user's likes for a set of comment IDs using individual getDoc calls. */
 async function fetchUserLikes(uid: string, commentIds: string[]): Promise<Set<string>> {
@@ -89,13 +93,28 @@ async function fetchSingleCollection(bId: string, uid: string, col: CollectionNa
       result.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
       return { customTags: result };
     }
+    case 'priceLevels': {
+      const snap = await getDocs(query(
+        collection(db, COLLECTIONS.PRICE_LEVELS).withConverter(priceLevelConverter),
+        where('businessId', '==', bId),
+      ));
+      return { priceLevels: snap.docs.map((d) => d.data()) };
+    }
+    case 'menuPhotos': {
+      const snap = await getDocs(query(
+        collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+        where('businessId', '==', bId),
+        where('status', '==', 'approved'),
+      ));
+      return { menuPhoto: snap.empty ? null : snap.docs[0].data() };
+    }
   }
 }
 
 async function fetchBusinessData(bId: string, uid: string) {
   const favDocId = `${uid}__${bId}`;
 
-  const [favSnap, ratingsSnap, commentsSnap, userTagsSnap, customTagsSnap] = await Promise.all([
+  const [favSnap, ratingsSnap, commentsSnap, userTagsSnap, customTagsSnap, priceLevelsSnap, menuPhotoSnap] = await Promise.all([
     getDoc(doc(db, COLLECTIONS.FAVORITES, favDocId)),
     getDocs(query(
       collection(db, COLLECTIONS.RATINGS).withConverter(ratingConverter),
@@ -114,6 +133,15 @@ async function fetchBusinessData(bId: string, uid: string) {
       where('userId', '==', uid),
       where('businessId', '==', bId),
     )),
+    getDocs(query(
+      collection(db, COLLECTIONS.PRICE_LEVELS).withConverter(priceLevelConverter),
+      where('businessId', '==', bId),
+    )),
+    getDocs(query(
+      collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+      where('businessId', '==', bId),
+      where('status', '==', 'approved'),
+    )),
   ]);
 
   const commentsResult = commentsSnap.docs.map((d) => d.data()).filter((c) => !c.flagged);
@@ -131,6 +159,8 @@ async function fetchBusinessData(bId: string, uid: string) {
     userTags: userTagsSnap.docs.map((d) => d.data()),
     customTags: customTagsResult,
     userCommentLikes,
+    priceLevels: priceLevelsSnap.docs.map((d) => d.data()),
+    menuPhoto: menuPhotoSnap.empty ? null : menuPhotoSnap.docs[0].data(),
   };
 }
 
@@ -143,13 +173,20 @@ export function useBusinessData(businessId: string | null): UseBusinessDataRetur
     userTags: UserTag[];
     customTags: CustomTag[];
     userCommentLikes: Set<string>;
-  }>({ isFavorite: false, ratings: [], comments: [], userTags: [], customTags: [], userCommentLikes: EMPTY_LIKES });
+    priceLevels: PriceLevel[];
+    menuPhoto: MenuPhoto | null;
+  }>({ isFavorite: false, ratings: [], comments: [], userTags: [], customTags: [], userCommentLikes: EMPTY_LIKES, priceLevels: [], menuPhoto: null });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
   const fetchIdRef = useRef(0);
+  // Collections patched by partial refetches while a full load is in-flight.
+  // When the full load completes, these fields are kept from prev state
+  // instead of being overwritten with stale full-load data.
+  const patchedRef = useRef(new Set<string>());
 
   const load = useCallback(async (bId: string, uid: string) => {
     const id = ++fetchIdRef.current;
+    patchedRef.current.clear();
 
     const cached = getBusinessCache(bId);
     if (cached) {
@@ -165,7 +202,23 @@ export function useBusinessData(businessId: string | null): UseBusinessDataRetur
     try {
       const result = await fetchBusinessData(bId, uid);
       if (fetchIdRef.current !== id) return; // stale
-      setData(result);
+      // Merge: keep fields that were patched by partial refetches during this load
+      const patched = patchedRef.current;
+      if (patched.size > 0) {
+        setData((prev) => {
+          const merged = { ...result };
+          if (patched.has('isFavorite')) merged.isFavorite = prev.isFavorite;
+          if (patched.has('ratings')) merged.ratings = prev.ratings;
+          if (patched.has('comments')) { merged.comments = prev.comments; merged.userCommentLikes = prev.userCommentLikes; }
+          if (patched.has('userTags')) merged.userTags = prev.userTags;
+          if (patched.has('customTags')) merged.customTags = prev.customTags;
+          if (patched.has('priceLevels')) merged.priceLevels = prev.priceLevels;
+          if (patched.has('menuPhoto')) merged.menuPhoto = prev.menuPhoto;
+          return merged;
+        });
+      } else {
+        setData(result);
+      }
       setBusinessCache(bId, result);
     } catch (err) {
       if (fetchIdRef.current !== id) return;
@@ -193,15 +246,17 @@ export function useBusinessData(businessId: string | null): UseBusinessDataRetur
       return;
     }
 
-    const id = ++fetchIdRef.current;
+    // Don't increment fetchIdRef for partial refetches — a single-collection
+    // refresh must not cancel a pending full load (race condition: user votes
+    // on price level while initial data is still loading).
+    // Track the patched collection so the full load won't overwrite it.
+    patchedRef.current.add(collectionName);
     fetchSingleCollection(businessId, user.uid, collectionName)
       .then((patch) => {
-        if (fetchIdRef.current !== id) return;
         setData((prev) => ({ ...prev, ...patch }));
         patchBusinessCache(businessId, patch);
       })
       .catch((err) => {
-        if (fetchIdRef.current !== id) return;
         if (import.meta.env.DEV) console.error(`Error refetching ${collectionName}:`, err);
       });
   }, [businessId, user, load]);

--- a/src/hooks/useBusinessDataCache.ts
+++ b/src/hooks/useBusinessDataCache.ts
@@ -1,4 +1,4 @@
-import type { Rating, Comment, UserTag, CustomTag } from '../types';
+import type { Rating, Comment, UserTag, CustomTag, MenuPhoto, PriceLevel } from '../types';
 
 export interface BusinessCacheEntry {
   isFavorite: boolean;
@@ -7,6 +7,8 @@ export interface BusinessCacheEntry {
   userTags: UserTag[];
   customTags: CustomTag[];
   userCommentLikes: Set<string>;
+  priceLevels: PriceLevel[];
+  menuPhoto: MenuPhoto | null;
   timestamp: number;
 }
 

--- a/src/hooks/useBusinesses.ts
+++ b/src/hooks/useBusinesses.ts
@@ -1,13 +1,15 @@
 import { useMemo, useDeferredValue } from 'react';
 import { useMapContext } from '../context/MapContext';
+import { usePriceLevelFilter } from './usePriceLevelFilter';
 import type { Business } from '../types';
 import businessesData from '../data/businesses.json';
 
 export const allBusinesses: Business[] = businessesData as Business[];
 
 export function useBusinesses() {
-  const { searchQuery, activeFilters } = useMapContext();
+  const { searchQuery, activeFilters, activePriceFilter } = useMapContext();
   const deferredQuery = useDeferredValue(searchQuery);
+  const priceMap = usePriceLevelFilter();
 
   const filteredBusinesses = useMemo(() => {
     let result = allBusinesses;
@@ -28,8 +30,12 @@ export function useBusinesses() {
       );
     }
 
+    if (activePriceFilter !== null) {
+      result = result.filter((b) => priceMap.get(b.id) === activePriceFilter);
+    }
+
     return result;
-  }, [deferredQuery, activeFilters]);
+  }, [deferredQuery, activeFilters, activePriceFilter, priceMap]);
 
   return { businesses: filteredBusinesses, allBusinesses };
 }

--- a/src/hooks/usePriceLevelFilter.ts
+++ b/src/hooks/usePriceLevelFilter.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../config/firebase';
+import { COLLECTIONS } from '../config/collections';
+import { priceLevelConverter } from '../config/converters';
+import type { PriceLevel } from '../types';
+
+/** Map of businessId -> average price level (rounded to nearest int) */
+type PriceMap = Map<string, number>;
+
+let globalPriceMap: PriceMap | null = null;
+let fetchPromise: Promise<PriceMap> | null = null;
+
+async function fetchAllPriceLevels(): Promise<PriceMap> {
+  const snap = await getDocs(
+    collection(db, COLLECTIONS.PRICE_LEVELS).withConverter(priceLevelConverter),
+  );
+  const byBusiness = new Map<string, number[]>();
+  for (const doc of snap.docs) {
+    const pl: PriceLevel = doc.data();
+    const arr = byBusiness.get(pl.businessId) ?? [];
+    arr.push(pl.level);
+    byBusiness.set(pl.businessId, arr);
+  }
+
+  const result: PriceMap = new Map();
+  for (const [bId, levels] of byBusiness) {
+    const avg = levels.reduce((a, b) => a + b, 0) / levels.length;
+    result.set(bId, Math.round(avg));
+  }
+  return result;
+}
+
+/**
+ * Returns a map of businessId -> average price level.
+ * Fetches once globally and caches.
+ */
+export function usePriceLevelFilter() {
+  const [priceMap, setPriceMap] = useState<PriceMap>(() => globalPriceMap ?? new Map());
+
+  const load = useCallback(() => {
+    if (!fetchPromise) {
+      fetchPromise = fetchAllPriceLevels();
+    }
+
+    fetchPromise.then((map) => {
+      globalPriceMap = map;
+      setPriceMap(map);
+    }).catch(() => {
+      // Silently fail — price filter just won't work
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!globalPriceMap) {
+      load();
+    }
+  }, [load]);
+
+  return priceMap;
+}
+
+/** Invalidate the global cache (call after user votes). */
+export function invalidatePriceLevelCache() {
+  globalPriceMap = null;
+  fetchPromise = null;
+}

--- a/src/hooks/useVisitHistory.ts
+++ b/src/hooks/useVisitHistory.ts
@@ -1,0 +1,68 @@
+import { useState, useCallback } from 'react';
+import { allBusinesses } from './useBusinesses';
+import type { Business } from '../types';
+
+interface VisitEntry {
+  businessId: string;
+  lastVisited: string;
+  visitCount: number;
+}
+
+const STORAGE_KEY = 'modo-mapa-visits';
+const MAX_ENTRIES = 50;
+
+function readVisits(): VisitEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeVisits(visits: VisitEntry[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(visits));
+}
+
+export interface VisitWithBusiness extends VisitEntry {
+  business: Business | null;
+}
+
+export function useVisitHistory() {
+  const [visits, setVisits] = useState<VisitEntry[]>(readVisits);
+
+  const recordVisit = useCallback((businessId: string) => {
+    setVisits((prev) => {
+      const now = new Date().toISOString();
+      const existing = prev.find((v) => v.businessId === businessId);
+      let updated: VisitEntry[];
+
+      if (existing) {
+        updated = [
+          { ...existing, lastVisited: now, visitCount: existing.visitCount + 1 },
+          ...prev.filter((v) => v.businessId !== businessId),
+        ];
+      } else {
+        updated = [
+          { businessId, lastVisited: now, visitCount: 1 },
+          ...prev,
+        ].slice(0, MAX_ENTRIES);
+      }
+
+      writeVisits(updated);
+      return updated;
+    });
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    setVisits([]);
+  }, []);
+
+  const visitsWithBusiness: VisitWithBusiness[] = visits.map((v) => ({
+    ...v,
+    business: allBusinesses.find((b) => b.id === v.businessId) || null,
+  }));
+
+  return { visits: visitsWithBusiness, recordVisit, clearHistory };
+}

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -11,6 +11,7 @@ import {
   query,
   orderBy,
   limit,
+  where,
 } from 'firebase/firestore';
 import type { QueryConstraint } from 'firebase/firestore';
 import { db } from '../config/firebase';
@@ -23,10 +24,11 @@ import {
   customTagConverter,
   feedbackConverter,
   userProfileConverter,
+  menuPhotoConverter,
 } from '../config/converters';
 import { countersConverter, dailyMetricsConverter, abuseLogConverter } from '../config/adminConverters';
 import type { AdminCounters, DailyMetrics, AbuseLog } from '../types/admin';
-import type { Comment, Rating, Favorite, UserTag, CustomTag, Feedback, UserProfile } from '../types';
+import type { Comment, Rating, Favorite, UserTag, CustomTag, Feedback, UserProfile, MenuPhoto } from '../types';
 
 // ── Counters ───────────────────────────────────────────────────────────
 
@@ -167,6 +169,29 @@ export async function fetchDailyMetrics(order: 'asc' | 'desc', maxDocs?: number)
     query(
       collection(db, COLLECTIONS.DAILY_METRICS).withConverter(dailyMetricsConverter),
       ...constraints,
+    ),
+  );
+  return snap.docs.map((d) => d.data());
+}
+
+// ── Menu Photos ───────────────────────────────────────────────────────
+
+export async function fetchPendingPhotos(): Promise<MenuPhoto[]> {
+  const snap = await getDocs(
+    query(
+      collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+      where('status', '==', 'pending'),
+      orderBy('createdAt', 'asc'),
+    ),
+  );
+  return snap.docs.map((d) => d.data());
+}
+
+export async function fetchAllPhotos(): Promise<MenuPhoto[]> {
+  const snap = await getDocs(
+    query(
+      collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+      orderBy('createdAt', 'desc'),
     ),
   );
   return snap.docs.map((d) => d.data());

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,3 +3,5 @@ export { upsertRating, getRatingsCollection } from './ratings';
 export { addComment, editComment, deleteComment, likeComment, unlikeComment, getCommentsCollection } from './comments';
 export { addUserTag, removeUserTag, createCustomTag, updateCustomTag, deleteCustomTag } from './tags';
 export { sendFeedback } from './feedback';
+export { uploadMenuPhoto, getApprovedMenuPhoto, getUserPendingPhotos } from './menuPhotos';
+export { upsertPriceLevel, getPriceLevelsCollection } from './priceLevels';

--- a/src/services/menuPhotos.ts
+++ b/src/services/menuPhotos.ts
@@ -1,0 +1,123 @@
+/**
+ * Firestore + Storage service for the `menuPhotos` collection.
+ */
+import { collection, doc, setDoc, getDocs, query, where, serverTimestamp } from 'firebase/firestore';
+import { ref, uploadBytesResumable } from 'firebase/storage';
+import type { CollectionReference, DocumentReference } from 'firebase/firestore';
+import type { UploadTask } from 'firebase/storage';
+import { db, storage } from '../config/firebase';
+import { COLLECTIONS } from '../config/collections';
+import { menuPhotoConverter } from '../config/converters';
+import { invalidateBusinessCache } from '../hooks/useBusinessDataCache';
+import type { MenuPhoto } from '../types';
+
+export function getMenuPhotosCollection(): CollectionReference<MenuPhoto> {
+  return collection(db, COLLECTIONS.MENU_PHOTOS)
+    .withConverter(menuPhotoConverter) as CollectionReference<MenuPhoto>;
+}
+
+/**
+ * Upload a menu photo. Returns a promise that resolves when the upload
+ * completes and the Firestore doc is created with status 'pending'.
+ */
+export async function uploadMenuPhoto(
+  userId: string,
+  businessId: string,
+  file: File,
+  onProgress?: (progress: number) => void,
+  signal?: AbortSignal,
+): Promise<{ docId: string }> {
+  const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    throw new Error('Formato no soportado. Usa JPG, PNG o WebP.');
+  }
+  if (file.size > 5 * 1024 * 1024) {
+    throw new Error('La imagen es muy grande. Máximo 5 MB.');
+  }
+
+  // Check pending count for this user
+  const pendingSnap = await getDocs(query(
+    collection(db, COLLECTIONS.MENU_PHOTOS),
+    where('userId', '==', userId),
+    where('status', '==', 'pending'),
+  ));
+  if (pendingSnap.size >= 3) {
+    throw new Error('Ya tenés 3 fotos pendientes de revisión. Esperá a que se revisen.');
+  }
+
+  // Create Firestore doc ref to get ID
+  const docRef: DocumentReference = doc(collection(db, COLLECTIONS.MENU_PHOTOS));
+  const storagePath = `menus/${businessId}/${docRef.id}_original`;
+
+  // Upload to Storage with explicit content type
+  const storageRef = ref(storage, storagePath);
+  const uploadTask: UploadTask = uploadBytesResumable(storageRef, file, {
+    contentType: file.type || 'image/jpeg',
+  });
+
+  return new Promise((resolve, reject) => {
+    // Allow external cancellation via AbortSignal
+    if (signal) {
+      signal.addEventListener('abort', () => {
+        uploadTask.cancel();
+        reject(new Error('Upload cancelado'));
+      }, { once: true });
+    }
+
+    uploadTask.on('state_changed',
+      (snapshot) => {
+        if (onProgress) {
+          const progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+          onProgress(progress);
+        }
+      },
+      (error) => reject(error),
+      async () => {
+        try {
+          await setDoc(docRef, {
+            userId,
+            businessId,
+            storagePath,
+            thumbnailPath: '',
+            status: 'pending',
+            createdAt: serverTimestamp(),
+            reportCount: 0,
+          });
+          invalidateBusinessCache(businessId);
+          resolve({ docId: docRef.id });
+        } catch (err) {
+          reject(err);
+        }
+      },
+    );
+  });
+}
+
+/**
+ * Get the approved menu photo for a business (if any).
+ */
+export async function getApprovedMenuPhoto(businessId: string): Promise<MenuPhoto | null> {
+  const snap = await getDocs(query(
+    collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+    where('businessId', '==', businessId),
+    where('status', '==', 'approved'),
+  ));
+  if (snap.empty) return null;
+  return snap.docs[0].data();
+}
+
+/**
+ * Get user's pending photos for a business.
+ */
+export async function getUserPendingPhotos(
+  userId: string,
+  businessId: string,
+): Promise<MenuPhoto[]> {
+  const snap = await getDocs(query(
+    collection(db, COLLECTIONS.MENU_PHOTOS).withConverter(menuPhotoConverter),
+    where('userId', '==', userId),
+    where('businessId', '==', businessId),
+    where('status', '==', 'pending'),
+  ));
+  return snap.docs.map((d) => d.data());
+}

--- a/src/services/priceLevels.ts
+++ b/src/services/priceLevels.ts
@@ -1,0 +1,46 @@
+/**
+ * Firestore service for the `priceLevels` collection.
+ */
+import { collection, doc, getDoc, setDoc, updateDoc, serverTimestamp } from 'firebase/firestore';
+import type { CollectionReference } from 'firebase/firestore';
+import { db } from '../config/firebase';
+import { COLLECTIONS } from '../config/collections';
+import { priceLevelConverter } from '../config/converters';
+import { invalidateQueryCache } from '../hooks/usePaginatedQuery';
+import type { PriceLevel } from '../types';
+
+export function getPriceLevelsCollection(): CollectionReference<PriceLevel> {
+  return collection(db, COLLECTIONS.PRICE_LEVELS)
+    .withConverter(priceLevelConverter) as CollectionReference<PriceLevel>;
+}
+
+export async function upsertPriceLevel(
+  userId: string,
+  businessId: string,
+  level: number,
+): Promise<void> {
+  if (!Number.isInteger(level) || level < 1 || level > 3) {
+    throw new Error('Level must be 1, 2, or 3');
+  }
+
+  const docId = `${userId}__${businessId}`;
+  const plRef = doc(db, COLLECTIONS.PRICE_LEVELS, docId);
+  const existing = await getDoc(plRef);
+
+  if (existing.exists()) {
+    await updateDoc(plRef, {
+      level,
+      updatedAt: serverTimestamp(),
+    });
+  } else {
+    await setDoc(plRef, {
+      userId,
+      businessId,
+      level,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    });
+  }
+
+  invalidateQueryCache(COLLECTIONS.PRICE_LEVELS, userId);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,6 +92,36 @@ export const PREDEFINED_TAGS = [
 
 export type PredefinedTagId = (typeof PREDEFINED_TAGS)[number]['id'];
 
+export type MenuPhotoStatus = 'pending' | 'approved' | 'rejected';
+
+export interface MenuPhoto {
+  id: string;
+  userId: string;
+  businessId: string;
+  storagePath: string;
+  thumbnailPath: string;
+  status: MenuPhotoStatus;
+  rejectionReason?: string;
+  reviewedBy?: string;
+  reviewedAt?: Date;
+  createdAt: Date;
+  reportCount: number;
+}
+
+export interface PriceLevel {
+  userId: string;
+  businessId: string;
+  level: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export const PRICE_LEVEL_LABELS: Record<number, string> = {
+  1: 'Económico',
+  2: 'Moderado',
+  3: 'Caro',
+};
+
 export const CATEGORY_LABELS: Record<BusinessCategory, string> = {
   restaurant: 'Restaurante',
   cafe: 'Café',

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,13 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    // Menu photos: authenticated users can upload, anyone authenticated can read approved
+    match /menus/{businessId}/{fileName} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null
+        && request.resource.size < 5 * 1024 * 1024
+        && request.resource.contentType.matches('image/(jpeg|png|webp)');
+      allow delete: if false; // Only Cloud Functions (admin SDK) can delete
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **F2: Menu Photos** — Upload menu photos with compression, admin review panel (approve/reject/delete), user reporting, Firebase Storage integration
- **F9: Visit History** — localStorage-based tracking of recently visited businesses, displayed in side menu with relative timestamps
- **F10b: Price Level** — User voting system ($/$$/$$$), map filtering by price level, global cache for performance

## Key changes
- Firebase Storage setup (rules, emulator, client SDK)
- 4 new Cloud Functions: thumbnail generation, photo approve/reject/delete/report
- Race condition fix in `useBusinessData` (partial refetches no longer cancel full loads)
- Admin photo panel with status filters, revert capabilities, and report badges
- Dev environment tooling: `scripts/dev-env.sh` (start/stop/seed/health) + `/test-local` skill
- `enforceAppCheck` disabled in emulator for all callable functions

## New files (21)
- `storage.rules`, `src/services/menuPhotos.ts`, `src/services/priceLevels.ts`
- `src/hooks/useVisitHistory.ts`, `src/hooks/usePriceLevelFilter.ts`
- `src/components/business/BusinessPriceLevel.tsx`, `MenuPhotoSection.tsx`, `MenuPhotoUpload.tsx`, `MenuPhotoViewer.tsx`
- `src/components/menu/RecentVisits.tsx`, `src/components/admin/PhotoReviewPanel.tsx`, `PhotoReviewCard.tsx`
- `functions/src/triggers/menuPhotos.ts`, `priceLevels.ts`, `functions/src/admin/menuPhotos.ts`, `functions/src/scheduled/cleanupPhotos.ts`
- `scripts/dev-env.sh`, `.claude/commands/test-local.md`
- `docs/feat-menu-photos-history/` (prd, specs, plan, changelog)

## Test plan
- [ ] Run `./scripts/dev-env.sh start` (auto-seeds data)
- [ ] Open business → vote price level → verify persists
- [ ] Upload menu photo → verify pending status
- [ ] Admin: approve/reject/delete photos
- [ ] Visit 3 businesses → check "Recientes" in side menu
- [ ] Filter map by price chips ($/$$/$$)
- [ ] Report a photo from viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)