### PR TITLE
fix: security Round 2 — N1, N2, N3, H2, M1

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -36,6 +36,7 @@ service cloud.firestore {
     match /favorites/{docId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'businessId', 'createdAt'])
         && request.resource.data.userId == request.auth.uid
         && isValidBusinessId(request.resource.data.businessId)
         && request.resource.data.createdAt == request.time;
@@ -69,6 +70,7 @@ service cloud.firestore {
     match /ratings/{docId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'businessId', 'score', 'createdAt', 'updatedAt', 'criteria'])
         && request.resource.data.userId == request.auth.uid
         && isValidBusinessId(request.resource.data.businessId)
         && request.resource.data.score is int
@@ -93,12 +95,12 @@ service cloud.firestore {
     // Owner puede crear con userName (1-30), text (1-500) y timestamp validado.
     // Puede incluir parentId opcional (para respuestas/threads).
     // Owner puede editar solo el texto (1-500) con updatedAt validado.
-    // Cualquier usuario autenticado puede incrementar/decrementar replyCount (para threads).
+    // replyCount es gestionado exclusivamente por Cloud Functions (onCommentCreated/Deleted).
     // Owner puede eliminar sus propios comentarios.
     match /comments/{docId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
-        && request.resource.data.keys().hasOnly(['userId', 'userName', 'businessId', 'text', 'createdAt', 'parentId', 'replyCount'])
+        && request.resource.data.keys().hasOnly(['userId', 'userName', 'businessId', 'text', 'createdAt', 'parentId'])
         && request.resource.data.userId == request.auth.uid
         && isValidBusinessId(request.resource.data.businessId)
         && request.resource.data.userName.size() > 0
@@ -106,31 +108,16 @@ service cloud.firestore {
         && request.resource.data.text.size() > 0
         && request.resource.data.text.size() <= 500
         && request.resource.data.createdAt == request.time
-        && (!('parentId' in request.resource.data) || (request.resource.data.parentId is string && request.resource.data.parentId.size() > 0 && request.resource.data.parentId.size() <= 40))
-        && (!('replyCount' in request.resource.data) || request.resource.data.replyCount == 0);
+        && (!('parentId' in request.resource.data) || (request.resource.data.parentId is string && request.resource.data.parentId.size() > 0 && request.resource.data.parentId.size() <= 40));
       allow update: if request.auth != null
-        && (
-          // Owner can edit text
-          (resource.data.userId == request.auth.uid
-            && request.resource.data.text.size() > 0
-            && request.resource.data.text.size() <= 500
-            && request.resource.data.updatedAt == request.time
-            && request.resource.data.userId == resource.data.userId
-            && request.resource.data.businessId == resource.data.businessId
-            && request.resource.data.userName == resource.data.userName
-            && request.resource.data.createdAt == resource.data.createdAt)
-          ||
-          // Any authenticated user can increment/decrement replyCount by exactly 1 (for thread replies)
-          (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['replyCount'])
-            && request.resource.data.replyCount is int
-            && request.resource.data.replyCount >= 0
-            && (
-              // First reply: replyCount goes from non-existent to 1
-              (!('replyCount' in resource.data) && request.resource.data.replyCount == 1)
-              // Subsequent: +1 or -1
-              || ('replyCount' in resource.data && (request.resource.data.replyCount == resource.data.replyCount + 1 || request.resource.data.replyCount == resource.data.replyCount - 1))
-            ))
-        );
+        && resource.data.userId == request.auth.uid
+        && request.resource.data.text.size() > 0
+        && request.resource.data.text.size() <= 500
+        && request.resource.data.updatedAt == request.time
+        && request.resource.data.userId == resource.data.userId
+        && request.resource.data.businessId == resource.data.businessId
+        && request.resource.data.userName == resource.data.userName
+        && request.resource.data.createdAt == resource.data.createdAt;
       allow delete: if request.auth != null
         && resource.data.userId == request.auth.uid;
     }
@@ -140,6 +127,7 @@ service cloud.firestore {
     match /commentLikes/{docId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'commentId', 'createdAt'])
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.commentId is string
         && request.resource.data.commentId.size() > 0
@@ -154,6 +142,7 @@ service cloud.firestore {
     match /userTags/{docId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'businessId', 'tagId', 'createdAt'])
         && request.resource.data.userId == request.auth.uid
         && isValidBusinessId(request.resource.data.businessId)
         && request.resource.data.tagId in ['barato', 'apto_celiacos', 'apto_veganos', 'rapido', 'delivery', 'buena_atencion']
@@ -167,6 +156,7 @@ service cloud.firestore {
     // category debe ser uno de: bug, sugerencia, otro.
     match /feedback/{docId} {
       allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'message', 'category', 'createdAt', 'rating'])
         && request.resource.data.userId == request.auth.uid
         && request.resource.data.message.size() > 0
         && request.resource.data.message.size() <= 1000
@@ -183,6 +173,7 @@ service cloud.firestore {
     match /customTags/{docId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'businessId', 'label', 'createdAt'])
         && request.resource.data.userId == request.auth.uid
         && isValidBusinessId(request.resource.data.businessId)
         && request.resource.data.label is string
@@ -191,6 +182,7 @@ service cloud.firestore {
         && request.resource.data.createdAt == request.time;
       allow update: if request.auth != null
         && resource.data.userId == request.auth.uid
+        && request.resource.data.userId == resource.data.userId
         && request.resource.data.label is string
         && request.resource.data.label.size() > 0
         && request.resource.data.label.size() <= 30;
@@ -239,6 +231,7 @@ service cloud.firestore {
     match /priceLevels/{docId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'businessId', 'level', 'createdAt', 'updatedAt'])
         && request.resource.data.userId == request.auth.uid
         && isValidBusinessId(request.resource.data.businessId)
         && request.resource.data.level is int
@@ -247,7 +240,8 @@ service cloud.firestore {
         && request.resource.data.createdAt == request.time
         && request.resource.data.updatedAt == request.time;
       allow update: if request.auth != null
-        && request.resource.data.userId == request.auth.uid
+        && resource.data.userId == request.auth.uid
+        && request.resource.data.userId == resource.data.userId
         && request.resource.data.level is int
         && request.resource.data.level >= 1
         && request.resource.data.level <= 3

--- a/functions/src/triggers/comments.ts
+++ b/functions/src/triggers/comments.ts
@@ -1,5 +1,5 @@
 import { onDocumentCreated, onDocumentDeleted, onDocumentUpdated } from 'firebase-functions/v2/firestore';
-import { getFirestore } from 'firebase-admin/firestore';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { checkRateLimit } from '../utils/rateLimiter';
 import { checkModeration } from '../utils/moderator';
 import { incrementCounter, trackWrite, trackDelete } from '../utils/counters';
@@ -45,7 +45,14 @@ export const onCommentCreated = onDocumentCreated(
       });
     }
 
-    // 3. Counters
+    // 3. Increment parent replyCount (server-side — H2 security fix)
+    const parentId = data.parentId as string | undefined;
+    if (parentId) {
+      const parentRef = db.collection('comments').doc(parentId);
+      await parentRef.update({ replyCount: FieldValue.increment(1) });
+    }
+
+    // 4. Counters
     await incrementCounter(db, 'comments', 1);
     await trackWrite(db, 'comments');
   },
@@ -84,8 +91,37 @@ export const onCommentUpdated = onDocumentUpdated(
 
 export const onCommentDeleted = onDocumentDeleted(
   'comments/{commentId}',
-  async () => {
+  async (event) => {
     const db = getFirestore();
+    const data = event.data?.data();
+    const commentId = event.params.commentId;
+
+    // 1. Decrement parent replyCount if this was a reply (H2 security fix)
+    const parentId = data?.parentId as string | undefined;
+    if (parentId) {
+      const parentRef = db.collection('comments').doc(parentId);
+      const parentSnap = await parentRef.get();
+      if (parentSnap.exists) {
+        const currentCount = (parentSnap.data()?.replyCount as number) ?? 0;
+        await parentRef.update({ replyCount: Math.max(0, currentCount - 1) });
+      }
+    }
+
+    // 2. Cascade delete orphaned replies if this was a parent comment (M1 fix)
+    const repliesSnap = await db.collection('comments')
+      .where('parentId', '==', commentId)
+      .get();
+
+    if (!repliesSnap.empty) {
+      const batch = db.batch();
+      for (const replyDoc of repliesSnap.docs) {
+        batch.delete(replyDoc.ref);
+      }
+      await batch.commit();
+      // Each deleted reply will trigger its own onCommentDeleted (for counter decrement)
+    }
+
+    // 3. Counters
     await incrementCounter(db, 'comments', -1);
     await trackDelete(db, 'comments');
   },

--- a/src/components/business/BusinessComments.tsx
+++ b/src/components/business/BusinessComments.tsx
@@ -177,7 +177,7 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
     const timer = setTimeout(async () => {
       if (!user) return;
       try {
-        await deleteComment(comment.id, user.uid, comment.parentId);
+        await deleteComment(comment.id, user.uid);
         onCommentsChange();
       } catch (error) {
         if (import.meta.env.DEV) console.error('Error deleting comment:', error);

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -1,7 +1,7 @@
 /**
  * Firestore service for the `comments` collection.
  */
-import { collection, addDoc, deleteDoc, setDoc, updateDoc, doc, serverTimestamp, increment, writeBatch } from 'firebase/firestore';
+import { collection, addDoc, deleteDoc, setDoc, updateDoc, doc, serverTimestamp } from 'firebase/firestore';
 import type { CollectionReference } from 'firebase/firestore';
 import { db } from '../config/firebase';
 import { COLLECTIONS } from '../config/collections';
@@ -31,31 +31,17 @@ export async function addComment(
     throw new Error('User name must be 1-30 characters');
   }
 
+  const commentData: Record<string, unknown> = {
+    userId,
+    userName: trimmedName,
+    businessId,
+    text: trimmedText,
+    createdAt: serverTimestamp(),
+  };
   if (parentId) {
-    // Use batch for atomic reply + parent replyCount increment
-    const batch = writeBatch(db);
-    const newRef = doc(collection(db, COLLECTIONS.COMMENTS));
-    batch.set(newRef, {
-      userId,
-      userName,
-      businessId,
-      text,
-      createdAt: serverTimestamp(),
-      parentId,
-    });
-    batch.update(doc(db, COLLECTIONS.COMMENTS, parentId), {
-      replyCount: increment(1),
-    });
-    await batch.commit();
-  } else {
-    await addDoc(collection(db, COLLECTIONS.COMMENTS), {
-      userId,
-      userName,
-      businessId,
-      text,
-      createdAt: serverTimestamp(),
-    });
+    commentData.parentId = parentId;
   }
+  await addDoc(collection(db, COLLECTIONS.COMMENTS), commentData);
 
   invalidateQueryCache(COLLECTIONS.COMMENTS, userId);
   trackEvent('comment_submit', { business_id: businessId, is_edit: false, is_reply: !!parentId });
@@ -74,19 +60,10 @@ export async function editComment(commentId: string, userId: string, newText: st
   trackEvent('comment_submit', { is_edit: true });
 }
 
-export async function deleteComment(commentId: string, userId: string, parentId?: string): Promise<void> {
-  if (parentId) {
-    // Use batch for atomic delete + parent replyCount decrement
-    const batch = writeBatch(db);
-    batch.delete(doc(db, COLLECTIONS.COMMENTS, commentId));
-    batch.update(doc(db, COLLECTIONS.COMMENTS, parentId), {
-      replyCount: increment(-1),
-    });
-    await batch.commit();
-  } else {
-    await deleteDoc(doc(db, COLLECTIONS.COMMENTS, commentId));
-  }
-
+export async function deleteComment(commentId: string, userId: string): Promise<void> {
+  await deleteDoc(doc(db, COLLECTIONS.COMMENTS, commentId));
+  // replyCount decrement and cascade delete of orphaned replies
+  // are handled server-side by the onCommentDeleted Cloud Function.
   invalidateQueryCache(COLLECTIONS.COMMENTS, userId);
 }
 


### PR DESCRIPTION
## Summary
- **N1 (Medio)**: Fix `priceLevels` update rule — check `resource.data.userId` instead of `request.resource.data.userId`, add immutability check
- **N2 (Bajo)**: Add `keys().hasOnly()` to create rules on 7 collections (ratings, favorites, customTags, userTags, feedback, priceLevels, commentLikes)
- **N3 (Bajo)**: Add userId immutability check on `customTags` update rule
- **H2 (Alto)**: Move `replyCount` management from client-side batches to Cloud Function triggers (`onCommentCreated`/`onCommentDeleted`), removing the any-user replyCount update path from Firestore rules
- **M1 (Medio)**: Add cascade delete of orphaned replies in `onCommentDeleted` Cloud Function

Closes #70

## Test plan
- [ ] Verify comments can still be created (parent and replies)
- [ ] Verify reply count updates via Cloud Function (not client)
- [ ] Verify deleting a parent comment cascades to delete its replies
- [ ] Verify price level voting still works (create, update, delete)
- [ ] Verify custom tags can be created and edited
- [ ] Verify no field injection possible on any collection create

🤖 Generated with [Claude Code](https://claude.com/claude-code)