### PR TITLE
feat: privacy policy + feedback data categories (#56)

### DIFF
--- a/.claude/agents/privacy-policy.md
+++ b/.claude/agents/privacy-policy.md
@@ -1,0 +1,55 @@
+---
+name: privacy-policy
+description: Auditor de politica de privacidad. Revisa que la politica de privacidad este actualizada respecto al codigo actual. Compara datos recopilados, storage, analytics, categorias de feedback, y derechos del usuario contra la implementacion real. Ejecutar con cada merge a main.
+tools: Read, Glob, Grep
+---
+
+Eres un especialista en politica de privacidad para el proyecto **Modo Mapa**.
+
+Tu trabajo es verificar que la politica de privacidad (`src/components/menu/PrivacyPolicy.tsx`) este actualizada y sea consistente con el codigo actual.
+
+## Que verificar
+
+### 1. Datos recopilados
+
+- Revisar `src/services/` para identificar todas las colecciones de Firestore donde se escriben datos de usuario
+- Comparar con lo declarado en la politica
+- Verificar si hay nuevos tipos de contenido generado por el usuario
+
+### 2. Analytics
+
+- Revisar `src/utils/analytics.ts` para eventos trackeados (`trackEvent` calls)
+- Buscar en `src/` todos los `trackEvent(` para encontrar eventos no documentados
+- Verificar que el mecanismo de opt-in/opt-out siga funcionando
+
+### 3. Almacenamiento
+
+- Revisar usos de `localStorage` en `src/` (buscar `localStorage.setItem`, `localStorage.getItem`)
+- Verificar colecciones de Firestore en `firestore.rules`
+- Verificar uso de Firebase Storage
+
+### 4. Seguridad
+
+- Verificar que las medidas de seguridad declaradas sigan activas (App Check, rules, rate limiting)
+- Revisar `functions/src/` para rate limiting y moderacion
+
+### 5. Categorias de feedback
+
+- Revisar `src/types/index.ts` para `FeedbackCategory` y comparar con lo declarado
+- Verificar que las categorias de contacto en la politica coincidan
+
+### 6. Derechos del usuario
+
+- Verificar que las acciones de eliminacion declaradas existan en el service layer
+- Verificar toggle de perfil publico/privado
+- Verificar opt-in de analytics
+
+## Output
+
+Genera un reporte con:
+
+1. **Estado**: OK / DESACTUALIZADA
+2. **Discrepancias encontradas** (si hay)
+3. **Sugerencias de actualizacion** (si hay)
+
+Si encuentras discrepancias, lista exactamente que lineas de `PrivacyPolicy.tsx` necesitan actualizacion y que deberian decir.

--- a/PROCEDURES.md
+++ b/PROCEDURES.md
@@ -105,11 +105,13 @@ Esto permite que cada agente tenga su propio directorio con su propia rama, sin 
 
 Después de mergear un PR a `main`:
 
-1. **Bump de versión** — Incrementar en `package.json` y `docs/PROJECT_REFERENCE.md`:
+1. **Verificar CI** — Esperar a que GitHub Actions termine y confirmar que pasa. Si falla, diagnosticar y fixear inmediatamente. Main nunca debe quedar roto.
+2. **Bump de versión** — Incrementar en `package.json` y `docs/PROJECT_REFERENCE.md`:
    - PATCH (1.1.x) para fixes
    - MINOR (1.x.0) para features
    - MAJOR (x.0.0) cada 10 iteraciones
-2. **Actualizar `docs/PROJECT_REFERENCE.md`** — Agregar el issue y PR a la tabla de issues resueltos
+3. **Actualizar `docs/PROJECT_REFERENCE.md`** — Agregar el issue y PR a la tabla de issues resueltos
+4. **Auditar política de privacidad** — Ejecutar el agente `privacy-policy` para verificar que la política siga actualizada respecto a los cambios mergeados. Si hay discrepancias, actualizarla en el mismo merge o en un commit inmediato.
 
 ### Convenciones de naming
 

--- a/docs/feat-privacy-policy/plan.md
+++ b/docs/feat-privacy-policy/plan.md
@@ -1,0 +1,36 @@
+# Plan: Politica de privacidad
+
+## Orden de implementacion
+
+### Paso 1: Nuevas categorias de feedback
+
+1. Agregar `'datos_usuario' | 'datos_comercio'` a `FeedbackCategory` en `src/types/index.ts`
+2. Actualizar `VALID_CATEGORIES` en `src/services/feedback.ts`
+3. Actualizar whitelist en `firestore.rules`
+4. Actualizar chips en `src/components/menu/FeedbackForm.tsx` con labels y flexWrap
+5. Actualizar `categoryColor` en `src/components/admin/FeedbackList.tsx`
+
+**Verificar**: `npx tsc --noEmit -p tsconfig.app.json`
+
+### Paso 2: Componente PrivacyPolicy
+
+1. Crear `src/components/menu/PrivacyPolicy.tsx` con contenido estatico
+
+### Paso 3: Integrar en SideMenu
+
+1. Agregar `'privacy'` al tipo Section y SECTION_TITLES
+2. Importar y renderizar PrivacyPolicy
+3. Agregar link en footer del menu
+
+### Paso 4: Test local
+
+1. `npm run lint`
+2. `npm run test:run`
+3. `npm run build`
+4. `npm run dev` — verificar:
+   - Link "Politica de privacidad" visible en footer del menu
+   - Click abre seccion con contenido completo
+   - Scroll funciona en mobile
+   - Dark mode compatible
+   - Nuevas categorias de feedback visibles en el formulario
+   - Chips no se cortan en mobile (flexWrap)

--- a/docs/feat-privacy-policy/prd.md
+++ b/docs/feat-privacy-policy/prd.md
@@ -1,0 +1,83 @@
+# PRD: Politica de privacidad
+
+## Issue
+
+[#56](https://github.com/benoffi7/modo-mapa/issues/56)
+
+## Problema
+
+La app no tiene una politica de privacidad visible para los usuarios. Con Firebase Analytics activo y la opcion de opt-out (#61), es necesario informar a los usuarios sobre que datos se recopilan y como se usan.
+
+## Objetivo
+
+Crear una pagina de politica de privacidad accesible desde el menu lateral que cubra todas las practicas de datos de la app.
+
+## Requisitos funcionales
+
+### RF-1: Contenido de la politica
+
+La politica debe cubrir:
+
+1. **Datos recopilados**
+   - Auth anonimo (UID generado automaticamente)
+   - Contenido generado: comentarios, ratings, favoritos, tags, fotos de menu, feedback, nivel de gasto
+   - Datos de uso: Firebase Analytics (GA4) — eventos anonimos de navegacion y uso
+
+2. **Almacenamiento**
+   - Cloud Firestore (datos estructurados)
+   - Firebase Storage (fotos de menu)
+   - localStorage (preferencias locales: tema, visitas recientes, consentimiento analytics)
+
+3. **Seguridad**
+   - Firebase App Check (reCAPTCHA Enterprise)
+   - Firestore Security Rules (acceso por usuario)
+   - Rate limiting en Cloud Functions
+   - Moderacion automatica de contenido
+
+4. **Derechos del usuario**
+   - Desactivar Analytics desde Configuracion (#61)
+   - Eliminar contenido propio (comentarios, ratings, favoritos, tags)
+   - Perfil publico/privado configurable
+
+5. **Contacto**
+   - Usar el formulario de Feedback existente con nuevas categorias:
+     - "Datos de usuario" — consultas sobre datos personales, privacidad, eliminacion
+     - "Datos de comercio" — consultas sobre informacion de comercios
+
+### RF-2: Ubicacion en la UI
+
+- **Link en footer del menu lateral** (seccion navegacion principal)
+- Abre como seccion dentro del SideMenu (patron existente: `activeSection`)
+- No requiere nueva ruta — consistente con el patron de secciones del menu
+
+### RF-3: Formato
+
+- Texto estatico en espanol (es-AR)
+- Secciones con titulos claros
+- Scroll dentro del drawer del menu lateral
+- Fecha de ultima actualizacion visible
+
+## Requisitos no funcionales
+
+- El contenido es estatico — no requiere fetch a Firestore
+- Debe ser legible en mobile (texto con buen contraste, font size adecuado)
+- Compatible con dark mode
+- No requiere autenticacion para verlo (pero esta dentro del menu lateral que requiere que la app este cargada)
+
+## Fuera de alcance
+
+- Banner de consentimiento de cookies (la app usa localStorage, no cookies de tracking)
+- Pagina standalone con URL publica (se puede agregar despues si es necesario)
+- Traduccion a otros idiomas
+- Compliance legal formal (GDPR/CCPA) — app interna para empleados
+
+## Dependencias
+
+- Opt-out de Analytics (#61) — para poder referenciar la opcion en la politica
+
+## Notas de implementacion
+
+- Agregar `'privacy'` al tipo `SectionType` en SideMenu
+- Crear componente `PrivacyPolicy.tsx` en `src/components/menu/`
+- Agregar item de navegacion con icono `PolicyOutlined` o `PrivacyTipOutlined`
+- Footer link adicional con texto "Politica de privacidad"

--- a/docs/feat-privacy-policy/specs.md
+++ b/docs/feat-privacy-policy/specs.md
@@ -1,0 +1,113 @@
+# Specs: Politica de privacidad
+
+## Archivos a crear
+
+### `src/components/menu/PrivacyPolicy.tsx`
+
+Componente estatico con el contenido de la politica de privacidad. Secciones con Typography de MUI, scroll natural dentro del drawer.
+
+Secciones:
+
+1. **Informacion general** — descripcion de la app
+2. **Datos que recopilamos** — auth anonimo, contenido generado, analytics
+3. **Almacenamiento** — Firestore, Storage, localStorage
+4. **Seguridad** — App Check, rules, rate limiting, moderacion
+5. **Tus derechos** — desactivar analytics, eliminar contenido, perfil privado
+6. **Contacto** — link a seccion Feedback con categorias de datos
+
+```tsx
+import { Box, Typography, Divider } from '@mui/material';
+
+export default function PrivacyPolicy() {
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+        Ultima actualizacion: marzo 2026
+      </Typography>
+      {/* Sections... */}
+    </Box>
+  );
+}
+```
+
+## Archivos a modificar
+
+### `src/types/index.ts`
+
+Agregar nuevas categorias de feedback:
+
+```typescript
+export type FeedbackCategory = 'bug' | 'sugerencia' | 'datos_usuario' | 'datos_comercio' | 'otro';
+```
+
+### `firestore.rules`
+
+Actualizar whitelist de categorias de feedback:
+
+```text
+&& request.resource.data.category in ['bug', 'sugerencia', 'datos_usuario', 'datos_comercio', 'otro']
+```
+
+### `src/services/feedback.ts`
+
+Actualizar `VALID_CATEGORIES`:
+
+```typescript
+const VALID_CATEGORIES: FeedbackCategory[] = ['bug', 'sugerencia', 'datos_usuario', 'datos_comercio', 'otro'];
+```
+
+### `src/components/menu/FeedbackForm.tsx`
+
+Actualizar array de categorias y labels:
+
+```typescript
+const CATEGORIES: { value: FeedbackCategory; label: string }[] = [
+  { value: 'bug', label: 'Bug' },
+  { value: 'sugerencia', label: 'Sugerencia' },
+  { value: 'datos_usuario', label: 'Datos de usuario' },
+  { value: 'datos_comercio', label: 'Datos de comercio' },
+  { value: 'otro', label: 'Otro' },
+];
+```
+
+Usar `flexWrap: 'wrap'` en el container de chips para que entren en mobile.
+
+### `src/components/admin/FeedbackList.tsx`
+
+Actualizar `categoryColor` para las nuevas categorias:
+
+```typescript
+function categoryColor(cat: FeedbackCategory): 'error' | 'primary' | 'info' | 'warning' | 'default' {
+  if (cat === 'bug') return 'error';
+  if (cat === 'sugerencia') return 'primary';
+  if (cat === 'datos_usuario') return 'info';
+  if (cat === 'datos_comercio') return 'warning';
+  return 'default';
+}
+```
+
+### `src/components/layout/SideMenu.tsx`
+
+1. Agregar `'privacy'` al tipo `Section`
+2. Agregar titulo en `SECTION_TITLES`: `privacy: 'Politica de privacidad'`
+3. Importar `PrivacyPolicy` y renderizar en section content
+4. Agregar link en footer (entre version y dark mode toggle):
+
+```tsx
+import PrivacyTipOutlinedIcon from '@mui/icons-material/PrivacyTipOutlined';
+import PrivacyPolicy from '../menu/PrivacyPolicy';
+```
+
+Link en footer como Typography clickeable con icono:
+
+```tsx
+<Typography
+  variant="caption"
+  color="text.secondary"
+  onClick={() => setActiveSection('privacy')}
+  sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5, py: 1, cursor: 'pointer' }}
+>
+  <PrivacyTipOutlinedIcon sx={{ fontSize: 14 }} />
+  Politica de privacidad
+</Typography>
+```

--- a/firestore.rules
+++ b/firestore.rules
@@ -128,7 +128,7 @@ service cloud.firestore {
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.message.size() > 0
         && request.resource.data.message.size() <= 1000
-        && request.resource.data.category in ['bug', 'sugerencia', 'otro']
+        && request.resource.data.category in ['bug', 'sugerencia', 'datos_usuario', 'datos_comercio', 'otro']
         && request.resource.data.createdAt == request.time;
       allow read: if (request.auth != null && resource.data.userId == request.auth.uid)
                   || isAdmin();

--- a/src/components/admin/FeedbackList.tsx
+++ b/src/components/admin/FeedbackList.tsx
@@ -8,9 +8,11 @@ import type { Feedback, FeedbackCategory } from '../../types';
 import AdminPanelWrapper from './AdminPanelWrapper';
 import ActivityTable from './ActivityTable';
 
-function categoryColor(cat: FeedbackCategory): 'error' | 'primary' | 'default' {
+function categoryColor(cat: FeedbackCategory): 'error' | 'primary' | 'info' | 'warning' | 'default' {
   if (cat === 'bug') return 'error';
   if (cat === 'sugerencia') return 'primary';
+  if (cat === 'datos_usuario') return 'info';
+  if (cat === 'datos_comercio') return 'warning';
   return 'default';
 }
 

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -41,7 +41,9 @@ import FeedbackForm from '../menu/FeedbackForm';
 import StatsView from '../menu/StatsView';
 import RankingsView from '../menu/RankingsView';
 import SettingsPanel from '../menu/SettingsPanel';
+import PrivacyPolicy from '../menu/PrivacyPolicy';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import PrivacyTipOutlinedIcon from '@mui/icons-material/PrivacyTipOutlined';
 import { trackEvent } from '../../utils/analytics';
 
 declare const __APP_VERSION__: string;
@@ -54,7 +56,7 @@ interface Props {
   onClose: () => void;
 }
 
-type Section = 'nav' | 'favorites' | 'recent' | 'comments' | 'ratings' | 'feedback' | 'stats' | 'rankings' | 'settings';
+type Section = 'nav' | 'favorites' | 'recent' | 'comments' | 'ratings' | 'feedback' | 'stats' | 'rankings' | 'settings' | 'privacy';
 
 const SECTION_TITLES: Record<Exclude<Section, 'nav'>, string> = {
   favorites: 'Favoritos',
@@ -65,6 +67,7 @@ const SECTION_TITLES: Record<Exclude<Section, 'nav'>, string> = {
   stats: 'Estadísticas',
   rankings: 'Rankings',
   settings: 'Configuración',
+  privacy: 'Política de privacidad',
 };
 
 export default function SideMenu({ open, onClose }: Props) {
@@ -228,7 +231,16 @@ export default function SideMenu({ open, onClose }: Props) {
                   />
                 </ListItemButton>
                 <Divider />
-                <Typography variant="caption" color="text.disabled" sx={{ display: 'block', textAlign: 'center', py: 1.5 }}>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  onClick={() => setActiveSection('privacy')}
+                  sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5, py: 1, cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                >
+                  <PrivacyTipOutlinedIcon sx={{ fontSize: 14 }} />
+                  Política de privacidad
+                </Typography>
+                <Typography variant="caption" color="text.disabled" sx={{ display: 'block', textAlign: 'center', pb: 1.5 }}>
                   Versión {__APP_VERSION__}
                   {import.meta.env.DEV && (
                     <>
@@ -269,6 +281,7 @@ export default function SideMenu({ open, onClose }: Props) {
                 {activeSection === 'rankings' && <RankingsView />}
                 {activeSection === 'stats' && <StatsView />}
                 {activeSection === 'settings' && <SettingsPanel />}
+                {activeSection === 'privacy' && <PrivacyPolicy />}
               </Box>
             </>
           )}

--- a/src/components/menu/FeedbackForm.tsx
+++ b/src/components/menu/FeedbackForm.tsx
@@ -48,15 +48,21 @@ export default function FeedbackForm() {
         Contanos cómo podemos mejorar la app
       </Typography>
 
-      <Box sx={{ display: 'flex', gap: 0.75, mb: 2 }}>
-        {(['bug', 'sugerencia', 'otro'] as FeedbackCategory[]).map((cat) => (
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mb: 2 }}>
+        {([
+          { value: 'bug', label: 'Bug' },
+          { value: 'sugerencia', label: 'Sugerencia' },
+          { value: 'datos_usuario', label: 'Datos de usuario' },
+          { value: 'datos_comercio', label: 'Datos de comercio' },
+          { value: 'otro', label: 'Otro' },
+        ] as { value: FeedbackCategory; label: string }[]).map(({ value, label }) => (
           <Chip
-            key={cat}
-            label={cat === 'bug' ? 'Bug' : cat === 'sugerencia' ? 'Sugerencia' : 'Otro'}
+            key={value}
+            label={label}
             size="small"
-            onClick={() => setCategory(cat)}
-            variant={category === cat ? 'filled' : 'outlined'}
-            color={category === cat ? 'primary' : 'default'}
+            onClick={() => setCategory(value)}
+            variant={category === value ? 'filled' : 'outlined'}
+            color={category === value ? 'primary' : 'default'}
           />
         ))}
       </Box>

--- a/src/components/menu/PrivacyPolicy.tsx
+++ b/src/components/menu/PrivacyPolicy.tsx
@@ -1,0 +1,147 @@
+import { Box, Typography, Divider } from '@mui/material';
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Box sx={{ mb: 2.5 }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
+        {title}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return (
+    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+      {children}
+    </Typography>
+  );
+}
+
+function Li({ children }: { children: React.ReactNode }) {
+  return (
+    <Typography component="li" variant="body2" color="text.secondary" sx={{ ml: 2, mb: 0.5 }}>
+      {children}
+    </Typography>
+  );
+}
+
+export default function PrivacyPolicy() {
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="caption" color="text.disabled" sx={{ display: 'block', mb: 2 }}>
+        Última actualización: marzo 2026
+      </Typography>
+
+      <Section title="Información general">
+        <P>
+          Modo Mapa es una aplicación web interna para empleados que permite encontrar
+          comercios gastronómicos cercanos en un mapa interactivo. Los usuarios pueden
+          buscar, filtrar, calificar, comentar, marcar favoritos, etiquetar comercios,
+          subir fotos de menú y votar niveles de gasto.
+        </P>
+      </Section>
+
+      <Divider sx={{ mb: 2.5 }} />
+
+      <Section title="Datos que recopilamos">
+        <P>Al usar la app, se recopilan los siguientes datos:</P>
+        <Box component="ul" sx={{ pl: 1, mt: 0 }}>
+          <Li>
+            <strong>Identificación anónima:</strong> se genera un identificador único (UID)
+            automáticamente al ingresar. No se solicita nombre real ni email.
+          </Li>
+          <Li>
+            <strong>Nombre de usuario:</strong> un alias que elegís al registrarte (puede
+            ser cualquier nombre, no tiene que ser real).
+          </Li>
+          <Li>
+            <strong>Contenido generado:</strong> comentarios, calificaciones, favoritos,
+            etiquetas, fotos de menú, feedback y votos de nivel de gasto.
+          </Li>
+          <Li>
+            <strong>Datos de uso (opcional):</strong> si activás &quot;Enviar datos de uso&quot;
+            en Configuración, Firebase Analytics (GA4) recopila eventos anónimos de
+            navegación y uso (ej: vistas de comercios, búsquedas). Estos datos no
+            identifican a personas individuales.
+          </Li>
+        </Box>
+      </Section>
+
+      <Divider sx={{ mb: 2.5 }} />
+
+      <Section title="Almacenamiento">
+        <Box component="ul" sx={{ pl: 1, mt: 0 }}>
+          <Li>
+            <strong>Cloud Firestore:</strong> almacena datos estructurados (comentarios,
+            calificaciones, favoritos, etc.) en servidores de Google Cloud.
+          </Li>
+          <Li>
+            <strong>Firebase Storage:</strong> almacena fotos de menú subidas por los usuarios.
+          </Li>
+          <Li>
+            <strong>localStorage:</strong> almacena preferencias locales en tu navegador
+            (tema claro/oscuro, visitas recientes, preferencia de analytics). Estos datos
+            no se envían a ningún servidor.
+          </Li>
+        </Box>
+      </Section>
+
+      <Divider sx={{ mb: 2.5 }} />
+
+      <Section title="Seguridad">
+        <P>Implementamos las siguientes medidas para proteger tus datos:</P>
+        <Box component="ul" sx={{ pl: 1, mt: 0 }}>
+          <Li>
+            <strong>Firebase App Check:</strong> verifica que las solicitudes provienen
+            de la app legítima.
+          </Li>
+          <Li>
+            <strong>Reglas de acceso:</strong> cada usuario solo puede modificar su propio
+            contenido. Los datos de otros usuarios son de solo lectura.
+          </Li>
+          <Li>
+            <strong>Límites de uso:</strong> se aplican límites para prevenir abuso
+            (ej: máximo de comentarios por día).
+          </Li>
+          <Li>
+            <strong>Moderación automática:</strong> el contenido se revisa automáticamente
+            para detectar lenguaje inapropiado.
+          </Li>
+        </Box>
+      </Section>
+
+      <Divider sx={{ mb: 2.5 }} />
+
+      <Section title="Tus derechos">
+        <P>Como usuario, podés:</P>
+        <Box component="ul" sx={{ pl: 1, mt: 0 }}>
+          <Li>
+            <strong>Desactivar Analytics:</strong> desde Configuración, podés activar o
+            desactivar el envío de datos de uso en cualquier momento.
+          </Li>
+          <Li>
+            <strong>Eliminar tu contenido:</strong> podés borrar tus comentarios,
+            calificaciones, favoritos y etiquetas desde la app.
+          </Li>
+          <Li>
+            <strong>Controlar tu perfil:</strong> podés elegir si tu perfil es público
+            o privado desde Configuración.
+          </Li>
+        </Box>
+      </Section>
+
+      <Divider sx={{ mb: 2.5 }} />
+
+      <Section title="Contacto">
+        <P>
+          Si tenés consultas sobre tus datos personales o los datos de comercios,
+          podés enviarnos un mensaje desde la sección <strong>Feedback</strong> del
+          menú lateral usando las categorías &quot;Datos de usuario&quot; o
+          &quot;Datos de comercio&quot;.
+        </P>
+      </Section>
+    </Box>
+  );
+}

--- a/src/services/feedback.ts
+++ b/src/services/feedback.ts
@@ -7,7 +7,7 @@ import { COLLECTIONS } from '../config/collections';
 import { trackEvent } from '../utils/analytics';
 import type { FeedbackCategory } from '../types';
 
-const VALID_CATEGORIES: FeedbackCategory[] = ['bug', 'sugerencia', 'otro'];
+const VALID_CATEGORIES: FeedbackCategory[] = ['bug', 'sugerencia', 'datos_usuario', 'datos_comercio', 'otro'];
 
 export async function sendFeedback(
   userId: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,7 +70,7 @@ export interface Favorite {
   createdAt: Date;
 }
 
-export type FeedbackCategory = 'bug' | 'sugerencia' | 'otro';
+export type FeedbackCategory = 'bug' | 'sugerencia' | 'datos_usuario' | 'datos_comercio' | 'otro';
 
 export interface Feedback {
   id: string;


### PR DESCRIPTION
## Summary

- Add "Política de privacidad" section in SideMenu with footer link
- Add 2 new feedback categories: "Datos de usuario" and "Datos de comercio" for privacy queries
- Create privacy-policy audit agent for post-merge verification
- Update PROCEDURES.md with privacy policy audit step

## Changes

| File | Change |
|------|--------|
| `src/components/menu/PrivacyPolicy.tsx` | New — static privacy policy content |
| `src/components/layout/SideMenu.tsx` | +privacy section type, render, footer link |
| `src/types/index.ts` | +`datos_usuario`, `datos_comercio` to FeedbackCategory |
| `src/services/feedback.ts` | +new categories in VALID_CATEGORIES |
| `firestore.rules` | +new categories in feedback whitelist |
| `src/components/menu/FeedbackForm.tsx` | +new category chips with flexWrap |
| `src/components/admin/FeedbackList.tsx` | +colors for new categories |
| `.claude/agents/privacy-policy.md` | New — audit agent |
| `PROCEDURES.md` | +privacy audit in post-merge checklist |

## Test plan

- [ ] "Política de privacidad" link visible in SideMenu footer
- [ ] Click opens privacy policy section with full content
- [ ] Back button returns to nav
- [ ] Scrollable on mobile
- [ ] Dark mode compatible
- [ ] Feedback form shows 5 categories (Bug, Sugerencia, Datos de usuario, Datos de comercio, Otro)
- [ ] Chips wrap on mobile (flexWrap)
- [ ] Can submit feedback with new categories
- [ ] Admin panel shows new categories with correct colors
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run test:run` passes (74/74)
- [ ] `npm run build` succeeds

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)