### PR TITLE
feat: analytics opt-in toggle in user settings (#61)

### DIFF
--- a/docs/feat-analytics-optout/plan.md
+++ b/docs/feat-analytics-optout/plan.md
@@ -1,0 +1,44 @@
+# Plan: Configuracion de privacidad — Opt-in de Analytics
+
+## Orden de implementacion
+
+### Paso 1: Modelo de datos
+
+1. Agregar `analyticsEnabled: boolean` a `UserSettings` en `src/types/index.ts`
+2. Agregar `analyticsEnabled: false` a `DEFAULT_SETTINGS` en `src/services/userSettings.ts`
+3. Agregar `analyticsEnabled` al destructuring de first-write en `updateUserSettings`
+4. Agregar `analyticsEnabled` al converter en `src/config/converters.ts`
+
+**Verificar**: `npx tsc --noEmit -p tsconfig.app.json` pasa.
+
+### Paso 2: Firestore rules
+
+1. Agregar `&& request.resource.data.analyticsEnabled is bool` a la regla write de `userSettings`
+
+### Paso 3: Analytics module
+
+1. Reescribir `src/utils/analytics.ts` con soporte de consent:
+   - `initAnalytics(app)` lee localStorage, solo activa si consent es `"true"`
+   - `setAnalyticsEnabled(value)` actualiza localStorage + SDK
+   - `trackEvent` y `setUserProperty` verifican `enabled`
+
+**Verificar**: `npx tsc --noEmit -p tsconfig.app.json` pasa.
+
+### Paso 4: Hook sync
+
+1. En `src/hooks/useUserSettings.ts`, agregar sincronizacion de `setAnalyticsEnabled` cuando `settings.analyticsEnabled` cambia
+
+### Paso 5: UI
+
+1. Agregar seccion "Datos de uso" en `src/components/menu/SettingsPanel.tsx`
+
+### Paso 6: Test local
+
+1. `npm run lint`
+2. `npm run test:run`
+3. `npm run build`
+4. `npm run dev` — verificar:
+   - Toggle aparece en Configuracion
+   - Por defecto deshabilitado
+   - Al activar, localStorage tiene `analytics-consent: "true"`
+   - Al desactivar, vuelve a `"false"`

--- a/docs/feat-analytics-optout/prd.md
+++ b/docs/feat-analytics-optout/prd.md
@@ -1,0 +1,59 @@
+# PRD: Configuracion de privacidad — Opt-out de Analytics
+
+## Issue
+
+[#61](https://github.com/benoffi7/modo-mapa/issues/61)
+
+## Problema
+
+Firebase Analytics (GA4) esta siempre activo en produccion sin posibilidad de que el usuario lo desactive. Esto no respeta la preferencia de privacidad del usuario y es prerequisito para la politica de privacidad (#56).
+
+## Objetivo
+
+Permitir que cada usuario active/desactive el envio de datos de Analytics desde el panel de configuracion existente (#59).
+
+## Requisitos funcionales
+
+### RF-1: Toggle en panel de configuracion
+
+- Agregar seccion "Datos de uso" en `SettingsPanel` (debajo de "Notificaciones")
+- Toggle "Enviar datos de uso" con texto explicativo: "Ayuda a mejorar la app enviando datos anonimos de uso"
+- Por defecto: deshabilitado (modelo opt-in)
+
+### RF-2: Persistencia dual
+
+- **localStorage** (`analytics-consent`): lectura inmediata al inicializar analytics, antes de que Firestore este disponible
+- **Firestore** (`userSettings.analyticsEnabled`): sincronizacion cross-device cuando el usuario esta autenticado
+- Prioridad: Firestore > localStorage > default (false)
+
+### RF-3: Comportamiento al desactivar
+
+- `trackEvent()` y `setUserProperty()` se convierten en no-op
+- Usar `setAnalyticsCollectionEnabled(analytics, false)` del SDK de Firebase para detener la recoleccion a nivel SDK
+- El cambio es inmediato (no requiere reload)
+
+### RF-4: Comportamiento al activar
+
+- Reactivar con `setAnalyticsCollectionEnabled(analytics, true)`
+- `trackEvent()` y `setUserProperty()` vuelven a funcionar normalmente
+
+## Requisitos no funcionales
+
+- No impactar el bundle size significativamente (analytics ya es lazy-loaded)
+- Compatible con el flujo existente de `useUserSettings` (optimistic UI con revert on error)
+- La lectura de localStorage debe ser sincrona al boot para no enviar eventos antes de conocer la preferencia
+
+## Fuera de alcance
+
+- Banner de consentimiento al primer uso (se evaluara en #56)
+- Configuracion granular por tipo de evento
+- GDPR compliance completo (app interna)
+
+## Dependencias
+
+- Panel de configuracion de usuario (#59) — ya implementado
+- Firebase Analytics (#57) — ya implementado
+
+## Relacion con otros issues
+
+- Prerequisito para: #56 (Politica de privacidad)

--- a/docs/feat-analytics-optout/specs.md
+++ b/docs/feat-analytics-optout/specs.md
@@ -1,0 +1,174 @@
+# Specs: Configuracion de privacidad — Opt-in de Analytics
+
+## Modelo de datos
+
+### `UserSettings` (actualizar)
+
+```typescript
+export interface UserSettings {
+  profilePublic: boolean;
+  notificationsEnabled: boolean;
+  notifyLikes: boolean;
+  notifyPhotos: boolean;
+  notifyRankings: boolean;
+  analyticsEnabled: boolean; // NUEVO — default false (opt-in)
+  updatedAt: Date;
+}
+```
+
+### Firestore rules (actualizar `userSettings`)
+
+Agregar validacion del nuevo campo booleano:
+
+```text
+match /userSettings/{userId} {
+  allow read: if request.auth != null;
+  allow write: if request.auth != null && request.auth.uid == userId
+    && request.resource.data.profilePublic is bool
+    && request.resource.data.notificationsEnabled is bool
+    && request.resource.data.notifyLikes is bool
+    && request.resource.data.notifyPhotos is bool
+    && request.resource.data.notifyRankings is bool
+    && request.resource.data.analyticsEnabled is bool    // NUEVO
+    && request.resource.data.updatedAt == request.time;
+}
+```
+
+### localStorage
+
+Key: `analytics-consent`
+Valores: `"true"` | `"false"` | ausente (= false por defecto)
+
+Se lee sincronamente al boot en `initAnalytics()` para decidir si inicializar o no.
+
+## Archivos a modificar
+
+### `src/types/index.ts`
+
+Agregar `analyticsEnabled: boolean` a `UserSettings`.
+
+### `src/utils/analytics.ts`
+
+Cambios:
+
+1. Variable module-level `let enabled = false`
+2. Al iniciar, leer `localStorage.getItem('analytics-consent')` — solo inicializar si es `"true"`
+3. Exportar `setAnalyticsEnabled(value: boolean)`:
+   - Guarda en localStorage
+   - Si `value === true` y `analytics === null`, lazy-init analytics
+   - Si `value === true` y analytics existe, `setAnalyticsCollectionEnabled(analytics, true)`
+   - Si `value === false` y analytics existe, `setAnalyticsCollectionEnabled(analytics, false)`
+   - Actualiza `enabled`
+4. `trackEvent` y `setUserProperty` verifican `enabled` ademas de `analytics`
+
+```typescript
+import type { Analytics } from 'firebase/analytics';
+import type { FirebaseApp } from 'firebase/app';
+
+let analytics: Analytics | null = null;
+let enabled = false;
+let firebaseApp: FirebaseApp | null = null;
+
+const LS_KEY = 'analytics-consent';
+
+export function initAnalytics(app: FirebaseApp): void {
+  firebaseApp = app;
+  if (!import.meta.env.PROD) return;
+
+  const consent = localStorage.getItem(LS_KEY);
+  if (consent === 'true') {
+    activateAnalytics(app);
+  }
+}
+
+function activateAnalytics(app: FirebaseApp): void {
+  enabled = true;
+  import('firebase/analytics').then(({ getAnalytics, setAnalyticsCollectionEnabled }) => {
+    analytics = getAnalytics(app);
+    setAnalyticsCollectionEnabled(analytics, true);
+  });
+}
+
+export function setAnalyticsEnabled(value: boolean): void {
+  localStorage.setItem(LS_KEY, String(value));
+  enabled = value;
+
+  if (!import.meta.env.PROD || !firebaseApp) return;
+
+  if (value && !analytics) {
+    activateAnalytics(firebaseApp);
+  } else if (analytics) {
+    import('firebase/analytics').then(({ setAnalyticsCollectionEnabled }) => {
+      setAnalyticsCollectionEnabled(analytics!, value);
+    });
+  }
+}
+
+export function trackEvent(
+  name: string,
+  params?: Record<string, string | number | boolean>,
+): void {
+  if (!enabled || !analytics) return;
+  import('firebase/analytics').then(({ logEvent }) => {
+    logEvent(analytics!, name, params);
+  });
+}
+
+export function setUserProperty(name: string, value: string): void {
+  if (!enabled || !analytics) return;
+  import('firebase/analytics').then(({ setUserProperties }) => {
+    setUserProperties(analytics!, { [name]: value });
+  });
+}
+```
+
+### `src/services/userSettings.ts`
+
+- Agregar `analyticsEnabled: false` a `DEFAULT_SETTINGS`
+- Agregar `analyticsEnabled` al destructuring en first-write path
+
+### `src/config/converters.ts`
+
+Agregar `analyticsEnabled` a `userSettingsConverter` (toFirestore + fromFirestore).
+
+### `src/hooks/useUserSettings.ts`
+
+Sin cambios — el hook es generico sobre las keys de `UserSettings`.
+Agregar efecto para sincronizar `setAnalyticsEnabled` cuando settings cambian:
+
+```typescript
+import { setAnalyticsEnabled } from '../utils/analytics';
+
+// Dentro del hook, despues de computar settings:
+const prevAnalyticsRef = useRef(settings.analyticsEnabled);
+if (prevAnalyticsRef.current !== settings.analyticsEnabled) {
+  prevAnalyticsRef.current = settings.analyticsEnabled;
+  setAnalyticsEnabled(settings.analyticsEnabled);
+}
+```
+
+Nota: se usa ref + comparacion en render (no useEffect) para evitar delay.
+El React compiler permite leer refs durante render si no es el resultado de un setState en el mismo render.
+
+### `src/components/menu/SettingsPanel.tsx`
+
+Agregar seccion "Datos de uso" despues de "Notificaciones":
+
+```tsx
+<Divider sx={{ my: 1.5 }} />
+
+{/* Analytics */}
+<Typography variant="overline" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+  Datos de uso
+</Typography>
+<SettingRow
+  label="Enviar datos de uso"
+  description="Ayuda a mejorar la app enviando datos anonimos de uso"
+  checked={settings.analyticsEnabled}
+  onChange={(val) => updateSetting('analyticsEnabled', val)}
+/>
+```
+
+### `firestore.rules`
+
+Agregar `&& request.resource.data.analyticsEnabled is bool` a la regla write de `userSettings`.

--- a/firestore.rules
+++ b/firestore.rules
@@ -238,6 +238,7 @@ service cloud.firestore {
         && request.resource.data.notifyLikes is bool
         && request.resource.data.notifyPhotos is bool
         && request.resource.data.notifyRankings is bool
+        && request.resource.data.analyticsEnabled is bool
         && request.resource.data.updatedAt == request.time;
     }
 

--- a/src/components/menu/SettingsPanel.tsx
+++ b/src/components/menu/SettingsPanel.tsx
@@ -101,6 +101,19 @@ export default function SettingsPanel() {
         indented
         onChange={(val) => updateSetting('notifyRankings', val)}
       />
+
+      <Divider sx={{ my: 1.5 }} />
+
+      {/* Analytics */}
+      <Typography variant="overline" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+        Datos de uso
+      </Typography>
+      <SettingRow
+        label="Enviar datos de uso"
+        description="Ayuda a mejorar la app enviando datos anónimos de uso"
+        checked={settings.analyticsEnabled}
+        onChange={(val) => updateSetting('analyticsEnabled', val)}
+      />
     </Box>
   );
 }

--- a/src/config/converters.ts
+++ b/src/config/converters.ts
@@ -267,6 +267,7 @@ export const userSettingsConverter: FirestoreDataConverter<UserSettings> = {
       notifyLikes: settings.notifyLikes,
       notifyPhotos: settings.notifyPhotos,
       notifyRankings: settings.notifyRankings,
+      analyticsEnabled: settings.analyticsEnabled,
       updatedAt: settings.updatedAt,
     };
   },
@@ -278,6 +279,7 @@ export const userSettingsConverter: FirestoreDataConverter<UserSettings> = {
       notifyLikes: d.notifyLikes ?? false,
       notifyPhotos: d.notifyPhotos ?? false,
       notifyRankings: d.notifyRankings ?? false,
+      analyticsEnabled: d.analyticsEnabled ?? false,
       updatedAt: toDate(d.updatedAt),
     };
   },

--- a/src/hooks/useUserSettings.ts
+++ b/src/hooks/useUserSettings.ts
@@ -1,7 +1,8 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useAsyncData } from './useAsyncData';
 import { fetchUserSettings, updateUserSettings, DEFAULT_SETTINGS } from '../services/userSettings';
+import { setAnalyticsEnabled } from '../utils/analytics';
 import type { UserSettings } from '../types';
 
 type SettingKey = keyof Omit<UserSettings, 'updatedAt'>;
@@ -21,6 +22,11 @@ export function useUserSettings() {
     ...(data ?? DEFAULT_SETTINGS),
     ...optimistic,
   };
+
+  // Sync analytics enabled state with the SDK
+  useEffect(() => {
+    setAnalyticsEnabled(settings.analyticsEnabled);
+  }, [settings.analyticsEnabled]);
 
   const updateSetting = useCallback(
     (key: SettingKey, value: boolean) => {

--- a/src/services/userSettings.ts
+++ b/src/services/userSettings.ts
@@ -10,6 +10,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   notifyLikes: false,
   notifyPhotos: false,
   notifyRankings: false,
+  analyticsEnabled: false,
   updatedAt: new Date(),
 };
 
@@ -32,7 +33,7 @@ export async function updateUserSettings(
     await setDoc(ref, { ...updates, updatedAt: serverTimestamp() }, { merge: true });
   } else {
     // First write — send all fields so Firestore rules pass validation
-    const { profilePublic, notificationsEnabled, notifyLikes, notifyPhotos, notifyRankings } = DEFAULT_SETTINGS;
-    await setDoc(ref, { profilePublic, notificationsEnabled, notifyLikes, notifyPhotos, notifyRankings, ...updates, updatedAt: serverTimestamp() });
+    const { profilePublic, notificationsEnabled, notifyLikes, notifyPhotos, notifyRankings, analyticsEnabled } = DEFAULT_SETTINGS;
+    await setDoc(ref, { profilePublic, notificationsEnabled, notifyLikes, notifyPhotos, notifyRankings, analyticsEnabled, ...updates, updatedAt: serverTimestamp() });
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -177,5 +177,6 @@ export interface UserSettings {
   notifyLikes: boolean;
   notifyPhotos: boolean;
   notifyRankings: boolean;
+  analyticsEnabled: boolean;
   updatedAt: Date;
 }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -2,11 +2,40 @@ import type { Analytics } from 'firebase/analytics';
 import type { FirebaseApp } from 'firebase/app';
 
 let analytics: Analytics | null = null;
+let enabled = false;
+let firebaseApp: FirebaseApp | null = null;
+
+const LS_KEY = 'analytics-consent';
+
+function activateAnalytics(app: FirebaseApp): void {
+  enabled = true;
+  import('firebase/analytics').then(({ getAnalytics, setAnalyticsCollectionEnabled }) => {
+    analytics = getAnalytics(app);
+    setAnalyticsCollectionEnabled(analytics, true);
+  });
+}
 
 export function initAnalytics(app: FirebaseApp): void {
-  if (import.meta.env.PROD) {
-    import('firebase/analytics').then(({ getAnalytics }) => {
-      analytics = getAnalytics(app);
+  firebaseApp = app;
+  if (!import.meta.env.PROD) return;
+
+  const consent = localStorage.getItem(LS_KEY);
+  if (consent === 'true') {
+    activateAnalytics(app);
+  }
+}
+
+export function setAnalyticsEnabled(value: boolean): void {
+  localStorage.setItem(LS_KEY, String(value));
+  enabled = value;
+
+  if (!import.meta.env.PROD || !firebaseApp) return;
+
+  if (value && !analytics) {
+    activateAnalytics(firebaseApp);
+  } else if (analytics) {
+    import('firebase/analytics').then(({ setAnalyticsCollectionEnabled }) => {
+      setAnalyticsCollectionEnabled(analytics!, value);
     });
   }
 }
@@ -15,14 +44,14 @@ export function trackEvent(
   name: string,
   params?: Record<string, string | number | boolean>,
 ): void {
-  if (!analytics) return;
+  if (!enabled || !analytics) return;
   import('firebase/analytics').then(({ logEvent }) => {
     logEvent(analytics!, name, params);
   });
 }
 
 export function setUserProperty(name: string, value: string): void {
-  if (!analytics) return;
+  if (!enabled || !analytics) return;
   import('firebase/analytics').then(({ setUserProperties }) => {
     setUserProperties(analytics!, { [name]: value });
   });


### PR DESCRIPTION
## Summary

- Add "Datos de uso" section in settings panel with toggle to enable/disable Firebase Analytics (GA4)
- Default is **disabled** (opt-in model) — user must explicitly enable analytics
- Persistence: localStorage (sync at boot) + Firestore `userSettings.analyticsEnabled` (cross-device)
- Uses `setAnalyticsCollectionEnabled()` from Firebase SDK for immediate effect

## Changes

| File | Change |
|------|--------|
| `src/types/index.ts` | +`analyticsEnabled: boolean` to UserSettings |
| `src/services/userSettings.ts` | +default value, +first-write field |
| `src/config/converters.ts` | +field in converter |
| `firestore.rules` | +`analyticsEnabled is bool` validation |
| `src/utils/analytics.ts` | Rewrite with consent support |
| `src/hooks/useUserSettings.ts` | Sync analytics state via useEffect |
| `src/components/menu/SettingsPanel.tsx` | +Analytics toggle section |

## Test plan

- [ ] Toggle appears in Settings under "Datos de uso"
- [ ] Default is OFF (disabled)
- [ ] Toggling ON sets `localStorage analytics-consent = "true"`
- [ ] Toggling OFF sets it to `"false"`
- [ ] Firestore `userSettings` doc includes `analyticsEnabled` field
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run test:run` passes (74/74)
- [ ] `npm run build` succeeds

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)