### PR TITLE
feat: admin custom claims (replace hardcoded email)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,12 +2,10 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Helper: verifica si el usuario es admin (requiere email verificado)
+    // Helper: verifica si el usuario es admin (via custom claim)
     function isAdmin() {
       return request.auth != null
-        && ('email_verified' in request.auth.token)
-        && request.auth.token.email_verified == true
-        && request.auth.token.email == 'benoffi11@gmail.com';
+        && request.auth.token.admin == true;
     }
 
     // Helper: valida que businessId tenga el formato esperado (biz_NNN)

--- a/functions/src/__tests__/admin/authStats.test.ts
+++ b/functions/src/__tests__/admin/authStats.test.ts
@@ -3,11 +3,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   handler,
   mockListUsers,
-  mockAdminEmailValue,
 } = vi.hoisted(() => ({
   handler: { fn: null as ((request: unknown) => Promise<unknown>) | null },
   mockListUsers: vi.fn(),
-  mockAdminEmailValue: vi.fn().mockReturnValue('admin@test.com'),
 }));
 
 // Mock firebase-functions/v2/https
@@ -30,11 +28,6 @@ vi.mock('firebase-functions/v2', () => ({
   logger: { error: vi.fn() },
 }));
 
-// Mock firebase-functions/params
-vi.mock('firebase-functions/params', () => ({
-  defineString: () => ({ value: mockAdminEmailValue }),
-}));
-
 // Mock firebase-admin/auth
 vi.mock('firebase-admin/auth', () => ({
   getAuth: () => ({ listUsers: mockListUsers }),
@@ -48,11 +41,20 @@ vi.mock('../../utils/sentry', () => ({
 // Import to trigger handler registration
 import '../../admin/authStats';
 
-function makeRequest(email: string, emailVerified: boolean) {
+function makeAdminRequest() {
   return {
     auth: {
       uid: 'admin-uid',
-      token: { email, email_verified: emailVerified },
+      token: { admin: true, email: 'admin@test.com', email_verified: true },
+    },
+  };
+}
+
+function makeNonAdminRequest() {
+  return {
+    auth: {
+      uid: 'user-uid',
+      token: { email: 'other@test.com', email_verified: true },
     },
   };
 }
@@ -60,7 +62,7 @@ function makeRequest(email: string, emailVerified: boolean) {
 function makeUserRecord(
   uid: string,
   providers: string[],
-  opts: { email?: string; emailVerified?: boolean; displayName?: string } = {},
+  opts: { email?: string; emailVerified?: boolean; displayName?: string; customClaims?: Record<string, unknown> } = {},
 ) {
   return {
     uid,
@@ -69,6 +71,7 @@ function makeUserRecord(
     displayName: opts.displayName ?? null,
     providerData: providers.map((id) => ({ providerId: id })),
     metadata: { creationTime: '2026-01-01T00:00:00Z' },
+    customClaims: opts.customClaims ?? null,
   };
 }
 
@@ -78,13 +81,12 @@ describe('getAuthStats', () => {
   });
 
   it('rejects non-admin users', async () => {
-    const request = makeRequest('other@test.com', true);
-    await expect(handler.fn!(request)).rejects.toThrow('Solo admin');
+    const request = makeNonAdminRequest();
+    await expect(handler.fn!(request)).rejects.toThrow('Admin only');
   });
 
-  it('rejects unverified admin email', async () => {
-    const request = makeRequest('admin@test.com', false);
-    await expect(handler.fn!(request)).rejects.toThrow('Email no verificado');
+  it('rejects unauthenticated requests', async () => {
+    await expect(handler.fn!({ auth: undefined })).rejects.toThrow('Must be signed in');
   });
 
   it('classifies anonymous users correctly', async () => {
@@ -93,7 +95,7 @@ describe('getAuthStats', () => {
       pageToken: undefined,
     });
 
-    const result = await handler.fn!(makeRequest('admin@test.com', true));
+    const result = await handler.fn!(makeAdminRequest());
     const data = result as { byMethod: { anonymous: number; email: number } };
     expect(data.byMethod.anonymous).toBe(1);
     expect(data.byMethod.email).toBe(0);
@@ -107,7 +109,7 @@ describe('getAuthStats', () => {
       pageToken: undefined,
     });
 
-    const result = await handler.fn!(makeRequest('admin@test.com', true));
+    const result = await handler.fn!(makeAdminRequest());
     const data = result as {
       byMethod: { anonymous: number; email: number };
       emailVerification: { verified: number; unverified: number };
@@ -119,13 +121,13 @@ describe('getAuthStats', () => {
   it('excludes admin from stats', async () => {
     mockListUsers.mockResolvedValueOnce({
       users: [
-        makeUserRecord('admin', ['password'], { email: 'admin@test.com' }),
+        makeUserRecord('admin', ['password'], { email: 'admin@test.com', customClaims: { admin: true } }),
         makeUserRecord('u1', []),
       ],
       pageToken: undefined,
     });
 
-    const result = await handler.fn!(makeRequest('admin@test.com', true));
+    const result = await handler.fn!(makeAdminRequest());
     const data = result as { users: unknown[] };
     expect(data.users).toHaveLength(1);
   });
@@ -141,7 +143,7 @@ describe('getAuthStats', () => {
         pageToken: undefined,
       });
 
-    const result = await handler.fn!(makeRequest('admin@test.com', true));
+    const result = await handler.fn!(makeAdminRequest());
     const data = result as { byMethod: { anonymous: number; email: number } };
     expect(data.byMethod.anonymous).toBe(1);
     expect(data.byMethod.email).toBe(1);

--- a/functions/src/admin/authStats.ts
+++ b/functions/src/admin/authStats.ts
@@ -1,16 +1,12 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import type { CallableRequest } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
-import { defineString } from 'firebase-functions/params';
 import { getAuth } from 'firebase-admin/auth';
 import type { UserRecord } from 'firebase-admin/auth';
 import { captureException } from '../utils/sentry';
+import { assertAdmin } from '../helpers/assertAdmin';
 
 const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === 'true';
-
-const ADMIN_EMAIL_PARAM = defineString('ADMIN_EMAIL', {
-  description: 'Email address of the admin user',
-});
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -30,19 +26,6 @@ interface AuthStatsResponse {
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
-function verifyAdmin(request: CallableRequest): void {
-  const email = request.auth?.token.email;
-  const emailVerified = request.auth?.token.email_verified;
-
-  if (!emailVerified) {
-    throw new HttpsError('permission-denied', 'Email no verificado');
-  }
-
-  if (email !== ADMIN_EMAIL_PARAM.value()) {
-    throw new HttpsError('permission-denied', 'Solo admin puede ver auth stats');
-  }
-}
-
 function classifyUser(user: UserRecord): 'anonymous' | 'email' {
   const providers = user.providerData.map((p) => p.providerId);
   if (providers.includes('password')) return 'email';
@@ -54,9 +37,8 @@ function classifyUser(user: UserRecord): 'anonymous' | 'email' {
 export const getAuthStats = onCall(
   { enforceAppCheck: !IS_EMULATOR },
   async (request: CallableRequest): Promise<AuthStatsResponse> => {
-    verifyAdmin(request);
+    assertAdmin(request.auth);
 
-    const adminEmail = ADMIN_EMAIL_PARAM.value();
     const byMethod = { anonymous: 0, email: 0 };
     const emailVerification = { verified: 0, unverified: 0 };
     const users: AuthUserInfo[] = [];
@@ -69,7 +51,7 @@ export const getAuthStats = onCall(
 
         for (const user of listResult.users) {
           // Exclude admin from user stats
-          if (user.email === adminEmail) continue;
+          if (user.customClaims?.admin === true) continue;
 
           const authMethod = classifyUser(user);
           byMethod[authMethod]++;

--- a/functions/src/admin/backups.ts
+++ b/functions/src/admin/backups.ts
@@ -1,19 +1,14 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
-import type { CallableRequest } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
-import { defineString } from 'firebase-functions/params';
 import { v1 } from '@google-cloud/firestore';
 import { getFirestore } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
 import { captureException } from '../utils/sentry';
+import { assertAdmin } from '../helpers/assertAdmin';
 
 const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === 'true';
 
 // ── Constants ──────────────────────────────────────────────────────────
-
-const ADMIN_EMAIL_PARAM = defineString('ADMIN_EMAIL', {
-  description: 'Email address of the admin user',
-});
 
 const PROJECT_DB = 'projects/modo-mapa-app/databases/(default)';
 const BACKUP_BUCKET_NAME = 'modo-mapa-app-backups';
@@ -102,21 +97,6 @@ async function checkRateLimit(uid: string): Promise<void> {
   });
 }
 
-async function verifyAdmin(request: CallableRequest): Promise<void> {
-  const email = request.auth?.token.email;
-  const emailVerified = request.auth?.token.email_verified;
-
-  if (!emailVerified) {
-    throw new HttpsError('permission-denied', 'Email no verificado');
-  }
-
-  if (email !== ADMIN_EMAIL_PARAM.value()) {
-    throw new HttpsError('permission-denied', 'Solo admin puede gestionar backups');
-  }
-
-  await checkRateLimit(request.auth!.uid);
-}
-
 function getBackupBucket() {
   return getStorage().bucket(BACKUP_BUCKET_NAME);
 }
@@ -165,7 +145,8 @@ export const createBackup = onCall<unknown, Promise<CreateBackupResponse>>({
   memory: '256MiB',
   enforceAppCheck: !IS_EMULATOR,
 }, async (request) => {
-  await verifyAdmin(request);
+  assertAdmin(request.auth);
+  await checkRateLimit(request.auth!.uid);
 
   const client = getFirestoreAdminClient();
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -197,7 +178,8 @@ export const listBackups = onCall<ListBackupsRequest, Promise<ListBackupsRespons
   memory: '256MiB',
   enforceAppCheck: !IS_EMULATOR,
 }, async (request) => {
-  await verifyAdmin(request);
+  assertAdmin(request.auth);
+  await checkRateLimit(request.auth!.uid);
 
   const pageSize = clampPageSize(request.data?.pageSize);
   const pageToken = request.data?.pageToken;
@@ -250,7 +232,8 @@ export const restoreBackup = onCall<RestoreBackupRequest, Promise<{ success: tru
   memory: '256MiB',
   enforceAppCheck: !IS_EMULATOR,
 }, async (request) => {
-  await verifyAdmin(request);
+  assertAdmin(request.auth);
+  await checkRateLimit(request.auth!.uid);
 
   const backupId = validateBackupId(request.data?.backupId);
   const backupUri = `${BACKUP_PREFIX}${backupId}`;
@@ -294,7 +277,8 @@ export const deleteBackup = onCall<DeleteBackupRequest, Promise<{ success: true 
   memory: '256MiB',
   enforceAppCheck: !IS_EMULATOR,
 }, async (request) => {
-  await verifyAdmin(request);
+  assertAdmin(request.auth);
+  await checkRateLimit(request.auth!.uid);
 
   const backupId = validateBackupId(request.data?.backupId);
 

--- a/functions/src/admin/claims.ts
+++ b/functions/src/admin/claims.ts
@@ -1,0 +1,65 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions/v2';
+import { defineString } from 'firebase-functions/params';
+import { getAuth } from 'firebase-admin/auth';
+
+const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === 'true';
+
+const ADMIN_EMAIL_PARAM = defineString('ADMIN_EMAIL', {
+  description: 'Email of the bootstrap admin (used only for initial setup)',
+});
+
+export const setAdminClaim = onCall<{ targetUid: string }, Promise<{ success: true }>>(
+  { enforceAppCheck: !IS_EMULATOR },
+  async (request) => {
+    const { targetUid } = request.data ?? {};
+    if (!targetUid || typeof targetUid !== 'string') {
+      throw new HttpsError('invalid-argument', 'targetUid required');
+    }
+
+    if (!IS_EMULATOR) {
+      const isExistingAdmin = request.auth?.token.admin === true;
+      const isBootstrap =
+        request.auth?.token.email_verified === true &&
+        request.auth?.token.email === ADMIN_EMAIL_PARAM.value();
+
+      if (!isExistingAdmin && !isBootstrap) {
+        throw new HttpsError('permission-denied', 'Not authorized to set admin claims');
+      }
+    }
+
+    await getAuth().setCustomUserClaims(targetUid, { admin: true });
+    logger.info('Admin claim set', {
+      targetUid,
+      setBy: request.auth?.uid ?? 'emulator',
+    });
+
+    return { success: true as const };
+  },
+);
+
+export const removeAdminClaim = onCall<{ targetUid: string }, Promise<{ success: true }>>(
+  { enforceAppCheck: !IS_EMULATOR },
+  async (request) => {
+    const { targetUid } = request.data ?? {};
+    if (!targetUid || typeof targetUid !== 'string') {
+      throw new HttpsError('invalid-argument', 'targetUid required');
+    }
+
+    if (!IS_EMULATOR && request.auth?.token.admin !== true) {
+      throw new HttpsError('permission-denied', 'Admin only');
+    }
+
+    if (request.auth?.uid === targetUid) {
+      throw new HttpsError('failed-precondition', 'Cannot remove your own admin claim');
+    }
+
+    await getAuth().setCustomUserClaims(targetUid, { admin: false });
+    logger.info('Admin claim removed', {
+      targetUid,
+      removedBy: request.auth?.uid ?? 'emulator',
+    });
+
+    return { success: true as const };
+  },
+);

--- a/functions/src/admin/feedback.ts
+++ b/functions/src/admin/feedback.ts
@@ -1,20 +1,13 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { createNotification } from '../utils/notifications';
+import { assertAdmin } from '../helpers/assertAdmin';
 
-const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'benoffi11@gmail.com';
 const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === 'true';
 const MAX_RESPONSE_LENGTH = 500;
 
 const GITHUB_OWNER = 'benoffi7';
 const GITHUB_REPO = 'modo-mapa';
-
-function assertAdmin(auth: { token: { email?: string; email_verified?: boolean } } | undefined): void {
-  if (IS_EMULATOR) return; // Skip all auth checks in emulator
-  if (!auth?.token.email_verified || auth?.token.email !== ADMIN_EMAIL) {
-    throw new HttpsError('permission-denied', 'Admin only');
-  }
-}
 
 export const respondToFeedback = onCall(
   { enforceAppCheck: !IS_EMULATOR, timeoutSeconds: 60 },

--- a/functions/src/admin/menuPhotos.ts
+++ b/functions/src/admin/menuPhotos.ts
@@ -2,17 +2,14 @@ import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
 import { createNotification } from '../utils/notifications';
+import { assertAdmin } from '../helpers/assertAdmin';
 
-const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'benoffi11@gmail.com';
 const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === 'true';
 
 export const approveMenuPhoto = onCall(
   { enforceAppCheck: !IS_EMULATOR, timeoutSeconds: 60 },
   async (request) => {
-    const { auth } = request;
-    if (!auth?.token.email_verified || auth.token.email !== ADMIN_EMAIL) {
-      throw new HttpsError('permission-denied', 'Admin only');
-    }
+    assertAdmin(request.auth);
 
     const { photoId } = request.data;
     if (!photoId || typeof photoId !== 'string') {
@@ -45,7 +42,7 @@ export const approveMenuPhoto = onCall(
     // Approve the new photo
     batch.update(photoRef, {
       status: 'approved',
-      reviewedBy: auth.uid,
+      reviewedBy: request.auth!.uid,
       reviewedAt: FieldValue.serverTimestamp(),
     });
 
@@ -70,10 +67,7 @@ export const approveMenuPhoto = onCall(
 export const rejectMenuPhoto = onCall(
   { enforceAppCheck: !IS_EMULATOR, timeoutSeconds: 60 },
   async (request) => {
-    const { auth } = request;
-    if (!auth?.token.email_verified || auth.token.email !== ADMIN_EMAIL) {
-      throw new HttpsError('permission-denied', 'Admin only');
-    }
+    assertAdmin(request.auth);
 
     const { photoId, reason } = request.data;
     if (!photoId || typeof photoId !== 'string') {
@@ -92,7 +86,7 @@ export const rejectMenuPhoto = onCall(
     await photoRef.update({
       status: 'rejected',
       rejectionReason: reason || '',
-      reviewedBy: auth.uid,
+      reviewedBy: request.auth!.uid,
       reviewedAt: FieldValue.serverTimestamp(),
     });
 
@@ -115,10 +109,7 @@ export const rejectMenuPhoto = onCall(
 export const deleteMenuPhoto = onCall(
   { enforceAppCheck: !IS_EMULATOR, timeoutSeconds: 60 },
   async (request) => {
-    const { auth } = request;
-    if (!auth?.token.email_verified || auth.token.email !== ADMIN_EMAIL) {
-      throw new HttpsError('permission-denied', 'Admin only');
-    }
+    assertAdmin(request.auth);
 
     const { photoId } = request.data;
     if (!photoId || typeof photoId !== 'string') {

--- a/functions/src/helpers/assertAdmin.ts
+++ b/functions/src/helpers/assertAdmin.ts
@@ -1,0 +1,23 @@
+import { HttpsError } from 'firebase-functions/v2/https';
+
+const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === 'true';
+
+interface AuthToken {
+  admin?: boolean;
+  email?: string;
+  email_verified?: boolean;
+}
+
+export function assertAdmin(
+  auth: { uid: string; token: AuthToken } | undefined,
+): void {
+  if (IS_EMULATOR) return;
+
+  if (!auth) {
+    throw new HttpsError('unauthenticated', 'Must be signed in');
+  }
+
+  if (auth.token.admin !== true) {
+    throw new HttpsError('permission-denied', 'Admin only');
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -26,3 +26,4 @@ export { createBackup, listBackups, restoreBackup, deleteBackup } from './admin/
 export { approveMenuPhoto, rejectMenuPhoto, deleteMenuPhoto, reportMenuPhoto } from './admin/menuPhotos';
 export { respondToFeedback, resolveFeedback, createGithubIssueFromFeedback } from './admin/feedback';
 export { getAuthStats } from './admin/authStats';
+export { setAdminClaim, removeAdminClaim } from './admin/claims';

--- a/scripts/seed-admin-data.mjs
+++ b/scripts/seed-admin-data.mjs
@@ -612,6 +612,71 @@ async function seed() {
     tagCounts: {},
   });
 
+  // Create admin user in Auth emulator with custom claims
+  console.log('Creating admin user in Auth emulator...');
+  const ADMIN_EMAIL = 'benoffi11@gmail.com';
+  const AUTH_EMULATOR = 'http://localhost:9099';
+
+  let adminUid = null;
+  try {
+    const createRes = await fetch(
+      `${AUTH_EMULATOR}/identitytoolkit.googleapis.com/v1/accounts:signUp`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer owner' },
+        body: JSON.stringify({
+          email: ADMIN_EMAIL,
+          password: 'dev123456',
+          returnSecureToken: true,
+        }),
+      },
+    );
+    const createData = await createRes.json();
+    adminUid = createData.localId;
+  } catch {
+    // User may already exist — try to look up
+    console.log('  Admin user may already exist, attempting lookup...');
+  }
+
+  if (!adminUid) {
+    // Try signing in to get the UID
+    try {
+      const signInRes = await fetch(
+        `${AUTH_EMULATOR}/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer owner' },
+          body: JSON.stringify({
+            email: ADMIN_EMAIL,
+            password: 'dev123456',
+            returnSecureToken: true,
+          }),
+        },
+      );
+      const signInData = await signInRes.json();
+      adminUid = signInData.localId;
+    } catch {
+      console.log('  Could not find or create admin user');
+    }
+  }
+
+  if (adminUid) {
+    // Set emailVerified + custom claims (admin: true)
+    await fetch(
+      `${AUTH_EMULATOR}/identitytoolkit.googleapis.com/v1/accounts:update`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer owner' },
+        body: JSON.stringify({
+          localId: adminUid,
+          emailVerified: true,
+          customAttributes: JSON.stringify({ admin: true }),
+        }),
+      },
+    );
+    console.log(`  Admin user ready: ${ADMIN_EMAIL} (uid: ${adminUid}, claim: admin=true)`);
+  }
+
   console.log('\n✅ Seed complete!');
   console.log('- 10 users');
   console.log('- ~60 comments (4 flagged, ~6 edited, with likeCount) + ~20 replies (threads)');
@@ -632,6 +697,7 @@ async function seed() {
   console.log('- 15 notifications (incl. feedback_response)');
   console.log('- 10 user settings (all public)');
   console.log('- Counters and moderation config');
+  console.log('- 1 admin user with custom claim (admin: true)');
   console.log('\nOpen http://localhost:4000 to see data in Emulator UI');
   console.log('Open http://localhost:5173/admin to see the dashboard');
 

--- a/src/components/admin/AdminGuard.tsx
+++ b/src/components/admin/AdminGuard.tsx
@@ -6,15 +6,17 @@ import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useAuth } from '../../context/AuthContext';
-import { ADMIN_EMAIL } from '../../constants/admin';
+
+const ADMIN_EMAIL = 'benoffi11@gmail.com';
+const DEV_PASSWORD = 'dev123456';
 
 interface AdminGuardProps {
   children: ReactNode;
 }
 
 /**
- * In DEV mode, auto-creates and signs in as the admin user in the Auth emulator.
- * This avoids popup auth issues and ensures Firestore rules pass isAdmin().
+ * In DEV mode, auto-creates and signs in as the admin user in the Auth emulator,
+ * then sets the admin custom claim via the setAdminClaim Cloud Function.
  */
 function DevAdminGuard({ children }: AdminGuardProps) {
   const [ready, setReady] = useState(false);
@@ -22,18 +24,17 @@ function DevAdminGuard({ children }: AdminGuardProps) {
   useEffect(() => {
     let cancelled = false;
     const setup = async () => {
-      const { auth } = await import('../../config/firebase');
+      const { auth, functions } = await import('../../config/firebase');
       const { signInWithEmailAndPassword, createUserWithEmailAndPassword } = await import('firebase/auth');
-      const DEV_PASSWORD = 'dev123456';
+      const { httpsCallable } = await import('firebase/functions');
 
       try {
         await signInWithEmailAndPassword(auth, ADMIN_EMAIL, DEV_PASSWORD);
       } catch {
-        // User doesn't exist yet — create it
         await createUserWithEmailAndPassword(auth, ADMIN_EMAIL, DEV_PASSWORD);
       }
 
-      // Set emailVerified via Auth Emulator admin API so isAdmin() passes in Firestore rules
+      // Set emailVerified via Auth Emulator admin API
       if (auth.currentUser && !auth.currentUser.emailVerified) {
         await fetch(
           'http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:update',
@@ -43,17 +44,22 @@ function DevAdminGuard({ children }: AdminGuardProps) {
             body: JSON.stringify({ localId: auth.currentUser.uid, emailVerified: true }),
           },
         );
-        // Force token refresh to pick up emailVerified
         await auth.currentUser.reload();
         await auth.currentUser.getIdToken(true);
       }
+
+      // Set admin custom claim via Cloud Function
+      const setAdmin = httpsCallable(functions, 'setAdminClaim');
+      await setAdmin({ targetUid: auth.currentUser!.uid });
+      // Force token refresh to pick up new claim
+      await auth.currentUser!.getIdToken(true);
 
       if (!cancelled) setReady(true);
     };
 
     setup().catch((err) => {
       console.error('[DevAdminGuard] setup failed:', err);
-      if (!cancelled) setReady(true); // render anyway so error is visible
+      if (!cancelled) setReady(true);
     });
 
     return () => { cancelled = true; };
@@ -84,9 +90,13 @@ export default function AdminGuard({ children }: AdminGuardProps) {
     setSigningIn(true);
     setAccessDenied(false);
     const result = await signInWithGoogle();
-    if (result && (result.email !== ADMIN_EMAIL || !result.emailVerified)) {
-      setAccessDenied(true);
-      await signOut();
+    if (result) {
+      const { getIdTokenResult } = await import('firebase/auth');
+      const tokenResult = await getIdTokenResult(result, true);
+      if (tokenResult.claims.admin !== true) {
+        setAccessDenied(true);
+        await signOut();
+      }
     }
     setSigningIn(false);
   };
@@ -103,7 +113,7 @@ export default function AdminGuard({ children }: AdminGuardProps) {
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100dvh', gap: 2 }}>
         <Alert severity="error" sx={{ maxWidth: 400 }}>
-          Acceso denegado. Solo {ADMIN_EMAIL} puede acceder al panel de administración.
+          Acceso denegado. Tu cuenta no tiene permisos de administrador.
         </Alert>
         <Button
           onClick={() => {

--- a/src/constants/admin.ts
+++ b/src/constants/admin.ts
@@ -1,8 +1,6 @@
 import type { AbuseLog } from '../types/admin';
 import type { MenuPhotoStatus } from '../types';
 
-export const ADMIN_EMAIL = 'benoffi11@gmail.com';
-
 export const FREE_TIER_READS = 50_000;
 export const FREE_TIER_WRITES = 20_000;
 


### PR DESCRIPTION
## Summary

- Migrates admin verification from hardcoded email comparison to **Firebase Custom Claims** (`admin: true`)
- Creates centralized `assertAdmin` helper replacing 3 different verification patterns across Cloud Functions
- Adds `setAdminClaim` / `removeAdminClaim` callable Cloud Functions for claim management
- Updates Firestore rules `isAdmin()` to check `request.auth.token.admin == true`
- Frontend `AdminGuard` now verifies the claim instead of comparing email
- Removes `ADMIN_EMAIL` from frontend constants — email no longer exposed in production bundle
- Seed script creates admin user with custom claim in Auth emulator
- Updates authStats tests for new claim-based pattern

## Post-merge: Bootstrap required

After CI deploys, run once:
```
firebase functions:shell
> setAdminClaim({ targetUid: "YOUR_UID" })
```
Then logout/login in admin panel. ~1 min downtime.

## Test plan

- [x] TypeScript compiles (frontend + functions)
- [x] Lint passes
- [x] Vite production build succeeds
- [x] Frontend tests: 14 files, 162 tests passing
- [x] Functions tests: 7 files, 59 tests passing
- [x] `benoffi11@gmail.com` NOT in production JS bundle (only in sourcemap)
- [x] Markdownlint passes on docs
- [ ] Local emulator test: admin panel loads with claim-based auth
- [ ] Production bootstrap after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)