### PR TITLE
feat: toast global de error/éxito (#138)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { APIProvider } from '@vis.gl/react-google-maps';
 import { ColorModeProvider } from './context/ColorModeContext';
 import { AuthProvider } from './context/AuthContext';
 import { NotificationsProvider } from './context/NotificationsContext';
+import { ToastProvider } from './context/ToastContext';
 import { MapProvider } from './context/MapContext';
 import ErrorBoundary from './components/layout/ErrorBoundary';
 import AppShell from './components/layout/AppShell';
@@ -32,6 +33,7 @@ function App() {
     <ColorModeProvider>
       <ErrorBoundary>
         <AuthProvider>
+        <ToastProvider>
         <NotificationsProvider>
           <Routes>
             {import.meta.env.DEV && (
@@ -74,6 +76,7 @@ function App() {
             />
           </Routes>
         </NotificationsProvider>
+        </ToastProvider>
         </AuthProvider>
       </ErrorBoundary>
     </ColorModeProvider>

--- a/src/components/business/BusinessComments.tsx
+++ b/src/components/business/BusinessComments.tsx
@@ -14,6 +14,7 @@ import {
 import SendIcon from '@mui/icons-material/Send';
 import CloseIcon from '@mui/icons-material/Close';
 import { useAuth } from '../../context/AuthContext';
+import { useToast } from '../../context/ToastContext';
 import { addComment, editComment, deleteComment, likeComment, unlikeComment } from '../../services/comments';
 import CommentRow from './CommentRow';
 import UserProfileSheet from '../user/UserProfileSheet';
@@ -34,6 +35,7 @@ interface Props {
 
 export default memo(function BusinessComments({ businessId, comments, userCommentLikes, isLoading, onCommentsChange }: Props) {
   const { user, displayName } = useAuth();
+  const toast = useToast();
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [profileUser, setProfileUser] = useState<{ id: string; name: string } | null>(null);
@@ -137,8 +139,10 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
       await addComment(user.uid, displayName || 'Anónimo', businessId, newComment.trim());
       setNewComment('');
       onCommentsChange();
+      toast.success('Comentario publicado');
     } catch (error) {
       if (import.meta.env.DEV) console.error('Error adding comment:', error);
+      toast.error('No se pudo publicar el comentario');
     }
     setIsSubmitting(false);
   };
@@ -161,8 +165,10 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
       setEditingId(null);
       setEditText('');
       onCommentsChange();
+      toast.success('Comentario editado');
     } catch (error) {
       if (import.meta.env.DEV) console.error('Error editing comment:', error);
+      toast.error('No se pudo editar el comentario');
     }
     setIsSavingEdit(false);
   };
@@ -201,6 +207,7 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
         return next;
       });
       if (import.meta.env.DEV) console.error('Error toggling like:', error);
+      toast.error('No se pudo actualizar el like');
     }
   };
 
@@ -227,8 +234,10 @@ export default memo(function BusinessComments({ businessId, comments, userCommen
       setReplyingTo(null);
       setReplyText('');
       onCommentsChange();
+      toast.success('Respuesta publicada');
     } catch (error) {
       if (import.meta.env.DEV) console.error('Error adding reply:', error);
+      toast.error('No se pudo publicar la respuesta');
     }
     setIsSubmitting(false);
   };

--- a/src/components/business/BusinessRating.tsx
+++ b/src/components/business/BusinessRating.tsx
@@ -9,6 +9,7 @@ import AttachMoneyOutlinedIcon from '@mui/icons-material/AttachMoneyOutlined';
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
 import BoltOutlinedIcon from '@mui/icons-material/BoltOutlined';
 import { useAuth } from '../../context/AuthContext';
+import { useToast } from '../../context/ToastContext';
 import { upsertRating, deleteRating, upsertCriteriaRating } from '../../services/ratings';
 import { RATING_CRITERIA } from '../../constants/criteria';
 import type { Rating as RatingType, RatingCriteria, RatingCriterionId } from '../../types';
@@ -35,6 +36,7 @@ interface CriteriaAverages {
 
 export default memo(function BusinessRating({ businessId, ratings, isLoading, onRatingChange }: Props) {
   const { user } = useAuth();
+  const toast = useToast();
   const [criteriaOpen, setCriteriaOpen] = useState(false);
 
   const { averageRating, totalRatings, serverMyRating, serverMyCriteria, criteriaAverages } = useMemo(() => {
@@ -95,6 +97,7 @@ export default memo(function BusinessRating({ businessId, ratings, isLoading, on
       onRatingChange();
     } catch {
       setPendingRating(null);
+      toast.error('No se pudo guardar la calificación');
     }
   };
 
@@ -107,6 +110,7 @@ export default memo(function BusinessRating({ businessId, ratings, isLoading, on
       onRatingChange();
     } catch {
       setPendingRating(null);
+      toast.error('No se pudo borrar la calificación');
     }
   };
 
@@ -123,8 +127,9 @@ export default memo(function BusinessRating({ businessId, ratings, isLoading, on
         delete next[criterionId];
         return Object.keys(next).length > 0 ? next : null;
       });
+      toast.error('No se pudo guardar el criterio');
     }
-  }, [user, businessId, onRatingChange]);
+  }, [user, businessId, onRatingChange, toast]);
 
   const hasCriteriaData = Object.values(criteriaAverages).some((c) => c.count > 0);
 

--- a/src/components/business/FavoriteButton.tsx
+++ b/src/components/business/FavoriteButton.tsx
@@ -3,6 +3,7 @@ import { IconButton } from '@mui/material';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import { useAuth } from '../../context/AuthContext';
+import { useToast } from '../../context/ToastContext';
 import { addFavorite, removeFavorite } from '../../services/favorites';
 
 interface Props {
@@ -14,6 +15,7 @@ interface Props {
 
 export default function FavoriteButton({ businessId, isFavorite, isLoading, onToggle }: Props) {
   const { user } = useAuth();
+  const toast = useToast();
   const [isToggling, setIsToggling] = useState(false);
 
   const toggleFavorite = useCallback(async () => {
@@ -22,15 +24,18 @@ export default function FavoriteButton({ businessId, isFavorite, isLoading, onTo
     try {
       if (isFavorite) {
         await removeFavorite(user.uid, businessId);
+        toast.info('Removido de favoritos');
       } else {
         await addFavorite(user.uid, businessId);
+        toast.success('Agregado a favoritos');
       }
       onToggle();
     } catch (error) {
       if (import.meta.env.DEV) console.error('Error toggling favorite:', error);
+      toast.error('No se pudo actualizar favoritos');
     }
     setIsToggling(false);
-  }, [user, businessId, isFavorite, onToggle]);
+  }, [user, businessId, isFavorite, onToggle, toast]);
 
   return (
     <IconButton

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,0 +1,79 @@
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import { Snackbar, Alert, IconButton } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import type { AlertColor } from '@mui/material';
+import type { ReactNode } from 'react';
+
+interface Toast {
+  id: string;
+  message: string;
+  severity: AlertColor;
+}
+
+interface ToastContextValue {
+  success: (message: string) => void;
+  error: (message: string) => void;
+  warning: (message: string) => void;
+  info: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const AUTO_HIDE_MS = 4000;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toast, setToast] = useState<Toast | null>(null);
+
+  const show = useCallback((message: string, severity: AlertColor) => {
+    setToast({ id: crypto.randomUUID(), message, severity });
+  }, []);
+
+  const handleClose = useCallback((_?: unknown, reason?: string) => {
+    if (reason === 'clickaway') return;
+    setToast(null);
+  }, []);
+
+  const value = useMemo<ToastContextValue>(() => ({
+    success: (message: string) => show(message, 'success'),
+    error: (message: string) => show(message, 'error'),
+    warning: (message: string) => show(message, 'warning'),
+    info: (message: string) => show(message, 'info'),
+  }), [show]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <Snackbar
+        key={toast?.id}
+        open={toast !== null}
+        autoHideDuration={AUTO_HIDE_MS}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {toast ? (
+          <Alert
+            severity={toast.severity}
+            variant="filled"
+            onClose={handleClose}
+            action={
+              <IconButton size="small" color="inherit" onClick={handleClose} aria-label="Cerrar">
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            }
+            sx={{ width: '100%', minWidth: 280 }}
+          >
+            {toast.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- Nuevo `ToastContext` con hook `useToast()` que expone `success/error/warning/info`
- Integrado en `BusinessRating`, `BusinessComments` y `FavoriteButton`
- Error toasts en todos los catches (antes eran fallos silenciosos)
- Success toasts en comments y favorites (no en ratings — las estrellas ya dan feedback visual)
- Auto-dismiss 4s, dismiss manual con X

## Test plan
- [ ] Publicar comentario → toast "Comentario publicado"
- [ ] Editar comentario → toast "Comentario editado"
- [ ] Agregar favorito → toast "Agregado a favoritos"
- [ ] Quitar favorito → toast "Removido de favoritos"
- [ ] Simular error de red → toast de error visible
- [ ] Calificar con estrellas → NO toast de éxito (solo error si falla)
- [ ] Toast se auto-cierra después de 4s
- [ ] Snackbar de undo-delete sigue funcionando independiente

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)