### PR TITLE
docs: update reference docs post pre-launch optimizations

### DIFF
--- a/docs/reference/PROJECT_REFERENCE.md
+++ b/docs/reference/PROJECT_REFERENCE.md
@@ -60,8 +60,8 @@ Cada seccion esta en un archivo separado en [`docs/reference/`](reference/):
 
 - **Mapa**: Google Maps con 40 marcadores, busqueda, filtros por tags y precio
 - **Business Sheet**: rating (global + multi-criterio), tags (predefinidos + custom), comentarios (editar/likes/sorting/threads), nivel de gasto ($/$$/$$), foto de menu (upload/report), compartir (deep link)
-- **Menu lateral**: recientes (localStorage), sugeridos para vos, favoritos, comentarios, calificaciones, rankings, feedback, estadisticas
-- **Notificaciones**: campana con badge, drawer, polling 60s, triggers automaticos (likes, fotos, rankings)
+- **Menu lateral**: recientes (localStorage), sugeridos para vos, favoritos, comentarios, calificaciones, rankings, feedback, estadisticas. Todas las secciones lazy-loaded via `React.lazy()`
+- **Notificaciones**: campana con badge, drawer, polling 60s (visibility-aware), triggers automaticos (likes, fotos, rankings)
 - **Perfil publico**: click en nombre de usuario → drawer con stats, ranking badge (top 3) y comentarios recientes
 - **Configuracion de usuario**: panel lateral con perfil publico/privado + preferencias de notificaciones (master + granulares)
 - **Analytics**: Firebase Analytics (GA4) con eventos de negocio (business_view, rating_submit, etc.) — solo en produccion, lazy-loaded
@@ -79,3 +79,7 @@ Cada seccion esta en un archivo separado en [`docs/reference/`](reference/):
 - **Optimistic UI**: pendingRating, pendingLevel, optimistic comments/likes
 - **`key={id}` remount**: evita useEffect/refs para reset de estado, compatible con strict lint
 - **`enforceAppCheck: !IS_EMULATOR`**: App Check solo en prod, deshabilitado en emuladores
+- **Lazy Sentry**: `@sentry/react` cargado via dynamic `import()` (no en main chunk)
+- **Batched likes**: `fetchUserLikes` usa `documentId('in')` con batches de 30 (no N+1 getDoc)
+- **Price level cache**: `usePriceLevelFilter` con `limit(20K)` safety bound + TTL 5min
+- **Tests**: 161 tests (111 frontend + 50 backend) cubriendo triggers, services, hooks, contexts

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -21,10 +21,10 @@
 - **Rating**: promedio + estrellas del usuario (1-5). Optimistic UI con `pendingRating`. Boton X para borrar calificacion. Multi-criterio expandible (comida, atencion, precio, ambiente, rapidez) con promedios por criterio. Criterios definidos en `constants/criteria.ts` (`RATING_CRITERIA`). Seccion multi-criterio deshabilitada hasta que el usuario tenga un rating global. Campo `criteria?: RatingCriteria` en tipo `Rating`
 - **Tags predefinidos**: vote count + toggle del usuario
 - **Tags custom**: crear, editar, eliminar (privados por usuario)
-- **Comentarios**: lista + formulario + editar propios + undo delete (5s, multiples pendientes simultaneas) + likes (otros) + sorting (Recientes/Antiguos/Utiles). Flaggeados ocultos. Indicador "(editado)". Threads: responder a comentarios (1 nivel), colapsables con "Ver N respuestas". Replies usan `writeBatch` para crear respuesta + incrementar `replyCount` atomicamente. Campos thread: `parentId` (opcional), `replyCount` (opcional, solo en root)
+- **Comentarios**: lista + formulario + editar propios + undo delete (5s, multiples pendientes simultaneas) + likes (otros) + sorting (Recientes/Antiguos/Utiles). Flaggeados ocultos. Indicador "(editado)". Threads: responder a comentarios (1 nivel), colapsables con "Ver N respuestas". `replyCount` gestionado exclusivamente por Cloud Functions (increment en create, decrement con floor en 0 en delete). Cascade delete de replies huerfanas en `onCommentDeleted`. Campos thread: `parentId` (opcional), `replyCount` (opcional, solo en root, server-managed)
 - **Nivel de gasto**: $/$$/$$$ con votos y promedio. Optimistic UI con `pendingLevel`. Toggle: click en el mismo nivel remueve el voto (`deletePriceLevel`). Reset via `key={businessId}` en parent para forzar remount
 - **Foto de menu**: preview con thumbnail, staleness chip si >6 meses. Upload con compresion + progress + cancel (AbortController). Viewer fullscreen con boton reportar. Overlay camera icon para subir nueva foto (reemplaza boton separado)
-- Datos cargados en paralelo (`Promise.all`, 7 queries) con cache client-side (5 min TTL)
+- Datos cargados en paralelo (`Promise.all`, 7 queries) con cache client-side (5 min TTL). User likes fetched via batched `documentId('in')` queries (30 per batch, not individual getDoc per comment)
 - Race condition fix con `patchedRef` para evitar que full loads sobreescriban refetches parciales
 - Escrituras via service layer (`src/services/`)
 - Visita registrada automaticamente en localStorage al abrir
@@ -34,6 +34,7 @@
 ## Menu lateral (SideMenu)
 
 - Header con avatar, nombre, boton editar nombre
+- Todas las secciones lazy-loaded via `React.lazy()` + `Suspense` con spinner fallback (reduce main chunk ~25%)
 - Secciones:
   - **Recientes**: ultimos 20 comercios visitados (localStorage). Click navega al comercio en el mapa
   - **Sugeridos para vos**: sugerencias personalizadas via `useSuggestions` hook + `services/suggestions.ts`. Fetch de favoritos, ratings y tags del usuario → scoring client-side (Haversine para cercania). Pesos en `constants/suggestions.ts` (`SUGGESTION_WEIGHTS`): categoria=3, tags=2, cercania=1, penalizacion por ya favorito=-5 o ya calificado=-3. Chips de razon (categoria, tags, cercania). Max 10 sugerencias. Componente: `SuggestionsView.tsx`
@@ -56,7 +57,7 @@
 - Drawer con lista de notificaciones, tiempo relativo ("hace 2 min", "ayer")
 - Marcar como leida individual o todas a la vez
 - Click en notificacion navega al comercio relacionado
-- Polling cada 60s para unread count
+- Polling cada 60s para unread count (con visibility awareness: se pausa cuando el tab esta oculto para ahorrar queries)
 - Tipos: `like`, `photo_approved`, `photo_rejected`, `ranking`
 - Generadas automaticamente por Cloud Functions triggers
 - Expiran a los 30 dias (cleanup diario)
@@ -153,9 +154,9 @@ Todas las callable admin:
 
 | Trigger | Coleccion | Acciones |
 |---------|-----------|----------|
-| `onCommentCreated` | `comments` | Rate limit (20/dia) + moderacion + counters |
-| `onCommentUpdated` | `comments` | Re-moderacion del texto editado |
-| `onCommentDeleted` | `comments` | Decrement counters |
+| `onCommentCreated` | `comments` | Rate limit (20/dia) + moderacion + increment parent `replyCount` (si es reply) + counters |
+| `onCommentUpdated` | `comments` | Re-moderacion del texto editado (flag/unflag) |
+| `onCommentDeleted` | `comments` | Decrement parent `replyCount` (floor 0) + cascade delete orphaned replies + decrement counters |
 | `onCommentLikeCreated` | `commentLikes` | Increment likeCount + rate limit (50/dia) + counters + notificacion al autor (si no es self-like) |
 | `onCommentLikeDeleted` | `commentLikes` | Decrement likeCount + counters |
 | `onCustomTagCreated` | `customTags` | Rate limit (10/business) + moderacion + counters |

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -61,7 +61,9 @@ src/
 │   ├── useColorMode.ts              # Hook for dark/light mode toggle (consumes ColorModeContext)
 │   ├── useListFilters.ts            # Filtrado generico: busqueda (debounced), categoria, estrellas, ordenamiento
 │   ├── usePaginatedQuery.ts         # Paginacion generica con cursores Firestore + cache primera pagina (2 min TTL)
-│   ├── usePriceLevelFilter.ts       # Cache global de promedios de precio para filtro de mapa
+│   ├── usePriceLevelFilter.ts       # Cache global de promedios de precio para filtro de mapa (limit 20K + TTL 5min)
+│   ├── useNotifications.ts          # Hook para notificaciones in-app con polling visibility-aware
+│   ├── useProfileVisibility.ts      # Hook para visibilidad de perfil publico (cache TTL 60s)
 │   ├── useVisitHistory.ts           # Historial de visitas en localStorage (ultimos 20)
 │   ├── useUserLocation.ts           # Geolocalizacion del navegador
 │   ├── usePublicMetrics.ts          # Hook para metricas publicas de dailyMetrics
@@ -144,6 +146,9 @@ src/
 │       ├── SuggestionsView.tsx       # Sugerencias personalizadas (useSuggestions)
 │       ├── FeedbackForm.tsx
 │       ├── StatsView.tsx            # Vista publica de estadisticas (usePublicMetrics)
+│       ├── RankingsView.tsx         # Rankings semanal/mensual con medallas
+│       ├── SettingsPanel.tsx        # Configuracion de usuario (privacidad, notificaciones)
+│       ├── PrivacyPolicy.tsx        # Politica de privacidad
 │       └── ListFilters.tsx
 ```
 
@@ -156,7 +161,7 @@ src/
 | `firebase.json` | Config de hosting (CSP), functions, emuladores, reglas |
 | `.firebaserc` | Proyecto: `modo-mapa-app` |
 | `vite.config.ts` | Plugin React + VitePWA + Sentry + `__APP_VERSION__` desde package.json |
-| `src/config/sentry.ts` | Inicializacion condicional de Sentry (frontend) |
+| `src/config/sentry.ts` | Inicializacion condicional de Sentry (frontend, lazy-loaded via dynamic import) |
 | `functions/src/utils/sentry.ts` | Inicializacion + captureException de Sentry (Cloud Functions) |
 | `firestore.indexes.json` | Indices compuestos Firestore (comments, ratings, favorites por userId+timestamp) |
 | `.github/workflows/deploy.yml` | CI/CD: build + deploy Firestore rules/indexes + hosting en push a main |
@@ -174,3 +179,4 @@ src/
 | `docs/reports/security-audit-v1.4.md` | Auditoria de seguridad v1.4 |
 | `docs/reports/architecture-audit-v1.4.md` | Auditoria de arquitectura v1.4 |
 | `docs/reports/audit-phase4-v1.md` | Auditoria de seguridad y arquitectura post-phase4 (threads, criteria, suggestions) |
+| `docs/reports/pre-launch-audit.md` | Auditoria pre-lanzamiento: seguridad, arquitectura, performance, tests, recomendaciones |

--- a/docs/reference/issues.md
+++ b/docs/reference/issues.md
@@ -43,6 +43,9 @@
 | — | feat | Phase 4: threads (F5), multi-criteria (F7), suggestions (F10) + docs reorg | [#68](https://github.com/benoffi7/modo-mapa/pull/68) | Merged | — |
 | [#69](https://github.com/benoffi7/modo-mapa/issues/69) | security | Security audit Round 1: C1, H1, H3, M2, L1 | [#68](https://github.com/benoffi7/modo-mapa/pull/68) | Closed | `docs/reports/audit-phase4-v1.md` |
 | [#70](https://github.com/benoffi7/modo-mapa/issues/70) | security | Security audit Round 2: N1, N2, N3, H2, M1 + Round 3: N4, N5, N6 | [#71](https://github.com/benoffi7/modo-mapa/pull/71), [#72](https://github.com/benoffi7/modo-mapa/pull/72) | Closed | — |
+| — | chore | Pre-launch prep: docs update, coding standards, pre-launch audit report | [#74](https://github.com/benoffi7/modo-mapa/pull/74) | Merged | `docs/reports/pre-launch-audit.md` |
+| — | feat | Pre-launch optimizations: critical tests + query fixes + lazy Sentry | [#75](https://github.com/benoffi7/modo-mapa/pull/75) | Merged | — |
+| — | feat | Lazy-load SideMenu + should-have tests (#5-#7) | [#76](https://github.com/benoffi7/modo-mapa/pull/76) | Merged | — |
 
 ---
 

--- a/docs/reports/pre-launch-audit.md
+++ b/docs/reports/pre-launch-audit.md
@@ -83,40 +83,39 @@ Todas las vulnerabilidades identificadas en las 3 rondas de auditoría fueron re
 
 | Área | Archivos | Tests | Cobertura |
 |------|----------|-------|-----------|
-| Frontend hooks | 16 | 4 testeados (56 tests) | ~25% |
-| Frontend services | 14 | 0 | **0%** |
+| Frontend hooks | 16 | 6 testeados (76 tests) | ~38% |
+| Frontend services | 14 | 2 testeados (25 tests) | ~14% |
 | Frontend utils | 3 | 0 | **0%** |
 | Frontend contexts | 2 | 2 testeados (22 tests) | 100% |
-| Backend triggers | 9 | 0 | **0%** |
-| Backend utils | 6 | 3 testeados | 50% |
-| **Total** | | **74 tests passing** | |
+| Backend triggers | 9 | 2 testeados (28 tests) | ~22% |
+| Backend utils | 6 | 4 testeados (22 tests) | 67% |
+| **Total** | | **161 tests passing** | |
 
-### Top 7 tests críticos faltantes para lanzamiento
+### Top 7 tests críticos — TODOS COMPLETADOS (PRs #75, #76)
 
-1. **`functions/src/triggers/comments.ts`** — cascade delete (riesgo: DATA LOSS)
-2. **`functions/src/triggers/comments.ts`** — rate limit + moderation (riesgo: ABUSE)
-3. **`src/services/comments.ts`** — input validation
-4. **`src/services/ratings.ts`** — criteria merge logic
-5. **`src/hooks/useSuggestions.ts`** — scoring algorithm + Haversine
-6. **`functions/src/triggers/commentLikes.ts`** — likeCount + notifications
-7. **`functions/src/utils/notifications.ts`** — shouldNotify preferences
+1. ~~`functions/src/triggers/comments.ts`~~ — 18 tests (cascade delete, replyCount, rate limit, moderation, re-moderation) ✅
+2. ~~`src/services/comments.ts`~~ — 12 tests (input validation, trim, parentId) ✅
+3. ~~`src/services/ratings.ts`~~ — 10 tests (score validation, criteria merge, create vs update) ✅
+4. ~~`src/hooks/useSuggestions.ts`~~ — 10 tests (scoring, penalties, sorting, limit) ✅
+5. ~~`functions/src/triggers/commentLikes.ts`~~ — 10 tests (likeCount, rate limit, notifications) ✅
+6. ~~`functions/src/utils/notifications.ts`~~ — 9 tests (shouldNotify preferences, all types, expiry) ✅
 
 ---
 
 ## 6. Recomendaciones priorizadas para lanzamiento
 
-### Must-have (antes del launch)
+### Must-have — COMPLETADO (PR #75)
 
-1. **Tests críticos (#1-#4)**: cascade delete, rate limiting, input validation
-2. **Fix P2.1**: N+1 likes query → batched `where(documentId(), 'in', ...)`
-3. **Fix P2.2**: Add `limit()` to `usePriceLevelFilter`
+1. ~~**Tests críticos (#1-#4)**~~: cascade delete, rate limiting, input validation ✅
+2. ~~**Fix P2.1**~~: N+1 likes → batched `documentId('in')` (30 per batch) ✅
+3. ~~**Fix P2.2**~~: `limit(20K)` + TTL 5min en `usePriceLevelFilter` ✅
 
-### Should-have (primera semana post-launch)
+### Should-have — COMPLETADO (PRs #75, #76)
 
-4. **Fix P1.1**: Lazy-load Sentry
-5. **Fix P1.3**: Lazy-load SideMenu sections
-6. **Fix P2.5**: Notification polling con visibility awareness
-7. **Tests #5-#7**: suggestions scoring, likeCount, notifications
+4. ~~**Fix P1.1**~~: Sentry lazy-loaded via dynamic import ✅
+5. ~~**Fix P1.3**~~: SideMenu sections lazy-loaded (main chunk 484→361 kB gzip, -25%) ✅
+6. ~~**Fix P2.5**~~: Notification polling con visibility awareness ✅
+7. ~~**Tests #5-#7**~~: suggestions, likeCount, notifications ✅
 
 ### Nice-to-have (post-launch iterativo)
 


### PR DESCRIPTION
## Summary

- Update all reference docs to reflect changes from PRs #75 and #76
- Mark all must-have and should-have items as completed in pre-launch audit
- Update test coverage table: 74 → 161 tests
- Add new patterns: lazy Sentry, batched likes, price level cache, visibility-aware polling

## Test plan

- [x] Docs-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)