### PR TITLE
fix: add --force to functions deploy CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           cd functions && npm ci
           cd ..
-          npx firebase-tools deploy --only functions --project modo-mapa-app
+          npx firebase-tools deploy --only functions --project modo-mapa-app --force
 
       - name: Deploy to production hosting
         run: npx firebase-tools deploy --only hosting:production --project modo-mapa-app


### PR DESCRIPTION
## Summary
- Adds `--force` flag to `firebase deploy --only functions` in CI workflow
- Fixes deploy failure caused by orphaned `getStorageStats` function existing in Firebase but not in local source
- Firebase CLI aborts in non-interactive mode without `--force` when it detects this mismatch

## Test plan
- [ ] Merge and verify the deploy action passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)