### PR TITLE
fix: docs site basePath for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,6 @@
         paths: 'auto',
       },
       relativePath: true,
-      basePath: '/',
     };
   </script>
   <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>


### PR DESCRIPTION
Remove hardcoded basePath that caused 404 on GitHub Pages subfolder.