### PR TITLE
fix: security Round 3 — N4, N5, N6 (field injection)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -111,13 +111,10 @@ service cloud.firestore {
         && (!('parentId' in request.resource.data) || (request.resource.data.parentId is string && request.resource.data.parentId.size() > 0 && request.resource.data.parentId.size() <= 40));
       allow update: if request.auth != null
         && resource.data.userId == request.auth.uid
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['text', 'updatedAt'])
         && request.resource.data.text.size() > 0
         && request.resource.data.text.size() <= 500
-        && request.resource.data.updatedAt == request.time
-        && request.resource.data.userId == resource.data.userId
-        && request.resource.data.businessId == resource.data.businessId
-        && request.resource.data.userName == resource.data.userName
-        && request.resource.data.createdAt == resource.data.createdAt;
+        && request.resource.data.updatedAt == request.time;
       allow delete: if request.auth != null
         && resource.data.userId == request.auth.uid;
     }
@@ -217,6 +214,7 @@ service cloud.firestore {
     match /menuPhotos/{docId} {
       allow read: if request.auth != null;
       allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'businessId', 'storagePath', 'thumbnailPath', 'status', 'createdAt', 'reportCount'])
         && request.resource.data.userId == request.auth.uid
         && isValidBusinessId(request.resource.data.businessId)
         && request.resource.data.status == 'pending'
@@ -271,6 +269,7 @@ service cloud.firestore {
     match /userSettings/{userId} {
       allow read: if request.auth != null;
       allow write: if request.auth != null && request.auth.uid == userId
+        && request.resource.data.keys().hasOnly(['profilePublic', 'notificationsEnabled', 'notifyLikes', 'notifyPhotos', 'notifyRankings', 'analyticsEnabled', 'updatedAt'])
         && request.resource.data.profilePublic is bool
         && request.resource.data.notificationsEnabled is bool
         && request.resource.data.notifyLikes is bool


### PR DESCRIPTION
## Summary
- **N4 (Medio)**: Add `keys().hasOnly()` to `menuPhotos` create rule
- **N5 (Bajo)**: Add `keys().hasOnly()` to `userSettings` write rule
- **N6 (Bajo)**: Restrict `comments` update to only `text` + `updatedAt` via `affectedKeys().hasOnly()` — prevents client-side tampering with `flagged`, `replyCount`, etc.

All 3 are single-line additions in `firestore.rules`.

## Test plan
- [ ] Verify comment editing still works
- [ ] Verify user settings (theme, notifications, analytics) still save
- [ ] Verify menu photo upload still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)