### PR TITLE
feat: phase 3 — CommentRow extraction + swipe actions (#109)

### DIFF
--- a/src/components/business/BusinessComments.tsx
+++ b/src/components/business/BusinessComments.tsx
@@ -5,9 +5,6 @@ import {
   TextField,
   Button,
   List,
-  ListItem,
-  ListItemText,
-  Avatar,
   Divider,
   IconButton,
   Snackbar,
@@ -15,22 +12,14 @@ import {
   Collapse,
 } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
-import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
-import FavoriteIcon from '@mui/icons-material/Favorite';
-import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
-import ReplyIcon from '@mui/icons-material/Reply';
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import { useAuth } from '../../context/AuthContext';
 import { addComment, editComment, deleteComment, likeComment, unlikeComment } from '../../services/comments';
-import { formatDateMedium } from '../../utils/formatDate';
+import CommentRow from './CommentRow';
 import UserProfileSheet from '../user/UserProfileSheet';
 import { useProfileVisibility } from '../../hooks/useProfileVisibility';
 import { useUndoDelete } from '../../hooks/useUndoDelete';
 import { MAX_COMMENT_LENGTH, MAX_COMMENTS_PER_DAY } from '../../constants/validation';
-import { LIKE_COLOR } from '../../constants/ui';
 import type { Comment } from '../../types';
 
 type SortMode = 'recent' | 'oldest' | 'useful';
@@ -154,15 +143,15 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
     setIsSubmitting(false);
   };
 
-  const handleStartEdit = (comment: Comment) => {
+  const handleStartEdit = useCallback((comment: Comment) => {
     setEditingId(comment.id);
     setEditText(comment.text);
-  };
+  }, []);
 
-  const handleCancelEdit = () => {
+  const handleCancelEdit = useCallback(() => {
     setEditingId(null);
     setEditText('');
-  };
+  }, []);
 
   const handleSaveEdit = async () => {
     if (!editingId || !user || !editText.trim()) return;
@@ -178,9 +167,9 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
     setIsSavingEdit(false);
   };
 
-  const handleDelete = (comment: Comment) => {
+  const handleDelete = useCallback((comment: Comment) => {
     markCommentForDelete(comment.id, comment);
-  };
+  }, [markCommentForDelete]);
 
   const handleToggleLike = async (commentId: string) => {
     if (!user) return;
@@ -216,13 +205,13 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
   };
 
   // Reply handlers
-  const handleStartReply = (comment: Comment) => {
+  const handleStartReply = useCallback((comment: Comment) => {
     setReplyingTo({ id: comment.id, userName: comment.userName });
     setReplyText('');
     // Auto-expand thread when replying
     setExpandedThreads((prev) => new Set(prev).add(comment.id));
     setTimeout(() => replyInputRef.current?.focus(), 100);
-  };
+  }, []);
 
   const handleCancelReply = () => {
     setReplyingTo(null);
@@ -256,188 +245,44 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
     });
   };
 
+  const handleShowProfile = useCallback((userId: string, userName: string) => {
+    setProfileUser({ id: userId, name: userName });
+  }, []);
+
+  const handleEditTextChange = useCallback((text: string) => {
+    setEditText(text);
+  }, []);
+
   const getReplyCount = (comment: Comment): number => {
     // Use denormalized count, but fall back to actual replies in local data
     const localReplies = repliesByParent.get(comment.id);
     return comment.replyCount ?? localReplies?.length ?? 0;
   };
 
-  // Render a single comment row (used for both top-level and replies)
-  const renderComment = (comment: Comment, isReply: boolean) => {
-    // If this comment is pending delete, skip rendering
+  const renderCommentRow = (comment: Comment, isReply: boolean) => {
     if (isPendingDelete(comment.id)) return null;
-
-    // Deleted parent placeholder
-    const isDeletedParent = !comment.text && !comment.userName;
-
     return (
-      <ListItem
+      <CommentRow
         key={comment.id}
-        alignItems="flex-start"
-        disablePadding
-        sx={{
-          py: 1,
-          ...(isReply ? { pl: 2 } : {}),
-        }}
-      >
-        <Avatar
-          sx={{
-            width: isReply ? 26 : 32,
-            height: isReply ? 26 : 32,
-            mr: 1.5,
-            mt: 0.5,
-            fontSize: isReply ? '0.75rem' : '0.85rem',
-            bgcolor: 'primary.main',
-          }}
-        >
-          {(comment.userName || 'A').charAt(0).toUpperCase()}
-        </Avatar>
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
-            <Typography
-              component="span"
-              variant="body2"
-              sx={{
-                fontWeight: 600,
-                fontSize: isReply ? '0.8rem' : undefined,
-                ...(profileVisibility.get(comment.userId) ? {
-                  cursor: 'pointer',
-                  '&:hover': { textDecoration: 'underline' },
-                } : {}),
-              }}
-              onClick={() => profileVisibility.get(comment.userId) && setProfileUser({ id: comment.userId, name: comment.userName })}
-            >
-              {isDeletedParent ? 'Comentario eliminado' : (comment.userName || 'Anónimo')}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
-              {formatDateMedium(comment.createdAt)}
-            </Typography>
-            {comment.updatedAt && (
-              <Typography variant="caption" color="text.disabled" sx={{ fontStyle: 'italic' }}>
-                (editado)
-              </Typography>
-            )}
-          </Box>
-
-          {editingId === comment.id ? (
-            <Box sx={{ mt: 0.5 }}>
-              <TextField
-                fullWidth
-                size="small"
-                multiline
-                maxRows={4}
-                value={editText}
-                onChange={(e) => setEditText(e.target.value)}
-                slotProps={{ htmlInput: { maxLength: MAX_COMMENT_LENGTH } }}
-                helperText={`${editText.length}/${MAX_COMMENT_LENGTH}`}
-              />
-              <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5 }}>
-                <IconButton
-                  size="small"
-                  color="primary"
-                  onClick={handleSaveEdit}
-                  disabled={isSavingEdit || !editText.trim()}
-                  aria-label="Guardar edición"
-                >
-                  <CheckIcon fontSize="small" />
-                </IconButton>
-                <IconButton size="small" onClick={handleCancelEdit} disabled={isSavingEdit} aria-label="Cancelar edición">
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            </Box>
-          ) : (
-            <ListItemText
-              secondary={comment.text}
-              slotProps={{ secondary: { component: 'span', display: 'block', ...(isReply ? { fontSize: '0.8rem' } : {}) } }}
-              sx={{ m: 0 }}
-            />
-          )}
-
-          {/* Action buttons row: like + reply count + reply button */}
-          {editingId !== comment.id && (
-            <Box sx={{ display: 'flex', alignItems: 'center', mt: 0.5, gap: 1 }}>
-              {/* Like button (not for own comments) */}
-              {user && comment.userId !== user.uid && (
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <IconButton
-                    size="small"
-                    onClick={() => handleToggleLike(comment.id)}
-                    sx={{ color: isLiked(comment.id) ? LIKE_COLOR : 'text.secondary', p: 0.5 }}
-                    aria-label={isLiked(comment.id) ? 'Quitar like' : 'Dar like'}
-                  >
-                    {isLiked(comment.id) ? <FavoriteIcon sx={{ fontSize: 16 }} /> : <FavoriteBorderIcon sx={{ fontSize: 16 }} />}
-                  </IconButton>
-                  {getLikeCount(comment) > 0 && (
-                    <Typography variant="caption" color="text.secondary" sx={{ ml: 0.25 }}>
-                      {getLikeCount(comment)}
-                    </Typography>
-                  )}
-                </Box>
-              )}
-              {/* Show like count for own comments (read-only) */}
-              {user && comment.userId === user.uid && getLikeCount(comment) > 0 && (
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <FavoriteIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
-                  <Typography variant="caption" color="text.disabled" sx={{ ml: 0.25 }}>
-                    {getLikeCount(comment)}
-                  </Typography>
-                </Box>
-              )}
-
-              {/* Reply count indicator (top-level only) */}
-              {!isReply && getReplyCount(comment) > 0 && (
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <ChatBubbleOutlineIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
-                  <Typography variant="caption" color="text.secondary" sx={{ ml: 0.25 }}>
-                    {getReplyCount(comment)}
-                  </Typography>
-                </Box>
-              )}
-
-              {/* Reply button (top-level only, for logged-in users) */}
-              {!isReply && user && (
-                <Button
-                  size="small"
-                  startIcon={<ReplyIcon sx={{ fontSize: 14 }} />}
-                  onClick={() => handleStartReply(comment)}
-                  sx={{
-                    textTransform: 'none',
-                    fontSize: '0.75rem',
-                    color: 'text.secondary',
-                    minWidth: 'auto',
-                    p: '2px 6px',
-                  }}
-                >
-                  Responder
-                </Button>
-              )}
-            </Box>
-          )}
-        </Box>
-
-        {/* Edit + Delete buttons for own comments */}
-        {user && comment.userId === user.uid && editingId !== comment.id && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', ml: 0.5 }}>
-            <IconButton
-              size="small"
-              onClick={() => handleStartEdit(comment)}
-              sx={{ color: 'text.secondary' }}
-              aria-label="Editar comentario"
-            >
-              <EditOutlinedIcon sx={{ fontSize: 18 }} />
-            </IconButton>
-            <IconButton
-              size="small"
-              onClick={() => handleDelete(comment)}
-              sx={{ color: 'text.secondary' }}
-              aria-label="Eliminar comentario"
-            >
-              <DeleteOutlineIcon sx={{ fontSize: 18 }} />
-            </IconButton>
-          </Box>
-        )}
-      </ListItem>
+        comment={comment}
+        isOwn={comment.userId === user?.uid}
+        isLiked={isLiked(comment.id)}
+        likeCount={getLikeCount(comment)}
+        replyCount={isReply ? 0 : getReplyCount(comment)}
+        isReply={isReply}
+        isEditing={editingId === comment.id}
+        editText={editText}
+        isSavingEdit={isSavingEdit}
+        isProfilePublic={profileVisibility.get(comment.userId) ?? false}
+        onToggleLike={handleToggleLike}
+        onStartEdit={handleStartEdit}
+        onSaveEdit={handleSaveEdit}
+        onCancelEdit={handleCancelEdit}
+        onEditTextChange={handleEditTextChange}
+        onDelete={handleDelete}
+        onReply={isReply ? undefined : handleStartReply}
+        onShowProfile={handleShowProfile}
+      />
     );
   };
 
@@ -518,7 +363,7 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
 
           return (
             <Box key={comment.id}>
-              {renderComment(comment, false)}
+              {renderCommentRow(comment, false)}
 
               {/* Thread: "Ver N respuestas" toggle + replies */}
               {replyCount > 0 && (
@@ -552,7 +397,7 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
                         gap: 1,
                       }}
                     >
-                      {visibleReplies.map((reply) => renderComment(reply, true))}
+                      {visibleReplies.map((reply) => renderCommentRow(reply, true))}
                     </Box>
                   </Collapse>
                 </Box>

--- a/src/components/business/CommentRow.tsx
+++ b/src/components/business/CommentRow.tsx
@@ -1,0 +1,239 @@
+import { memo } from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  ListItem,
+  ListItemText,
+  Avatar,
+  IconButton,
+  Button,
+} from '@mui/material';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import ReplyIcon from '@mui/icons-material/Reply';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import { formatDateMedium } from '../../utils/formatDate';
+import { LIKE_COLOR } from '../../constants/ui';
+import { MAX_COMMENT_LENGTH } from '../../constants/validation';
+import type { Comment } from '../../types';
+
+export interface CommentRowProps {
+  comment: Comment;
+  isOwn: boolean;
+  isLiked: boolean;
+  likeCount: number;
+  replyCount: number;
+  isReply?: boolean;
+  isEditing: boolean;
+  editText: string;
+  isSavingEdit: boolean;
+  isProfilePublic: boolean;
+  onToggleLike: (commentId: string) => void;
+  onStartEdit: (comment: Comment) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onEditTextChange: (text: string) => void;
+  onDelete: (comment: Comment) => void;
+  onReply?: (comment: Comment) => void;
+  onShowProfile?: (userId: string, userName: string) => void;
+}
+
+const CommentRow = memo(function CommentRow({
+  comment,
+  isOwn,
+  isLiked,
+  likeCount,
+  replyCount,
+  isReply = false,
+  isEditing,
+  editText,
+  isSavingEdit,
+  isProfilePublic,
+  onToggleLike,
+  onStartEdit,
+  onSaveEdit,
+  onCancelEdit,
+  onEditTextChange,
+  onDelete,
+  onReply,
+  onShowProfile,
+}: CommentRowProps) {
+  const isDeletedParent = !comment.text && !comment.userName;
+
+  return (
+    <ListItem
+      alignItems="flex-start"
+      disablePadding
+      sx={{
+        py: 1,
+        ...(isReply ? { pl: 2 } : {}),
+      }}
+    >
+      <Avatar
+        sx={{
+          width: isReply ? 26 : 32,
+          height: isReply ? 26 : 32,
+          mr: 1.5,
+          mt: 0.5,
+          fontSize: isReply ? '0.75rem' : '0.85rem',
+          bgcolor: 'primary.main',
+        }}
+      >
+        {(comment.userName || 'A').charAt(0).toUpperCase()}
+      </Avatar>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
+          <Typography
+            component="span"
+            variant="body2"
+            sx={{
+              fontWeight: 600,
+              fontSize: isReply ? '0.8rem' : undefined,
+              ...(isProfilePublic ? {
+                cursor: 'pointer',
+                '&:hover': { textDecoration: 'underline' },
+              } : {}),
+            }}
+            onClick={() => isProfilePublic && onShowProfile?.(comment.userId, comment.userName)}
+          >
+            {isDeletedParent ? 'Comentario eliminado' : (comment.userName || 'Anónimo')}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {formatDateMedium(comment.createdAt)}
+          </Typography>
+          {comment.updatedAt && (
+            <Typography variant="caption" color="text.disabled" sx={{ fontStyle: 'italic' }}>
+              (editado)
+            </Typography>
+          )}
+        </Box>
+
+        {isEditing ? (
+          <Box sx={{ mt: 0.5 }}>
+            <TextField
+              fullWidth
+              size="small"
+              multiline
+              maxRows={4}
+              value={editText}
+              onChange={(e) => onEditTextChange(e.target.value)}
+              disabled={isSavingEdit}
+              slotProps={{ htmlInput: { maxLength: MAX_COMMENT_LENGTH } }}
+              helperText={`${editText.length}/${MAX_COMMENT_LENGTH}`}
+            />
+            <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5 }}>
+              <IconButton
+                size="small"
+                color="primary"
+                onClick={onSaveEdit}
+                disabled={isSavingEdit || !editText.trim()}
+                aria-label="Guardar edición"
+              >
+                <CheckIcon fontSize="small" />
+              </IconButton>
+              <IconButton size="small" onClick={onCancelEdit} disabled={isSavingEdit} aria-label="Cancelar edición">
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Box>
+        ) : (
+          <ListItemText
+            secondary={comment.text}
+            slotProps={{ secondary: { component: 'span', display: 'block', ...(isReply ? { fontSize: '0.8rem' } : {}) } }}
+            sx={{ m: 0 }}
+          />
+        )}
+
+        {/* Action buttons row */}
+        {!isEditing && (
+          <Box sx={{ display: 'flex', alignItems: 'center', mt: 0.5, gap: 1 }}>
+            {/* Like button (not for own comments) */}
+            {!isOwn && (
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <IconButton
+                  size="small"
+                  onClick={() => onToggleLike(comment.id)}
+                  sx={{ color: isLiked ? LIKE_COLOR : 'text.secondary', p: 0.5 }}
+                  aria-label={isLiked ? 'Quitar like' : 'Dar like'}
+                >
+                  {isLiked ? <FavoriteIcon sx={{ fontSize: 16 }} /> : <FavoriteBorderIcon sx={{ fontSize: 16 }} />}
+                </IconButton>
+                {likeCount > 0 && (
+                  <Typography variant="caption" color="text.secondary" sx={{ ml: 0.25 }}>
+                    {likeCount}
+                  </Typography>
+                )}
+              </Box>
+            )}
+            {/* Show like count for own comments (read-only) */}
+            {isOwn && likeCount > 0 && (
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <FavoriteIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
+                <Typography variant="caption" color="text.disabled" sx={{ ml: 0.25 }}>
+                  {likeCount}
+                </Typography>
+              </Box>
+            )}
+
+            {/* Reply count indicator (top-level only) */}
+            {!isReply && replyCount > 0 && (
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <ChatBubbleOutlineIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+                <Typography variant="caption" color="text.secondary" sx={{ ml: 0.25 }}>
+                  {replyCount}
+                </Typography>
+              </Box>
+            )}
+
+            {/* Reply button (top-level only) */}
+            {!isReply && onReply && (
+              <Button
+                size="small"
+                startIcon={<ReplyIcon sx={{ fontSize: 14 }} />}
+                onClick={() => onReply(comment)}
+                sx={{
+                  textTransform: 'none',
+                  fontSize: '0.75rem',
+                  color: 'text.secondary',
+                  minWidth: 'auto',
+                  p: '2px 6px',
+                }}
+              >
+                Responder
+              </Button>
+            )}
+          </Box>
+        )}
+      </Box>
+
+      {/* Edit + Delete buttons for own comments */}
+      {isOwn && !isEditing && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', ml: 0.5 }}>
+          <IconButton
+            size="small"
+            onClick={() => onStartEdit(comment)}
+            sx={{ color: 'text.secondary' }}
+            aria-label="Editar comentario"
+          >
+            <EditOutlinedIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+          <IconButton
+            size="small"
+            onClick={() => onDelete(comment)}
+            sx={{ color: 'text.secondary' }}
+            aria-label="Eliminar comentario"
+          >
+            <DeleteOutlineIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+        </Box>
+      )}
+    </ListItem>
+  );
+});
+
+export default CommentRow;

--- a/src/components/menu/CommentsList.tsx
+++ b/src/components/menu/CommentsList.tsx
@@ -27,6 +27,7 @@ import { useAuth } from '../../context/AuthContext';
 import { useSelection } from '../../context/MapContext';
 import { usePaginatedQuery } from '../../hooks/usePaginatedQuery';
 import { useUndoDelete } from '../../hooks/useUndoDelete';
+import { useSwipeActions } from '../../hooks/useSwipeActions';
 import { allBusinesses } from '../../hooks/useBusinesses';
 import { deleteComment, editComment, getCommentsCollection } from '../../services/comments';
 import { PaginatedListShell } from './PaginatedListShell';
@@ -81,6 +82,9 @@ export default function CommentsList({ onNavigate }: Props) {
 
   // Stats (#107)
   const [statsExpanded, setStatsExpanded] = useState(false);
+
+  // Swipe actions (#109)
+  const swipe = useSwipeActions();
 
   // "Load all" when search is active
   useEffect(() => {
@@ -344,112 +348,171 @@ export default function CommentsList({ onNavigate }: Props) {
 
       {filteredComments.length > 0 && (
         <List disablePadding>
-          {filteredComments.map(({ id, comment, business }) => (
-            <ListItemButton
-              key={id}
-              onClick={() => editingId !== id && handleSelectBusiness(business)}
-              disabled={!business && editingId !== id}
-              sx={{ pr: 1, alignItems: 'flex-start' }}
-            >
-              <ListItemText
-                primary={business?.name || 'Comercio desconocido'}
-                secondary={
-                  editingId === id ? (
-                    // #106: Edit inline
-                    <Box component="span" sx={{ display: 'block', mt: 0.5 }}>
-                      <TextField
-                        fullWidth
-                        size="small"
-                        multiline
-                        maxRows={4}
-                        value={editText}
-                        onChange={(e) => setEditText(e.target.value)}
-                        disabled={isSavingEdit}
-                        slotProps={{ htmlInput: { maxLength: MAX_COMMENT_LENGTH } }}
-                        helperText={`${editText.length}/${MAX_COMMENT_LENGTH}`}
-                        onClick={(e) => e.stopPropagation()}
-                      />
-                      <Box component="span" sx={{ display: 'flex', gap: 0.5, mt: 0.5 }}>
+          {filteredComments.map(({ id, comment, business }) => {
+            const handlers = swipe.getHandlers(id);
+            const style = swipe.getStyle(id);
+            const isSwiped = swipe.swipedId === id;
+
+            return (
+              <Box
+                key={id}
+                sx={{ position: 'relative', overflow: 'hidden' }}
+                onClick={() => isSwiped && swipe.reset()}
+              >
+                {/* #109: Revealed swipe actions behind the item */}
+                {isSwiped && (
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: 0,
+                      bottom: 0,
+                      ...(swipe.direction === 'left'
+                        ? { right: 0, bgcolor: 'error.main' }
+                        : { left: 0, bgcolor: 'primary.main' }),
+                      width: 80,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <IconButton
+                      sx={{ color: '#fff' }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (swipe.direction === 'left') {
+                          markForDelete(id, comment);
+                        } else {
+                          handleStartEdit(comment);
+                        }
+                        swipe.reset();
+                      }}
+                      aria-label={swipe.direction === 'left' ? 'Eliminar' : 'Editar'}
+                    >
+                      {swipe.direction === 'left'
+                        ? <DeleteOutlineIcon />
+                        : <EditOutlinedIcon />}
+                    </IconButton>
+                  </Box>
+                )}
+
+                {/* Swipeable list item */}
+                <Box
+                  {...handlers}
+                  sx={{
+                    position: 'relative',
+                    bgcolor: 'background.paper',
+                    zIndex: 1,
+                    '@media (pointer: fine)': { touchAction: 'none' },
+                  }}
+                  style={style}
+                >
+                  <ListItemButton
+                    onClick={() => editingId !== id && !isSwiped && handleSelectBusiness(business)}
+                    disabled={!business && editingId !== id}
+                    sx={{ pr: 1, alignItems: 'flex-start' }}
+                  >
+                    <ListItemText
+                      primary={business?.name || 'Comercio desconocido'}
+                      secondary={
+                        editingId === id ? (
+                          // #106: Edit inline
+                          <Box component="span" sx={{ display: 'block', mt: 0.5 }}>
+                            <TextField
+                              fullWidth
+                              size="small"
+                              multiline
+                              maxRows={4}
+                              value={editText}
+                              onChange={(e) => setEditText(e.target.value)}
+                              disabled={isSavingEdit}
+                              slotProps={{ htmlInput: { maxLength: MAX_COMMENT_LENGTH } }}
+                              helperText={`${editText.length}/${MAX_COMMENT_LENGTH}`}
+                              onClick={(e) => e.stopPropagation()}
+                            />
+                            <Box component="span" sx={{ display: 'flex', gap: 0.5, mt: 0.5 }}>
+                              <IconButton
+                                size="small"
+                                color="primary"
+                                onClick={(e) => { e.stopPropagation(); handleSaveEdit(); }}
+                                disabled={isSavingEdit || !editText.trim()}
+                                aria-label="Guardar edición"
+                              >
+                                <CheckIcon fontSize="small" />
+                              </IconButton>
+                              <IconButton
+                                size="small"
+                                onClick={(e) => { e.stopPropagation(); handleCancelEdit(); }}
+                                disabled={isSavingEdit}
+                                aria-label="Cancelar edición"
+                              >
+                                <CloseIcon fontSize="small" />
+                              </IconButton>
+                            </Box>
+                          </Box>
+                        ) : (
+                          <>
+                            {/* Comment text */}
+                            <Typography component="span" variant="body2" color="text.secondary" sx={{ fontSize: '0.8rem', display: 'block' }}>
+                              {truncate(comment.text, 80)}
+                            </Typography>
+                            {/* #108 + #104: Metadata row */}
+                            <Box component="span" sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 0.25, flexWrap: 'wrap' }}>
+                              <Typography component="span" variant="caption" color="text.secondary">
+                                {formatRelativeTime(comment.createdAt)}
+                              </Typography>
+                              {comment.updatedAt && (
+                                <Typography component="span" variant="caption" color="text.disabled">
+                                  (editado)
+                                </Typography>
+                              )}
+                              {comment.likeCount > 0 && (
+                                <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25 }}>
+                                  <FavoriteIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+                                  <Typography component="span" variant="caption" color="text.disabled">
+                                    {comment.likeCount}
+                                  </Typography>
+                                </Box>
+                              )}
+                              {(comment.replyCount ?? 0) > 0 && (
+                                <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25 }}>
+                                  <ChatBubbleOutlineIcon sx={{ fontSize: 12, color: 'text.secondary' }} />
+                                  <Typography component="span" variant="caption" color="text.secondary">
+                                    {comment.replyCount}
+                                  </Typography>
+                                </Box>
+                              )}
+                            </Box>
+                          </>
+                        )
+                      }
+                      primaryTypographyProps={{ fontWeight: 500, fontSize: '0.9rem' }}
+                    />
+                    {/* Action buttons: edit + delete (visible fallback for accessibility) */}
+                    {editingId !== id && (
+                      <Box sx={{ display: 'flex', flexDirection: 'column', ml: 0.5 }}>
                         <IconButton
                           size="small"
-                          color="primary"
-                          onClick={(e) => { e.stopPropagation(); handleSaveEdit(); }}
-                          disabled={isSavingEdit || !editText.trim()}
-                          aria-label="Guardar edición"
+                          onClick={(e) => { e.stopPropagation(); handleStartEdit(comment); }}
+                          sx={{ color: 'text.secondary' }}
+                          aria-label="Editar comentario"
                         >
-                          <CheckIcon fontSize="small" />
+                          <EditOutlinedIcon sx={{ fontSize: 18 }} />
                         </IconButton>
                         <IconButton
                           size="small"
-                          onClick={(e) => { e.stopPropagation(); handleCancelEdit(); }}
-                          disabled={isSavingEdit}
-                          aria-label="Cancelar edición"
+                          onClick={(e) => { e.stopPropagation(); markForDelete(id, comment); }}
+                          sx={{ color: 'text.secondary' }}
+                          aria-label="Eliminar comentario"
                         >
-                          <CloseIcon fontSize="small" />
+                          <DeleteOutlineIcon sx={{ fontSize: 18 }} />
                         </IconButton>
                       </Box>
-                    </Box>
-                  ) : (
-                    <>
-                      {/* Comment text */}
-                      <Typography component="span" variant="body2" color="text.secondary" sx={{ fontSize: '0.8rem', display: 'block' }}>
-                        {truncate(comment.text, 80)}
-                      </Typography>
-                      {/* #108 + #104: Metadata row */}
-                      <Box component="span" sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 0.25, flexWrap: 'wrap' }}>
-                        <Typography component="span" variant="caption" color="text.secondary">
-                          {formatRelativeTime(comment.createdAt)}
-                        </Typography>
-                        {comment.updatedAt && (
-                          <Typography component="span" variant="caption" color="text.disabled">
-                            (editado)
-                          </Typography>
-                        )}
-                        {comment.likeCount > 0 && (
-                          <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25 }}>
-                            <FavoriteIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
-                            <Typography component="span" variant="caption" color="text.disabled">
-                              {comment.likeCount}
-                            </Typography>
-                          </Box>
-                        )}
-                        {(comment.replyCount ?? 0) > 0 && (
-                          <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25 }}>
-                            <ChatBubbleOutlineIcon sx={{ fontSize: 12, color: 'text.secondary' }} />
-                            <Typography component="span" variant="caption" color="text.secondary">
-                              {comment.replyCount}
-                            </Typography>
-                          </Box>
-                        )}
-                      </Box>
-                    </>
-                  )
-                }
-                primaryTypographyProps={{ fontWeight: 500, fontSize: '0.9rem' }}
-              />
-              {/* Action buttons: edit + delete */}
-              {editingId !== id && (
-                <Box sx={{ display: 'flex', flexDirection: 'column', ml: 0.5 }}>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => { e.stopPropagation(); handleStartEdit(comment); }}
-                    sx={{ color: 'text.secondary' }}
-                    aria-label="Editar comentario"
-                  >
-                    <EditOutlinedIcon sx={{ fontSize: 18 }} />
-                  </IconButton>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => { e.stopPropagation(); markForDelete(id, comment); }}
-                    sx={{ color: 'text.secondary' }}
-                    aria-label="Eliminar comentario"
-                  >
-                    <DeleteOutlineIcon sx={{ fontSize: 18 }} />
-                  </IconButton>
+                    )}
+                  </ListItemButton>
                 </Box>
-              )}
-            </ListItemButton>
-          ))}
+              </Box>
+            );
+          })}
         </List>
       )}
 

--- a/src/hooks/useSwipeActions.ts
+++ b/src/hooks/useSwipeActions.ts
@@ -1,0 +1,122 @@
+import { useState, useRef, useCallback } from 'react';
+
+interface UseSwipeActionsOptions {
+  threshold?: number;
+}
+
+interface SwipeHandlers {
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+}
+
+export interface SwipeState {
+  /** Currently swiped item id (left or right) */
+  swipedId: string | null;
+  /** Direction of active swipe */
+  direction: 'left' | 'right' | null;
+  /** Get touch handlers for an item */
+  getHandlers: (id: string) => SwipeHandlers;
+  /** Get inline transform style for an item */
+  getStyle: (id: string) => React.CSSProperties;
+  /** Reset/close any open swipe */
+  reset: () => void;
+}
+
+/**
+ * Hook for swipe-to-reveal actions on list items.
+ * Only activates on touch devices (pointer: coarse).
+ * Cancels if vertical movement exceeds 10px.
+ */
+export function useSwipeActions(options: UseSwipeActionsOptions = {}): SwipeState {
+  const { threshold = 80 } = options;
+  const [swipedId, setSwipedId] = useState<string | null>(null);
+  const [direction, setDirection] = useState<'left' | 'right' | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [deltaX, setDeltaX] = useState(0);
+
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const cancelled = useRef(false);
+
+  const reset = useCallback(() => {
+    setSwipedId(null);
+    setDirection(null);
+    setActiveId(null);
+    setDeltaX(0);
+  }, []);
+
+  const getHandlers = useCallback((id: string): SwipeHandlers => ({
+    onTouchStart: (e: React.TouchEvent) => {
+      // Close previously swiped item
+      if (swipedId && swipedId !== id) {
+        reset();
+      }
+      startX.current = e.touches[0].clientX;
+      startY.current = e.touches[0].clientY;
+      cancelled.current = false;
+      setActiveId(id);
+      setDeltaX(0);
+    },
+    onTouchMove: (e: React.TouchEvent) => {
+      if (cancelled.current || activeId !== id) return;
+
+      const dx = e.touches[0].clientX - startX.current;
+      const dy = e.touches[0].clientY - startY.current;
+
+      // Cancel swipe if vertical movement > 10px (user is scrolling)
+      if (Math.abs(dy) > 10 && Math.abs(dx) < Math.abs(dy)) {
+        cancelled.current = true;
+        setDeltaX(0);
+        setActiveId(null);
+        return;
+      }
+
+      // Dampen movement (max 120px)
+      const clamped = Math.max(-120, Math.min(120, dx));
+      setDeltaX(clamped);
+    },
+    onTouchEnd: () => {
+      if (cancelled.current || activeId !== id) {
+        setActiveId(null);
+        return;
+      }
+
+      if (Math.abs(deltaX) >= threshold) {
+        setSwipedId(id);
+        setDirection(deltaX < 0 ? 'left' : 'right');
+      } else {
+        // Snap back
+        setSwipedId(null);
+        setDirection(null);
+      }
+      setDeltaX(0);
+      setActiveId(null);
+    },
+  }), [swipedId, activeId, deltaX, threshold, reset]);
+
+  const getStyle = useCallback((id: string): React.CSSProperties => {
+    // While actively swiping
+    if (activeId === id && deltaX !== 0) {
+      return {
+        transform: `translateX(${deltaX}px)`,
+        transition: 'none',
+      };
+    }
+    // Settled in swiped position
+    if (swipedId === id && direction) {
+      const offset = direction === 'left' ? -80 : 80;
+      return {
+        transform: `translateX(${offset}px)`,
+        transition: 'transform 0.2s ease-out',
+      };
+    }
+    // Default position
+    return {
+      transform: 'translateX(0)',
+      transition: 'transform 0.2s ease-out',
+    };
+  }, [activeId, deltaX, swipedId, direction]);
+
+  return { swipedId, direction, getHandlers, getStyle, reset };
+}


### PR DESCRIPTION
## Summary
- **DT-4**: Extract `CommentRow` from BusinessComments — memoized component with 18 props, handlers wrapped with `useCallback`, parent drops ~190 lines
- **#109**: Swipe actions for mobile — new `useSwipeActions` hook with touch events, 80px threshold, vertical scroll cancellation. Swipe left=delete (red), right=edit (blue). Visible icon buttons kept as accessible fallback.

## Test plan
- [x] TypeScript zero errors
- [x] 162/162 tests passing
- [ ] BusinessComments: comments render identically after CommentRow extraction
- [ ] BusinessComments: edit, like, reply, delete all work as before
- [ ] Swipe: touch device — swipe left reveals red delete, swipe right reveals blue edit
- [ ] Swipe: vertical scroll not affected
- [ ] Swipe: tap outside resets swiped item
- [ ] Accessible: edit/delete buttons still visible and functional without swipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)