### PR TITLE
fix(#342) PR-A: deps vulnerables (react-router/firebase-admin) + hardening isValidStorageUrl

### DIFF
--- a/docs/feat/admin/admin-ip-rate-limits-inspector/plan.md
+++ b/docs/feat/admin/admin-ip-rate-limits-inspector/plan.md
@@ -1,0 +1,245 @@
+# Plan: Inspector admin de `_ipRateLimits` + cierre del tipo `ip_rate_limit` muerto
+
+**Specs:** [specs.md](specs.md)
+**PRD:** [prd.md](prd.md)
+**Issue:** #348
+**Fecha:** 2026-06-12
+
+---
+
+## Implementacion recomendada
+
+**Agente unico (luna o nico).** El feature toca backend (`functions/src/admin/`, `functions/src/triggers/authBlocking.ts`, `functions/src/index.ts`, `analyticsReport.ts`) y frontend (`services/admin/`, `components/admin/`, `types/admin.ts`, `constants/`), pero el flujo es secuencial-friendly y es un espejo verificado del patron #327 (`rateLimits.ts` / `RateLimitsSection.tsx` / `AbuseAlerts.tsx`). No hay riesgo de overlap que justifique paralelizar.
+
+Si manu decide paralelizar, file ownership por workstream:
+
+- **Backend:** `functions/src/admin/ipRateLimits.ts`, `functions/src/admin/analyticsReport.ts`, `functions/src/triggers/authBlocking.ts`, `functions/src/index.ts`
+- **Frontend:** `src/services/admin/`, `src/components/admin/`, `src/types/admin.ts`, `src/constants/`
+
+> **Boundary critica entre workstreams:** el tipo backend `AdminIpRateLimitItem` y el frontend mirror deben quedar identicos en shape. Si se paraleliza, congelar el shape del tipo en Fase 1 antes de abrir ambos workstreams.
+
+**Estimacion total: M.** Detalle por fase en la columna "Estimacion" de cada tabla.
+
+---
+
+## Observaciones de Diego incorporadas (gate tecnico)
+
+Dos observaciones no-bloqueantes del sello Diego (specs.md, "Revisión Técnica"), reflejadas como pasos/tests explicitos en este plan:
+
+1. **`orderBy('date','desc')` sin tie-breaker** — cuando NO hay filtro, todos los docs de la misma `date` (los de hoy) carecen de orden estable entre hashes. Es aceptable para un inspector admin de bajo volumen con `limit`, pero el plan documenta que **el orden intra-dia es no-deterministico** y NO introduce un `orderBy` compuesto (requeriria indice). Ver Fase 2 paso 1 (comentario en codigo) y Decisiones tecnicas en specs.
+2. **Parseo del docId `{ipHash}_{action}_{date}`** — `action` (`'anon_create'`) contiene underscore; el helper `parseIpRateLimitDocId` separa por `_` tomando primer segmento=`ipHash`, ultimo=`date`, y el medio (join) = `action`. Un split naive por `_` fallaria. El plan incluye un **test explicito con action multi-segmento**. Ver Fase 2 paso 4 (test).
+
+---
+
+## Fases de implementacion
+
+### Fase 1: Tipos, constantes, mensajes y registro GA4 (foundational, sin UI)
+
+**Branch:** `feat/348-admin-ip-rate-limits-inspector`
+**Estimacion:** S (~1h)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/types/admin.ts` | Agregar `interface AdminIpRateLimitItem { docId; ipHash; action; date; count; windowActive }` (mirror exacto del backend, ver specs "Tipo frontend nuevo"). Doc-comment indicando que debe mantenerse en sync con `functions/src/admin/ipRateLimits.ts` |
+| 2 | `src/constants/analyticsEvents/admin.ts` | Agregar `EVT_ADMIN_IP_RATE_LIMIT_VIEWED = 'admin_ip_rate_limit_viewed'` y `EVT_ADMIN_IP_RATE_LIMIT_RESET = 'admin_ip_rate_limit_reset'` bajo comentario `// #348 — IP rate limits inspector` |
+| 3 | `src/constants/messages/admin.ts` | Extender `MSG_ADMIN` con `ipRateLimitResetSuccess = 'Reseteado correctamente'`, `ipRateLimitResetError = 'No se pudo resetear. Verificá tu sesión admin.'`, `ipRateLimitAlreadyReset = 'Esta entrada ya fue reseteada por otro admin. Refrescamos la tabla.'` (seccion `// #348 — IP rate limits inspector`) |
+| 4 | `functions/src/admin/analyticsReport.ts` | En el array `GA4_EVENT_NAMES` (~149-152, seccion Admin tools): agregar `'admin_ip_rate_limit_viewed'` y `'admin_ip_rate_limit_reset'`. **Registro upfront** para evitar la ventana de evento huerfano (mismo principio que #327): si Fase 4 mergeara antes que este registro, los eventos quedarian huerfanos transitoriamente |
+| 5 | `src/components/admin/features/ga4FeatureDefinitions.ts` | Card `admin_metrics` (~194): agregar `'admin_ip_rate_limit_viewed'` y `'admin_ip_rate_limit_reset'` a su `eventNames`. **Registro upfront en frontend** para simetria con backend |
+
+### Fase 2: Callable backend `adminListIpRateLimits` + `adminResetIpRateLimit`
+
+**Estimacion:** M (~2-3h)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `functions/src/admin/ipRateLimits.ts` (nuevo) | Crear `adminListIpRateLimits` (espejo de `adminListRateLimits`): `onCall` con `enforceAppCheck: ENFORCE_APP_CHECK_ADMIN`, `timeoutSeconds: 30`; `assertAdmin`; validacion `action` (`/^[a-z0-9_]{1,40}$/`), `ipHash` (`/^[a-f0-9]{16}$/`, NO acepta IP raw), `limit` clamp `[1,100]` default 50; `checkCallableRateLimit(db, 'admin_ip_rate_limits_'+uid, 30, uid)`; query sin indice compuesto (`where('ipHash')` simple / `where('action')` simple / `orderBy('date','desc')` solo sin filtro; filtro `action` client-side post-fetch si ambos presentes); mapeo a `AdminIpRateLimitItem[]` con `windowActive = (date === new Date().toISOString().slice(0,10))`; `trackFunctionTiming('adminListIpRateLimits', start)` happy+catch; catch `captureException`+`logger.error`+`HttpsError('internal')`. **Comentario en el `orderBy('date','desc')`: orden intra-dia no-deterministico entre hashes; NO agregar orderBy compuesto (Diego obs #1)** |
+| 2 | `functions/src/admin/ipRateLimits.ts` | Agregar `adminResetIpRateLimit` (espejo de `adminResetRateLimit`): `assertAdmin`; `DOC_ID_REGEX = /^[a-zA-Z0-9_-]{1,200}$/` (constante local duplicada, NO importar la privada de `rateLimits.ts` — regla no-append); `checkCallableRateLimit(db, 'admin_ip_rate_limit_reset_'+uid, 20, uid)`; `get` doc → `not-found` si no existe → `delete()`; `logAbuse` `type:'config_edit'`, `collection:'_ipRateLimits'`, `detail: JSON.stringify({ action:'reset_ip_rate_limit', docId, ipHash, ipAction })`; `trackFunctionTiming('adminResetIpRateLimit', start)` ambos paths |
+| 3 | `functions/src/admin/ipRateLimits.ts` | Agregar helper `parseIpRateLimitDocId(docId)`: split por `_`, `ipHash` = `parts[0]`, `date` = `parts[parts.length-1]`, `action` = `parts.slice(1,-1).join('_')`. Best-effort para el audit detail (Diego obs #2). Documentar que `action` puede ser multi-segmento |
+| 4 | `functions/src/admin/__tests__/ipRateLimits.test.ts` (nuevo) | Tests segun specs. **Incluir explicitamente:** (a) `parseIpRateLimitDocId` con `action` multi-segmento (`a1b2c3d4e5f60718_anon_create_2026-06-10` → `ipHash:'a1b2c3d4e5f60718'`, `action:'anon_create'`, `date:'2026-06-10'`) — un split naive por `_` fallaria (Diego obs #2); (b) `assertAdmin` rechaza no-admin; (c) rate limit invocado (`admin_ip_rate_limits_{uid}` 30 / reset 20); (d) regex `action`/`ipHash`/`docId` invalido → `invalid-argument`; (e) `limit` clamp+default; (f) `windowActive` true (date==hoy) y false; (g) filtro `action` (where), `ipHash` (where + action client-side), sin filtro (orderBy date desc); (h) reset borra doc + escribe `abuseLog` config_edit; (i) `not-found`; (j) catch → `HttpsError('internal')`; (k) `trackFunctionTiming` happy+catch |
+| 5 | `functions/src/index.ts` | `export { adminListIpRateLimits, adminResetIpRateLimit } from './admin/ipRateLimits';` |
+
+### Fase 3: Servicio frontend (wrappers httpsCallable)
+
+**Estimacion:** S (~1h)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/services/admin/ipRateLimits.ts` (nuevo) | Crear `listAdminIpRateLimits({ action?, ipHash?, limit? })` (arma request solo con campos definidos, mapea `result.data.items`) y `resetAdminIpRateLimit(docId)`, espejo de `services/admin/rateLimits.ts`. Solo `httpsCallable` — sin queries Firestore, sin `measureAsync` |
+| 2 | `src/services/admin/index.ts` | Agregar `export { listAdminIpRateLimits, resetAdminIpRateLimit } from './ipRateLimits';` al final del barrel (vecino a linea 56) |
+| 3 | `src/services/admin/__tests__/ipRateLimits.test.ts` (nuevo) | Test de wiring: `listAdminIpRateLimits` llama `'adminListIpRateLimits'` con payload solo de campos definidos + mapea `result.data.items`; `resetAdminIpRateLimit` llama `'adminResetIpRateLimit'` con `{ docId }`; ambos propagan error |
+
+### Fase 4: Componente `IpRateLimitsSection` + integracion en `AbuseAlerts`
+
+**Estimacion:** L (~3-4h)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/components/admin/alerts/IpRateLimitsSection.tsx` (nuevo) | Implementar segun specs (espejo de `RateLimitsSection.tsx`, sin props): state `actionFilter`/`ipHashFilter` con `useDeferredValue`; `useAsyncData(fetcher)`; emit `EVT_ADMIN_IP_RATE_LIMIT_VIEWED` 1x por mount via `useRef` (primer load exitoso); caption "Se muestra un hash SHA-256 de la IP, no la dirección real."; tabla MUI (IP Hash con `Tooltip`+truncado, Acción `Chip`, Fecha, Count align-right, Estado `Activa`/`Expirada` por `windowActive`, boton Resetear `color="error"` `minHeight:44` `aria-label` con hash+accion, `disabled={isOffline}` + `Tooltip` `MSG_OFFLINE.requiresConnection`); Dialog `role="alertdialog"` + `aria-labelledby`/`aria-describedby`, body condicional segun `windowActive`; `handleConfirmReset` try/catch: success → `MSG_ADMIN.ipRateLimitResetSuccess` + `trackEvent(EVT_ADMIN_IP_RATE_LIMIT_RESET,{action})` + refetch; `not-found` (`isAlreadyResetError` local) → `toast.info(MSG_ADMIN.ipRateLimitAlreadyReset)` + refetch; otro → `logger.error` + `toast.error(MSG_ADMIN.ipRateLimitResetError)`. Boton confirmar `disabled={submitting || isOffline}` |
+| 2 | `src/components/admin/AbuseAlerts.tsx` | 4 puntos de cambio (lineas verificadas): (a) **L32** union type → `useState<'alerts'\|'reincidentes'\|'rateLimits'\|'ipRateLimits'>('alerts')`; (b) **L33** `useAbuseLogsRealtime(200, innerTab !== 'rateLimits' && innerTab !== 'ipRateLimits')`; (c) **L157** `const isRateLimitsTab = innerTab === 'rateLimits' \|\| innerTab === 'ipRateLimits';` (tab que no usa abuseLogs → suprime loading/error/KPIs); (d) **L174** ampliar el tipo del callback `onChange` con `'ipRateLimits'`, agregar `<Tab value="ipRateLimits" label="Rate Limits IP" />` despues del de "Rate Limits", y `{innerTab === 'ipRateLimits' && <IpRateLimitsSection />}`. Import `import IpRateLimitsSection from './alerts/IpRateLimitsSection';` |
+| 3 | `src/components/admin/alerts/__tests__/IpRateLimitsSection.test.tsx` (nuevo) | Tests segun specs: render tabla; loading/error/empty via `AdminPanelWrapper`; `EVT_ADMIN_IP_RATE_LIMIT_VIEWED` 1x por mount; truncado de hash + `Tooltip`; dialog reset (open/confirm); boton disabled offline (`useConnectivity` mock); toast success/error/already-reset (`not-found`); filtro action/ipHash |
+| 4 | `src/components/admin/__tests__/AbuseAlerts.test.tsx` (modificar) | Agregar casos: el subtab "Rate Limits IP" se renderiza y monta `IpRateLimitsSection`; `useAbuseLogsRealtime` se suspende (enabled=false) en ese subtab; volver a "alerts" re-suscribe. Si el archivo no existe aun, crearlo `(nuevo)` |
+
+### Fase 5: Emitir tipo `ip_rate_limit` en `authBlocking` (S4 — Opcion A)
+
+**Estimacion:** S (~1h)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `functions/src/triggers/authBlocking.ts` | En el bloque `if (exceeded)` (~65-73): cambiar `type` del `logAbuse` de `'anon_flood'` a `'ip_rate_limit'`, conservando `severity: 'high'` explicito y agregando `collection: '_ipRateLimits'`. El bloque del umbral (`currentCount >= ANON_FLOOD_ALERT_THRESHOLD`, ~49-56) **NO cambia**: sigue emitiendo `anon_flood` con su `severity: 'medium'`. Sin tocar `abuseLogger.ts`/`alertsHelpers.ts`/`types/admin.ts`/`constants/admin.ts` (el tipo ya existe en los 4) |
+| 2 | `functions/src/__tests__/triggers/authBlocking.test.ts` (modificar) | Agregar/ajustar casos: el bloqueo por IP (`exceeded`) emite `abuseLog` con `type:'ip_rate_limit'` y `severity:'high'`; el umbral (`currentCount >= threshold`) sigue emitiendo `anon_flood` `severity:'medium'`; ambos coexisten en el flujo de exceso. Verificar que no se rompan los asserts existentes que esperaban `anon_flood` en el bloqueo |
+
+### Fase 6: Documentacion (OBLIGATORIA)
+
+**Estimacion:** S (~1h)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `docs/reference/security.md` | Tabla "Rate limiting server-side (callables)": agregar `adminListIpRateLimits` (30/dia, `admin_ip_rate_limits_{uid}`) y `adminResetIpRateLimit` (20/dia, `admin_ip_rate_limit_reset_{uid}`). En la seccion "IP-based rate limiting": mencionar el inspector admin y (Opcion A) que `authBlocking` emite `ip_rate_limit` (severity high) en el bloqueo, distinto de `anon_flood` (umbral) |
+| 2 | `docs/reference/features.md` | Tab admin "Alertas" → mencionar el cuarto subtab "Rate Limits IP" (inspector hash-only + reset auditado) |
+| 3 | `docs/reference/firestore.md` | Documentar que `_ipRateLimits` se lee exclusivamente via callable admin (Admin SDK); rules `allow read, write: if false` sin cambios. Verificar que no falte la coleccion en el doc |
+| 4 | `docs/reference/patterns.md` | Verificar: reusa "Admin panel pattern" / "Abuse alerts (admin)" existentes. Agregar fila del subtab IP solo si aporta. Probable no-op |
+| 5 | `docs/reference/project-reference.md` | Actualizar **solo el resumen de features** (inspector `_ipRateLimits` + cierre del tipo `ip_rate_limit` muerto). El bump de version/fecha lo hace `/merge` |
+| 6 | `docs/_sidebar.md` | Agregar entradas Specs y Plan bajo "#348 admin-ip-rate-limits-inspector" (verificado: aun no estan registradas) |
+
+---
+
+## Estimacion de tamano de archivos
+
+| Archivo | Lineas estimadas | Status |
+|---------|-----------------|--------|
+| `functions/src/admin/ipRateLimits.ts` (nuevo) | ~150 (list + reset + helper + regex) | ideal |
+| `src/services/admin/ipRateLimits.ts` (nuevo) | ~52 (espejo de `rateLimits.ts`) | ideal |
+| `src/components/admin/alerts/IpRateLimitsSection.tsx` (nuevo) | ~230 (espejo de `RateLimitsSection`, 253) | aceptable |
+| `src/components/admin/AbuseAlerts.tsx` (modificado) | actual → +~10 | aceptable |
+| `functions/src/triggers/authBlocking.ts` (modificado) | +~2 lineas | ideal |
+| `src/types/admin.ts` (modificado) | +~12 | ideal |
+| `src/constants/messages/admin.ts` / `analyticsEvents/admin.ts` (modificado) | +~6 c/u | ideal |
+
+Ningun archivo supera 400 lineas. Plan B para `IpRateLimitsSection.tsx` si excede 300: extraer `parseAndTruncateHash`/`isAlreadyResetError` a helper local en `alerts/` (sin acoplar a `RateLimitsSection` por worktree boundary).
+
+---
+
+## Orden de implementacion
+
+Dependency chain:
+
+1. **Fase 1** (tipos + constantes + mensajes + registro GA4) — sin dependencias upstream. Congela el shape de `AdminIpRateLimitItem`. Habilita typing en Fases 2-4.
+2. **Fase 2** (callable backend) — depende de Fase 1 (mismo shape de tipo, conceptualmente). Habilita Fase 3.
+3. **Fase 3** (servicio frontend) — depende de Fase 1 (tipo) y Fase 2 (callable existe para wiring de tests). Habilita Fase 4.
+4. **Fase 4** (`IpRateLimitsSection` + integracion `AbuseAlerts`) — depende de Fases 1, 3.
+5. **Fase 5** (emitir `ip_rate_limit` en `authBlocking`) — **independiente** de las anteriores; puede correr en paralelo o al final. No depende del inspector.
+6. **Fase 6** (docs) — al final, recoge cambios reales.
+
+---
+
+## Riesgos
+
+1. **`orderBy('date','desc')` sin tie-breaker → orden intra-dia no-deterministico** (Diego obs #1). Mitigacion: documentado en codigo y en specs; inspector de bajo volumen con `limit`; NO se agrega orderBy compuesto (evita indice). Si en QA molesta, el filtro por `ipHash`/`action` da orden estable por subconjunto.
+2. **Parseo del docId con `action` multi-segmento** (Diego obs #2). Mitigacion: `parseIpRateLimitDocId` separa por primer/ultimo segmento con join del medio; test explicito en Fase 2 paso 4. El `action` del audit es best-effort (ya declarado en specs).
+3. **`authBlocking.test.ts` rompe asserts que esperaban `anon_flood` en el bloqueo.** Mitigacion: Fase 5 paso 2 ajusta esos asserts a `ip_rate_limit`+`severity:high` y mantiene los del umbral en `anon_flood`. Revisar el test existente antes de editar el trigger.
+4. **`copy-auditor` flagea textos nuevos.** Mitigacion: los 3 mensajes centralizados en `MSG_ADMIN` con tildes/voseo verificados; ejecutar el agente antes del merge.
+
+---
+
+## Rollback strategy
+
+Acoplamiento entre fases para revert (en caso de regresion en produccion):
+
+- **Fase 1 (constantes/types/messages/registro GA4)** — rollback-safe individualmente. Si se revierte, las fases 2-4 que dependen del tipo y los eventos quedan rotas en build; en la practica conviene revertir junto con lo posterior.
+- **Fase 2 (callable backend)** — rollback-safe individualmente. Sin consumidores hasta Fase 3 (servicio) y Fase 4 (UI). Revertir aislado solo afecta el export en `index.ts` (eliminar tambien).
+- **Fase 3 (servicio frontend)** — **acoplado con Fase 2** (los wrappers llaman a los callables `adminListIpRateLimits`/`adminResetIpRateLimit`). Revertir Fase 2 sin Fase 3 deja el servicio llamando a un callable inexistente. Revertir juntos.
+- **Fase 4 (`IpRateLimitsSection` + `AbuseAlerts`)** — depende de Fases 1 y 3. Rollback: Fase 4 sola es segura (el subtab desaparece, el resto de `AbuseAlerts` queda intacto). Si se revierte mas abajo, revertir 4 primero.
+- **Fase 5 (`authBlocking` emite `ip_rate_limit`)** — **independiente y rollback-safe individualmente.** Revertir restaura `anon_flood` en el bloqueo. No afecta al inspector (que lee `_ipRateLimits`, no `abuseLogs`). El tipo `ip_rate_limit` vuelve a quedar "muerto" pero sin romper nada.
+- **Fase 6 (docs)** — rollback-safe trivialmente.
+
+**Recomendacion: merge unificado** en una sola PR/branch. Evita ventanas donde la UI (Fase 4) este sin el callable (Fase 2), o donde los eventos se emitan sin estar registrados en `GA4_EVENT_NAMES` (Fase 1 los registra upfront).
+
+---
+
+## Guardrails de modularidad
+
+- [x] `IpRateLimitsSection` NO importa `firebase/functions` ni `firebase/firestore` — solo via `services/admin/ipRateLimits.ts` (barrel).
+- [x] Archivos nuevos en carpeta de dominio correcta (`components/admin/alerts/`, `services/admin/`, `functions/src/admin/`), NO en `components/menu/`.
+- [x] Logica de negocio en callable + servicio. El componente es shell sobre `useAsyncData` + `AdminPanelWrapper`.
+- [x] No-append: callable y servicio en archivos nuevos `ipRateLimits.ts`; `DOC_ID_REGEX`/`isAlreadyResetError` se duplican localmente (no se importan los privados de `rateLimits.ts`).
+- [x] Ningun archivo resultante supera 400 lineas (plan B documentado para `IpRateLimitsSection`).
+- [x] Usa contextos existentes (`ToastContext`, `ConnectivityContext`) — no crea god-context.
+
+## Guardrails de seguridad
+
+- [x] Sin cambios en Firestore rules — `_ipRateLimits` sigue `allow read, write: if false`. Acceso 100% Admin SDK via callable.
+- [x] Ambos callables: `assertAdmin` antes de cualquier query + App Check (`ENFORCE_APP_CHECK_ADMIN`).
+- [x] Rate limit por admin: 30/dia (list), 20/dia (reset) via `checkCallableRateLimit`.
+- [x] Inputs validados: `action` (`/^[a-z0-9_]{1,40}$/`), `ipHash` (`/^[a-f0-9]{16}$/`, no acepta IP raw), `limit` clamp `[1,100]`, `docId` (`/^[a-zA-Z0-9_-]{1,200}$/`, sin wildcard delete).
+- [x] No se expone ninguna IP raw — solo `ipHash`. El callable no acepta ni deriva IPs.
+- [x] Reset escribe `abuseLog` `config_edit` para audit trail.
+- [x] Sin `orderBy` compuesto sin indice (mitiga query costosa por input).
+- [x] No hay secrets/admin emails/credenciales en archivos commiteados.
+- [x] `getCountFromServer`: n/a — sin reads de count.
+
+## Guardrails de observabilidad
+
+- [x] Callables nuevos incluyen `trackFunctionTiming('adminListIpRateLimits'/'adminResetIpRateLimit', start)` en happy path y catch.
+- [x] Trigger modificado (`authBlocking`) ya tiene su instrumentacion existente; el cambio es solo el `type`/`severity` del `abuseLog`.
+- [x] Servicio frontend NO hace queries Firestore — solo `httpsCallable`. `measureAsync` no aplica.
+- [x] `admin_ip_rate_limit_viewed` y `_reset` registrados en `GA4_EVENT_NAMES` (Fase 1 paso 4, upfront) y en `ga4FeatureDefinitions.ts` card `admin_metrics` (Fase 1 paso 5).
+- [x] `logger.error` NUNCA dentro de `if (import.meta.env.DEV)` — handler de reset y catch del callable lo emiten siempre (Sentry).
+
+## Guardrails de accesibilidad y UI
+
+- [x] Boton "Resetear" tiene `aria-label` descriptivo con hash truncado + accion.
+- [x] Sin `<Typography onClick>` ni `<Box onClick>` — botones MUI.
+- [x] Touch targets `minHeight: 44`.
+- [x] Componente con fetch tiene error state via `AdminPanelWrapper` (no skeleton infinito).
+- [x] `<img>` con URL dinamica: n/a.
+- [x] `httpsCallable` user-facing con guard offline (`useConnectivity`): boton + confirmar disabled offline.
+- [x] Dialog destructivo con `role="alertdialog"` + `aria-labelledby`/`aria-describedby`.
+- [x] `Tooltip` sobre el hash truncado con valor completo.
+
+## Guardrails de copy
+
+- [x] Voseo en mensajes accionables ("Verificá").
+- [x] Tildes correctas: "acción", "sesión", "dirección", "día", "expiró".
+- [x] Terminologia consistente con `RateLimitsSection` (Count, Resetear, Activa/Expirada).
+- [x] Strings reutilizables en `src/constants/messages/admin.ts` (`MSG_ADMIN`).
+- [x] Pasar `copy-auditor` antes del merge.
+
+---
+
+## Criterios de done
+
+- [ ] Todos los items del scope del PRD implementados (S1, S2 in-scope, S3, S4 Opcion A).
+- [ ] Tests pasan con >= 80% coverage en codigo nuevo, incluyendo el test de `parseIpRateLimitDocId` con action multi-segmento (Diego obs #2).
+- [ ] Sin lint errors. `pre-staging-check.sh` pasa.
+- [ ] Build succeeds (`tsc -b && vite build`) + `cd functions && npm run build`.
+- [ ] Seed data: n/a (sin cambios de schema; `_ipRateLimits` ya existe y la puebla `ipRateLimiter.ts`).
+- [ ] Privacy policy: n/a (sin nueva recoleccion; hash-only existente).
+- [ ] Reference docs actualizados: `security.md`, `features.md`, `firestore.md`, `project-reference.md`.
+- [ ] Sidebar actualizado con Specs y Plan.
+- [ ] `copy-auditor` ejecutado sin findings sobre los 3 mensajes nuevos.
+- [ ] Smoke manual en emulador: subtab "Rate Limits IP" lista, filtra por action/ipHash y resetea con confirmacion; boton reset disabled offline; bloqueo por IP forzado emite `abuseLog` `ip_rate_limit`.
+
+---
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Ciclo:** 1
+
+**Observaciones para el implementador:**
+
+1. **Merge unificado, no parcial.** El plan ya lo recomienda y lo comparto: una sola PR/branch. Las Fases 2 (callable) y 3 (servicio) estan acopladas para rollback — el servicio llama a un callable que debe existir. No mergear Fase 3 sin Fase 2 en el mismo push. Si se splitea por algun motivo, Fase 2 va primero y sola.
+
+2. **Agente unico es la opcion correcta.** El feature es secuencial-friendly y espejo verificado del #327. Si manu decide paralelizar backend/frontend igual, el unico punto de contacto es el shape de `AdminIpRateLimitItem`: congelarlo en Fase 1 antes de abrir ambos workstreams (el plan ya lo marca como boundary critica). No hay otro overlap de archivos entre workstreams.
+
+3. **Tests en el paso de la feature, ya agendado.** Verifique que el test de `parseIpRateLimitDocId` con action multi-segmento (Diego obs #2) esta en Fase 2 paso 4, y el de regresion de `authBlocking` (que rompe asserts que esperaban `anon_flood` en el bloqueo) esta en Fase 5 paso 2. Confirmado contra el codigo: el bloque `exceeded` real (authBlocking.ts L65-73) emite hoy `anon_flood`/`severity:'high'`; el implementador DEBE ajustar ese assert existente, no solo agregar uno nuevo.
+
+4. **Ampliar mock de test existente.** `src/components/admin/__tests__/AbuseAlerts.test.tsx` ya mockea `services/admin` con `listAdminRateLimits`/`resetAdminRateLimit`. Fase 4 paso 4 debe agregar `listAdminIpRateLimits`/`resetAdminIpRateLimit` a ese mock, o el render del nuevo subtab fallara. El plan dice "modificar" — correcto, no crear.
+
+5. **`orderBy('date','desc')` sin tie-breaker: punto cerrado, no introducir orderBy compuesto.** Verifique que el callable real espejo (`rateLimits.ts` L125-130) usa `orderBy('resetAt','desc')` solo sin filtro; el plan adapta a `orderBy('date','desc')` y documenta el orden intra-dia no-deterministico en codigo (Fase 2 paso 1) y riesgos. No agregar indice compuesto. Cerrado.
+
+6. **Referencias de linea menores (no bloqueante):** el plan cita `GA4_EVENT_NAMES ~149-152`; el array real termina en `'admin_rate_limit_viewed'` cerca de L152 (la seccion "Admin tools" arranca en L144). Y el sidebar #348 confirmado ausente — Fase 6 paso 6 lo agenda bien. Son refs cosmeticas; agregar al final del array/seccion correcta, no en el numero exacto.
+
+**Sin BLOQUEANTES ni IMPORTANTES abiertos.** Orden logico correcto (infra->backend->servicio->UI->trigger independiente->docs), granularidad commit-por-paso, ningun archivo >400 lineas, risk staging sano (sin schema/rules/migrations; el cambio de mayor riesgo —trigger— aislado en Fase 5 e independiente), rollback por fase documentado con acoplamientos identificados, estimacion (S+M+S+L+S+S = M) coincide con el PRD. Listo para implementacion.

--- a/docs/feat/admin/admin-ip-rate-limits-inspector/prd.md
+++ b/docs/feat/admin/admin-ip-rate-limits-inspector/prd.md
@@ -1,0 +1,289 @@
+# PRD: Inspector admin de `_ipRateLimits` + cierre del tipo `ip_rate_limit` muerto
+
+**Feature:** admin-ip-rate-limits-inspector
+**Categoria:** admin
+**Fecha:** 2026-06-09
+**Issue:** #348
+**Prioridad:** Media
+
+---
+
+## Contexto
+
+`functions/src/utils/ipRateLimiter.ts` escribe contadores de abuso por IP (creacion de cuentas anonimas, hasta 10/dia/IP) en la coleccion `_ipRateLimits`, pero el admin esta ciego a esos datos: la coleccion no aparece en ningun panel, a diferencia de `_rateLimits` (por usuario) que tiene su inspector `RateLimitsSection.tsx` desde #327 dentro del subtab "Rate Limits" de la tab Alertas. Ademas el tipo `ip_rate_limit` esta definido en `abuseLogger.ts` (con `severity: 'medium'`) y en `src/constants/admin.ts` (label "Rate Limit IP" + color warning), pero ningun call site lo emite — `authBlocking.ts` siempre usa `anon_flood` —, dejando una categoria de Alertas que nunca recibira datos.
+
+## Problema
+
+- El admin no tiene visibilidad de los rate limits por IP (`_ipRateLimits`): no puede ver cuantas IPs estan cerca o por encima del limite de creacion de cuentas anonimas, ni desbloquear una IP legitima falsamente bloqueada (housekeeping o incidente).
+- La unica senal actual de abuso por IP es indirecta: un `abuseLog` de tipo `anon_flood` que se escribe al cruzar el umbral o el limite — pero no expone el contador acumulado ni el estado de la ventana diaria.
+- El tipo `ip_rate_limit` es codigo muerto: el panel Alertas muestra una categoria/filtro que nunca tendra resultados, lo que confunde al admin (parece un bug de datos) y es deuda de consistencia entre el enum del backend, las constantes del frontend y los call sites reales.
+
+## Solucion
+
+La solucion tiene dos mitades independientes pero coherentes: dar visibilidad de `_ipRateLimits` reusando el patron de `_rateLimits` (#327), y resolver el tipo `ip_rate_limit` muerto decidiendo entre emitirlo o eliminarlo. Por privacidad, `_ipRateLimits` nunca almacena IPs raw — solo `ipHash` (SHA-256 truncado a 16 chars, con bucketing IPv6 /64). El inspector trabaja sobre `ipHash`, nunca sobre IPs reales.
+
+### S1 — Callable admin `adminListIpRateLimits` (backend)
+
+Crear un callable en `functions/src/admin/` (archivo nuevo `ipRateLimits.ts`, NO appendear a `rateLimits.ts` para respetar regla de no-append y mantener archivos < 400 lineas) siguiendo el patron exacto de `adminListRateLimits`:
+
+- `onCall` con `enforceAppCheck: ENFORCE_APP_CHECK_ADMIN`, `timeoutSeconds: 30`.
+- `assertAdmin(auth)` como primera linea de autorizacion.
+- `checkCallableRateLimit(db, 'admin_ip_rate_limits_{uid}', 30, uid)` — 30/dia por admin, igual que el inspector de usuario, para desalentar scraping.
+- Lee `_ipRateLimits` ordenado por algun criterio estable. Los docs tienen `{ ipHash, action, date, count, createdAt }` (ID = `{ipHash}_{action}_{date}`). Como no hay campo `resetAt`, la ventana es diaria por `date` (string `YYYY-MM-DD`); el item derivado expone `windowActive = (date === hoy)`.
+- Filtro opcional por `action` (ej: `anon_create`) y/o por `ipHash` (input validado con regex hex 16 chars). NO aceptar IP raw como input — solo hash.
+- Clamp de `limit` a `[1, 100]`, default 50.
+- `trackFunctionTiming('adminListIpRateLimits', start)` en happy path y catch (patron try/catch de callables de patterns.md).
+- `captureException` + `logger.error` en catch, mapeo a `HttpsError('internal', ...)`.
+- Tipo de respuesta `AdminIpRateLimitItem[]` con `{ docId, ipHash, action, date, count, windowActive }`.
+
+Exportar en `functions/src/index.ts`.
+
+### S2 — Callable admin `adminResetIpRateLimit` (backend, opcional segun decision de producto)
+
+Mismo patron que `adminResetRateLimit`: borra un doc de `_ipRateLimits` por `docId` (validado con regex), 20/dia por admin, escribe `abuseLog` de tipo `config_edit` con `collection: '_ipRateLimits'` y detalle JSON (`action: 'reset_ip_rate_limit'`, `docId`, `action` del doc, `ipHash`). Permite desbloquear una IP legitima falsamente limitada (ej: NAT corporativo, oficina compartida).
+
+> Decision de producto pendiente (ver Sofia): si el reset de IP se considera fuera de scope por ahora (el bloqueo es por dia y se auto-resetea), S2 puede quedar Out of Scope y el inspector ser solo lectura. El default propuesto es incluirlo por simetria con `_rateLimits`.
+
+### S3 — Servicio frontend + UI subtab IP (frontend)
+
+- Servicio: `src/services/admin/ipRateLimits.ts` (archivo nuevo de dominio, no appendear a `rateLimits.ts`) — wrappers `listAdminIpRateLimits()` y `resetAdminIpRateLimit(docId)` via `httpsCallable`, identicos en forma a `services/admin/rateLimits.ts`. Re-exportar desde `services/admin/index.ts` si existe el barrel (verificar; no crear barrel nuevo).
+- Tipo `AdminIpRateLimitItem` en `src/types/admin.ts` (mirror del backend).
+- UI: extender `AbuseAlerts.tsx` agregando un cuarto subtab `ipRateLimits` (label "Rate Limits IP") al `<Tabs>` existente. El subtab renderiza un componente nuevo `src/components/admin/alerts/IpRateLimitsSection.tsx` (NO en `menu/`, va en el dominio de su tab). El componente reusa el shell de `RateLimitsSection`: `useAsyncData(fetcher)` + `AdminPanelWrapper` + tabla (columnas: IP Hash, Accion, Fecha, Count, Estado, [Accion si S2]).
+  - Mostrar `ipHash` truncado con `Tooltip` (igual que userId en RateLimitsSection). Aclarar en caption que es un hash, no una IP.
+  - Chip de estado Activa/Expirada por `windowActive`.
+  - Si S2: boton "Resetear" con dialog `role="alertdialog"` deshabilitado offline (`useConnectivity` + `MSG_OFFLINE.requiresConnection`).
+- Analytics: `EVT_ADMIN_IP_RATE_LIMIT_VIEWED` (+ `EVT_ADMIN_IP_RATE_LIMIT_RESET` si S2) en `src/constants/analyticsEvents/admin.ts`. Registrar en `GA4_EVENT_NAMES` (analyticsReport.ts) y `ga4FeatureDefinitions.ts`.
+
+### S4 — Resolver el tipo `ip_rate_limit` muerto
+
+Dos opciones; elegir UNA (decision de producto, ver Sofia):
+
+- **Opcion A (emitir):** en `authBlocking.ts`, cuando `checkIpRateLimit` devuelve `exceeded`, escribir el `abuseLog` con `type: 'ip_rate_limit'` en vez de (o ademas de) `anon_flood`. Asi la categoria del panel recibe datos reales y el tipo deja de estar muerto. Ventaja: distingue semanticamente "umbral de flood detectado" (`anon_flood`, alerta) de "IP bloqueada por rate limit" (`ip_rate_limit`, accion tomada).
+- **Opcion B (eliminar):** remover `'ip_rate_limit'` del enum en `abuseLogger.ts`, del `SEVERITY_MAP`, del enum en `src/types/admin.ts`, y de los maps de label/color en `src/constants/admin.ts`. Ventaja: menos superficie, una sola fuente de verdad (`anon_flood`).
+
+Recomendacion: **Opcion A**, porque el inspector de S1 + S3 da sentido a que exista un tipo de alerta distinto para bloqueos por IP, y el cambio en `authBlocking.ts` es de una linea. Pero requiere actualizar el test del flujo `authBlocking` y posiblemente la doc de seguridad.
+
+### Consideraciones de seguridad
+
+- `_ipRateLimits` esta protegido en `firestore.rules` con `allow read, write: if false` — solo el admin SDK puede leerlo. Por eso el inspector DEBE pasar por un callable admin, nunca leer la coleccion desde el cliente. No se modifican las rules.
+- Nunca exponer IPs raw: el doc ya solo guarda `ipHash`. El callable no debe re-derivar ni aceptar IPs.
+- El reset (S2) es una accion privilegiada que debe quedar auditada via `abuseLog` (`config_edit`), igual que `adminResetRateLimit`.
+
+### UX
+
+- Vive dentro de la tab "Alertas" del admin (`/admin`), como cuarto subtab junto a Alertas / Reincidentes / Rate Limits. Cero navegacion nueva: el admin ya conoce el patron de subtabs.
+- Flujo: admin abre Alertas → subtab "Rate Limits IP" → ve tabla de hashes con su contador y estado de ventana → (si S2) puede resetear una entrada con confirmacion.
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| S1 — callable `adminListIpRateLimits` + tipo backend + export | Alta | S |
+| S3 — servicio frontend + tipo + subtab UI `IpRateLimitsSection` | Alta | M |
+| S4 — resolver tipo `ip_rate_limit` (Opcion A o B) | Alta | S |
+| S2 — callable `adminResetIpRateLimit` + boton reset UI | Media | S |
+| Analytics events (viewed/reset) + registro en reportes GA4 | Media | S |
+| Tests (callable, servicio, componente) | Alta | M |
+
+**Esfuerzo total estimado:** M
+
+---
+
+## Out of Scope
+
+- Cambiar la politica de rate limiting por IP (limites, ventana, bucketing IPv6) — solo se inspecciona lo que ya escribe `ipRateLimiter.ts`.
+- Geolocalizacion o de-anonimizacion de IPs: el sistema es hash-only por diseno y asi se mantiene.
+- Inspector de `_fanoutDedup` u otras colecciones internas (`_cronRuns` ya tiene su panel).
+- Agregar `_ipRateLimits` a `src/config/collections.ts` (no es accedida desde el frontend; el acceso es 100% via callable). Si se agrega, debe ser solo como constante backend.
+
+---
+
+## Tests
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `functions/src/admin/ipRateLimits.ts` | Callable | assertAdmin rechaza no-admin; rate limit por admin; validacion de input (`action`/`ipHash`/`limit` clamp); mapeo de docs a `AdminIpRateLimitItem` con `windowActive` segun `date`; filtro por action/hash; catch → `HttpsError('internal')`; `trackFunctionTiming` invocado en ambos paths. Si S2: reset borra doc, escribe `abuseLog` config_edit, not-found cuando no existe |
+| `src/services/admin/ipRateLimits.ts` | Service | wrappers llaman al callable correcto con payload correcto; propagan error; mapean `result.data.items` |
+| `src/components/admin/alerts/IpRateLimitsSection.tsx` | Component | render de tabla; estado loading/error/empty via `AdminPanelWrapper`; emite `EVT_ADMIN_IP_RATE_LIMIT_VIEWED` una vez por mount; truncado de hash; (S2) dialog reset, disabled offline, toast success/error/already-reset |
+| `functions/src/triggers/authBlocking.ts` (si Opcion A) | Trigger | el bloqueo por IP emite `abuseLog` con `type: 'ip_rate_limit'`; el umbral sigue emitiendo `anon_flood` |
+| `src/constants/admin.ts` (si Opcion B) | Constants | ausencia del tipo no rompe el render del panel Alertas (cobertura via AbuseAlerts test existente) |
+
+### Criterios de testing
+
+- Cobertura >= 80% del codigo nuevo
+- Tests de validacion para todos los inputs del usuario (action, ipHash regex, limit clamp, docId regex)
+- Todos los paths condicionales cubiertos (filtro vs sin filtro, windowActive true/false, doc exists/not-found)
+- Side effects verificados (abuseLog en reset, trackFunctionTiming, trackEvent)
+
+---
+
+## Seguridad
+
+- [ ] El acceso a `_ipRateLimits` es 100% via callable admin — el cliente NUNCA lee la coleccion directamente (rules: `allow read, write: if false`, no se modifican)
+- [ ] `adminListIpRateLimits` / `adminResetIpRateLimit` llaman `assertAdmin(auth)` antes de cualquier query
+- [ ] App Check enforced server-side (`ENFORCE_APP_CHECK_ADMIN`)
+- [ ] Rate limit por admin en ambos callables (30/dia list, 20/dia reset) via `checkCallableRateLimit`
+- [ ] Inputs validados: `action` whitelist o string acotado, `ipHash` regex hex 16, `limit` clamp `[1,100]`, `docId` regex
+- [ ] No se expone ninguna IP raw — solo `ipHash`. El callable no acepta ni deriva IPs
+- [ ] Reset (S2) escribe `abuseLog` de tipo `config_edit` para audit trail
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| `adminListIpRateLimits` callable | usuario no-admin intenta scrapear hashes de IP / patrones de abuso | `assertAdmin` + App Check + rate limit 30/dia por admin |
+| `adminResetIpRateLimit` callable | admin comprometido borra masivamente entradas para deshabilitar la proteccion anti-flood | rate limit 20/dia + `abuseLog` audit + `docId` regex (no wildcard delete) |
+| Input `ipHash`/`action` | inyeccion para forzar query costosa o index scan | regex estricto + `limit` clamp + sin orderBy compuesto sin indice |
+
+`_ipRateLimits` NO es escribible por usuarios (solo admin SDK desde `beforeUserCreated`), por lo que no aplican los checklists de create/update rules ni de rate limit de trigger — la coleccion ya tiene su escritura controlada server-side en `ipRateLimiter.ts`.
+
+Este feature lee datos sensibles (hashes de IP + contadores de abuso). El acceso queda restringido a admin + rate-limit + audit. No hay scraping masivo posible para usuarios normales.
+
+---
+
+## Deuda tecnica y seguridad
+
+Consultado: `gh issue list --label security --state open` y `--label "tech debt"` no devuelven resultados con esos labels exactos; los tech-debt activos usan `enhancement` y viven en #341-#349 + #168.
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| #348 (este) | resuelve | inspector `_ipRateLimits` + cierre del tipo `ip_rate_limit` muerto |
+| #347 (perf — count queries sin `measureAsync`) | empeora si se ignora | el callable es backend, usa `trackFunctionTiming` (no `measureAsync`); no agrega count queries sin instrumentar |
+| #342 (security — secrets en functions/.env) | no agrava | el feature no agrega env vars ni secrets nuevos |
+
+### Mitigacion incorporada
+
+- Cierre del tipo `ip_rate_limit` muerto (S4): elimina la inconsistencia entre enum backend, tipos frontend, constantes y call sites. Paso explicito en el plan de implementacion.
+- El inspector cierra la asimetria detectada en #327 (donde `_rateLimits` quedo con inspector pero `_ipRateLimits` no).
+
+---
+
+## Robustez del codigo
+
+### Checklist de hooks async
+
+- [ ] `IpRateLimitsSection` usa `useAsyncData` (ya maneja cancelacion/cleanup) — no agregar `useEffect` con await crudo
+- [ ] Handler de reset (si S2) tiene `try/catch` con `toast.error` y maneja el caso `not-found` como `toast.info`
+- [ ] `logger.error` NUNCA dentro de `if (import.meta.env.DEV)` (callsite del catch del componente y del callable)
+- [ ] Constantes de analytics nuevas en `constants/analyticsEvents/admin.ts`, no string literals
+- [ ] Archivos nuevos no superan 300 lineas (`IpRateLimitsSection.tsx` puede compartir helpers con `RateLimitsSection` si crece)
+- [ ] El emit de `EVT_ADMIN_IP_RATE_LIMIT_VIEWED` usa `useRef` para dedup una vez por mount (patron de `RateLimitsSection`)
+
+### Checklist de observabilidad
+
+- [ ] Callables nuevos incluyen `trackFunctionTiming('adminListIpRateLimits' / 'adminResetIpRateLimit', start)` en happy path y catch
+- [ ] `EVT_ADMIN_IP_RATE_LIMIT_VIEWED` (+ reset) registrado en `GA4_EVENT_NAMES` (analyticsReport.ts) y `ga4FeatureDefinitions.ts`
+- [ ] El servicio frontend no hace queries Firestore (solo `httpsCallable`), por lo que no requiere `measureAsync`
+
+### Checklist offline
+
+- [ ] El inspector es read-only-by-default; si el dato no carga offline, `AdminPanelWrapper` muestra error state (no skeleton infinito)
+- [ ] Boton "Resetear" (S2) deshabilitado cuando `isOffline`, con tooltip `MSG_OFFLINE.requiresConnection`
+- [ ] Error handler del catch muestra `toast.error` en todos los environments
+
+### Checklist de documentacion
+
+- [ ] No se agregan secciones a HomeScreen (es admin)
+- [ ] Nuevos analytics events en `src/constants/analyticsEvents/admin.ts` (dominio, no barrel)
+- [ ] Nuevo tipo `AdminIpRateLimitItem` en `src/types/admin.ts` (dominio admin)
+- [ ] `docs/reference/features.md` actualizado: nuevo subtab "Rate Limits IP" en tab Alertas del admin
+- [ ] `docs/reference/firestore.md` actualizado si se documenta la lectura admin de `_ipRateLimits`
+- [ ] `docs/reference/security.md` actualizado: seccion "IP-based rate limiting" menciona el inspector y (Opcion A) el tipo `ip_rate_limit`
+- [ ] `docs/reference/patterns.md`: la fila "Abuse alerts (admin)" / "Admin panel decomposition" puede mencionar el subtab IP si aporta
+
+---
+
+## Offline
+
+### Data flows
+
+| Operacion | Tipo (read/write) | Estrategia offline | Fallback UI |
+|-----------|-------------------|-------------------|-------------|
+| Listar `_ipRateLimits` via callable | read (callable) | sin persistencia offline — callable requiere red | `AdminPanelWrapper` error state con reintentar |
+| Resetear IP rate limit (S2) | write (callable) | sin queue offline — accion admin critica + auditada | boton disabled offline + tooltip "Requiere conexion" |
+
+### Checklist offline
+
+- [ ] Reads via callable: no usan persistencia offline (callable). Error de red → error state visible
+- [ ] Writes (reset): boton disabled offline, NO se encola (accion admin auditada, no apta para offline queue)
+- [ ] APIs externas: ninguna nueva
+- [ ] UI: indicador offline en el boton de reset (tooltip + disabled)
+- [ ] Datos criticos: no aplica primera carga (panel admin, no flujo de usuario)
+
+### Esfuerzo offline adicional: S
+
+---
+
+## Modularizacion y % monolitico
+
+- Logica de negocio en callable backend + servicio frontend; el componente es shell sobre `useAsyncData` + `AdminPanelWrapper`.
+- `IpRateLimitsSection` recibe datos via su propio servicio/hook, no se acopla a contexto de layout.
+- Firebase SDK (`httpsCallable`) solo en `src/services/admin/ipRateLimits.ts`, nunca en el componente.
+- Componente nuevo en `src/components/admin/alerts/` (dominio de su tab), NO en `menu/`.
+
+### Checklist modularizacion
+
+- [ ] Logica en callable + servicio, no inline en `AbuseAlerts`
+- [ ] `IpRateLimitsSection` reutilizable (recibe sus datos via servicio propio)
+- [ ] No se agregan `useState` de logica de negocio a AppShell/SideMenu (es admin)
+- [ ] Props/handlers explicitos en el dialog de reset (sin noop `() => {}`)
+- [ ] El componente NO importa `firebase/functions` directamente — solo el servicio
+- [ ] Servicio nuevo en archivo de dominio `services/admin/ipRateLimits.ts` (no appendear a `rateLimits.ts`)
+- [ ] Callable nuevo en `functions/src/admin/ipRateLimits.ts` (no appendear a `rateLimits.ts`)
+- [ ] Ningun archivo nuevo supera 400 lineas (300 = warning); compartir helpers con `RateLimitsSection` si conviene
+- [ ] Usa el contexto existente (`ToastContext`, `ConnectivityContext`) — no crea contexto nuevo
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | = | componente aislado en `admin/alerts/`, espejo de `RateLimitsSection` |
+| Estado global | = | usa Toast/Connectivity existentes, sin god-context |
+| Firebase coupling | = | `httpsCallable` solo en servicio; componente desacoplado |
+| Organizacion por dominio | = | archivos en carpetas correctas (admin/alerts, services/admin, functions/admin) |
+
+---
+
+## Accesibilidad y UI mobile
+
+### Checklist de accesibilidad
+
+- [ ] El `<Tab>` "Rate Limits IP" hereda la semantica de tablist de MUI Tabs (igual que los 3 subtabs existentes)
+- [ ] Boton "Resetear" (S2) tiene `aria-label` descriptivo con el hash truncado y la accion
+- [ ] Dialog de reset usa `role="alertdialog"` + `aria-labelledby`/`aria-describedby` (patron de `RateLimitsSection`)
+- [ ] Touch targets >= 44px (`minHeight: 44` en botones, igual que `RateLimitsSection`)
+- [ ] Tabla con error state via `AdminPanelWrapper` (no skeleton infinito)
+- [ ] `Tooltip` sobre el hash truncado con el valor completo
+
+### Checklist de copy
+
+- [ ] Textos en espanol con tildes correctas ("Acción", "Estado", "Activa"/"Expirada")
+- [ ] Voseo donde aplique (es panel admin, mayormente labels)
+- [ ] Terminologia consistente con `RateLimitsSection`
+- [ ] Aclaracion visible de que se muestra un hash de IP, no la IP real (caption)
+- [ ] Mensajes de error accionables (reusar `MSG_ADMIN`/`MSG_OFFLINE` o agregar al dominio admin si falta)
+
+---
+
+## Success Criteria
+
+1. El admin puede ver, dentro de la tab Alertas (subtab "Rate Limits IP"), las entradas de `_ipRateLimits` con hash de IP, accion, fecha, contador y estado de ventana — sin exponer ninguna IP raw.
+2. El acceso pasa exclusivamente por un callable admin (`assertAdmin` + App Check + rate limit + audit), sin lecturas directas del cliente a `_ipRateLimits`.
+3. El tipo `ip_rate_limit` deja de ser codigo muerto: o bien `authBlocking.ts` lo emite en bloqueos por IP (Opcion A), o se elimina de enum/tipos/constantes (Opcion B) — sin dejar inconsistencias.
+4. (Si S2) El admin puede resetear una entrada de IP rate limit con confirmacion, accion auditada en `abuseLogs`, deshabilitada offline.
+5. Cobertura de tests >= 80% del codigo nuevo (callable, servicio, componente), con todos los paths condicionales y side effects verificados.
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** Recomendado: incluir S2 (reset callable) in-scope y Opcion A (emitir ip_rate_limit). La Opcion B subestima superficie: falta alertsHelpers.ts (SEVERITY_MAP:17 + ALL_TYPES:39). Ruta real: AbuseAlerts.tsx en admin/ (no alerts/). El subtab es union type en 2 lugares. Replicar el patron de saltar orderBy cuando hay filtro (sin indice).

--- a/docs/feat/admin/admin-ip-rate-limits-inspector/specs.md
+++ b/docs/feat/admin/admin-ip-rate-limits-inspector/specs.md
@@ -1,0 +1,413 @@
+# Specs: Inspector admin de `_ipRateLimits` + cierre del tipo `ip_rate_limit` muerto
+
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-10
+
+---
+
+## Resumen de decisiones adoptadas (Sofia, VALIDADO CON OBSERVACIONES)
+
+- **S2 (reset por IP): IN-SCOPE.** Simetría con `adminResetRateLimit`. El bloqueo por IP es diario (`date == hoy`) y se auto-resetea a medianoche UTC; el reset manual desbloquea antes (NAT corporativo, oficina compartida, incidente).
+- **S4: OPCIÓN A (emitir `ip_rate_limit`).** En `authBlocking.ts`, el bloqueo por IP (`exceeded == true`) cambia el `type` del `abuseLog` de `anon_flood` a `ip_rate_limit`, conservando el `severity: 'high'` explícito del entry actual (override deliberado del `SEVERITY_MAP.ip_rate_limit = 'medium'`: "IP bloqueada" es más severo que "umbral detectado"). El umbral de flood (`currentCount >= ANON_FLOOD_ALERT_THRESHOLD`, bloque líneas 49-56) NO cambia: sigue emitiendo `anon_flood` con su `severity: 'medium'` explícito actual. Así el tipo deja de ser código muerto **sin tocar** `abuseLogger.ts`/`alertsHelpers.ts`/`types/admin.ts`/`constants/admin.ts` (el tipo `ip_rate_limit` ya está definido en los 4: `abuseLogger.ts:6`+`SEVERITY_MAP:18`, `alertsHelpers.ts:17`+`ALL_TYPES:39`, `types/admin.ts:59`, `constants/admin.ts:45`+`:56`), evitando la superficie de la Opción B.
+- **Ruta real:** `AbuseAlerts.tsx` está en `src/components/admin/` (NO en `alerts/`). El nuevo `IpRateLimitsSection.tsx` SÍ va en `src/components/admin/alerts/`.
+- **Subtab union type:** se toca en 2 lugares de `AbuseAlerts.tsx` (declaración del `useState` línea 32 y el `onChange` del `<Tabs>` línea 174). Se agrega `'ipRateLimits'`.
+- **Sin índice compuesto:** replicar el patrón de `adminListRateLimits` (saltar `orderBy` cuando hay filtro).
+
+---
+
+## Modelo de datos
+
+### Colección existente (NO se modifica): `_ipRateLimits`
+
+Escrita exclusivamente por `functions/src/utils/ipRateLimiter.ts` vía Admin SDK. Sin acceso de cliente (rules `allow read, write: if false`).
+
+- **Doc ID:** `{ipHash}_{action}_{date}` — ej. `a1b2c3d4e5f60718_anon_create_2026-06-10`.
+- **Campos:** `{ ipHash: string (16 hex), action: string, date: string 'YYYY-MM-DD', count: number, createdAt: Timestamp }`.
+- **Ventana:** diaria por `date`. NO existe campo `resetAt`. El item derivado calcula `windowActive = (date === hoyUTC)`.
+- **Privacidad:** solo `ipHash` (SHA-256 truncado a 16 chars, IPv6 bucketeado a /64). Nunca IP raw.
+
+> NO se agrega `_ipRateLimits` a `src/config/collections.ts` (acceso 100% vía callable). Si se necesitara constante, sería solo backend.
+
+### Tipo backend nuevo (`functions/src/admin/ipRateLimits.ts`)
+
+```typescript
+export interface AdminIpRateLimitItem {
+  docId: string;       // {ipHash}_{action}_{date}
+  ipHash: string;      // 16 hex chars
+  action: string;      // ej. 'anon_create'
+  date: string;        // 'YYYY-MM-DD'
+  count: number;
+  windowActive: boolean; // date === hoyUTC ('YYYY-MM-DD')
+}
+```
+
+### Tipo frontend nuevo (`src/types/admin.ts`)
+
+Mirror exacto del backend (mismo patrón que `AdminRateLimitItem` líneas 217-226):
+
+```typescript
+/**
+ * Frontend mirror of the backend `AdminIpRateLimitItem` payload returned by the
+ * `adminListIpRateLimits` callable (`functions/src/admin/ipRateLimits.ts`).
+ * Shape MUST stay in sync with the server-side interface.
+ */
+export interface AdminIpRateLimitItem {
+  docId: string;
+  ipHash: string;
+  action: string;
+  date: string;          // 'YYYY-MM-DD'
+  count: number;
+  /** `true` when `date === todayUTC` at the moment the callable resolved */
+  windowActive: boolean;
+}
+```
+
+## Firestore Rules
+
+**Ningún cambio.** `_ipRateLimits` ya está en `firestore.rules` con `allow read, write: if false`. El acceso es 100% vía callable admin con Admin SDK (que bypassa rules). Esto es intencional y se mantiene.
+
+### Rules impact analysis
+
+| Query (service file) | Collection | Auth context | Rule que la permite | Cambio? |
+|---------------------|------------|-------------|--------------------|---------|
+| `adminListIpRateLimits` (functions/admin/ipRateLimits.ts) | `_ipRateLimits` | Admin SDK (bypassa rules) | N/A — Admin SDK ignora rules | No |
+| `adminResetIpRateLimit` (functions/admin/ipRateLimits.ts) | `_ipRateLimits` | Admin SDK (bypassa rules) | N/A — Admin SDK ignora rules | No |
+| `checkCallableRateLimit` (`_rateLimits`) | `_rateLimits` | Admin SDK | N/A | No |
+| `logAbuse` (`abuseLogs`) | `abuseLogs` | Admin SDK | N/A | No |
+| `authBlocking` emit `ip_rate_limit` | `abuseLogs` | Admin SDK | N/A | No |
+
+No hay queries de cliente nuevas. Ninguna query lee de una colección que el caller no debería leer — todas son Admin SDK.
+
+### Field whitelist check
+
+No aplica: ninguna escritura nueva de cliente a Firestore. Las escrituras son Admin SDK (`_ipRateLimits` delete en reset, `abuseLogs` add en audit) y no pasan por `hasOnly()`. El `abuseLog` con `type: 'ip_rate_limit'` usa el shape ya existente de `AbuseLogEntry` (sin campos nuevos).
+
+## Cloud Functions
+
+### `adminListIpRateLimits` (callable, nuevo)
+
+Archivo nuevo `functions/src/admin/ipRateLimits.ts`. Patrón exacto de `adminListRateLimits`:
+
+- `onCall<AdminListIpRateLimitsRequest>` con `{ enforceAppCheck: ENFORCE_APP_CHECK_ADMIN, timeoutSeconds: 30 }`.
+- `const start = performance.now();` primero.
+- `const adminAuth = assertAdmin(auth);` como primera línea de autorización.
+- Validación de input:
+  - `data.action` (opcional): `typeof === 'string'` y `ACTION_REGEX.test` (`/^[a-z0-9_]{1,40}$/`). Si inválido → `HttpsError('invalid-argument')`.
+  - `data.ipHash` (opcional): `typeof === 'string'` y `IP_HASH_REGEX.test` (`/^[a-f0-9]{16}$/`). NO acepta IP raw. Si inválido → `HttpsError('invalid-argument')`.
+  - `data.limit` (opcional): number finito, clamp a `[1, 100]`, default 50.
+- `await checkCallableRateLimit(db, 'admin_ip_rate_limits_' + adminAuth.uid, 30, adminAuth.uid)`.
+- Query (sin índice compuesto, replicando el patrón):
+  - Si `ipHash`: `baseCol.where('ipHash', '==', ipHash).limit(itemLimit)` (+ filtro `action` client-side post-fetch si ambos presentes, para no requerir índice compuesto `ipHash+action`).
+  - Else si `action`: `baseCol.where('action', '==', action).limit(itemLimit)`.
+  - Else: `baseCol.orderBy('date', 'desc').limit(itemLimit)`.
+  - **Regla:** nunca combinar `where` + `orderBy` sobre campos distintos (evita índice compuesto). Cuando hay filtro, se omite `orderBy`.
+- Mapeo de docs a `AdminIpRateLimitItem[]`: `windowActive = (docData.date === todayUTC)` donde `todayUTC = new Date().toISOString().slice(0,10)`.
+- `await trackFunctionTiming('adminListIpRateLimits', start)` antes del `return` happy.
+- Catch: `captureException(err); logger.error(...); await trackFunctionTiming(...); if (err instanceof HttpsError) throw err; throw new HttpsError('internal', 'No se pudo listar IP rate limits')`.
+
+### `adminResetIpRateLimit` (callable, nuevo)
+
+Mismo archivo. Patrón exacto de `adminResetRateLimit`:
+
+- `onCall<AdminResetIpRateLimitRequest>` con `{ enforceAppCheck: ENFORCE_APP_CHECK_ADMIN, timeoutSeconds: 30 }`.
+- `assertAdmin`, validación `data.docId` con `DOC_ID_REGEX` (`/^[a-zA-Z0-9_-]{1,200}$/`, reutilizar el del archivo o exportar uno local equivalente; NO importar el privado de `rateLimits.ts` — duplicar la constante local respeta no-append).
+- `await checkCallableRateLimit(db, 'admin_ip_rate_limit_reset_' + adminAuth.uid, 20, adminAuth.uid)`.
+- `const docRef = db.collection('_ipRateLimits').doc(data.docId); const snap = await docRef.get(); if (!snap.exists) throw new HttpsError('not-found', ...)`.
+- `await docRef.delete();`.
+- Parsear `docId` para extraer `ipHash` y `action` (helper `parseIpRateLimitDocId(docId)` que separa por `_`: `ipHash` = primer segmento, `date` = último, `action` = lo del medio). Se documenta como best-effort para el audit detail.
+- `await logAbuse(db, { userId: adminAuth.uid, type: 'config_edit', collection: '_ipRateLimits', detail: JSON.stringify({ action: 'reset_ip_rate_limit', docId, ipHash, ipAction }) })`.
+- `trackFunctionTiming('adminResetIpRateLimit', start)` en happy y catch.
+- Catch idéntico a `adminResetRateLimit` (`if (!(err instanceof HttpsError)) { captureException; logger.error }`).
+
+### Trigger modificado: `functions/src/triggers/authBlocking.ts` (Opción A)
+
+En el bloque `if (exceeded)` (líneas 65-73), cambiar el `type` del `logAbuse` de `'anon_flood'` a `'ip_rate_limit'`:
+
+```typescript
+if (exceeded) {
+  await logAbuse(db, {
+    userId: hashIp(ip),
+    type: 'ip_rate_limit',     // antes: 'anon_flood'
+    collection: '_ipRateLimits',
+    detail: `IP exceeded ${MAX_ANON_CREATES_PER_IP_PER_DAY} anonymous accounts/day — blocked`,
+    severity: 'high',
+  });
+  throw new HttpsError('resource-exhausted', 'Too many accounts created from this network.');
+}
+```
+
+El umbral de alerta (líneas 49-56) NO cambia: sigue emitiendo `anon_flood` (severity `medium`). Distinción semántica: `anon_flood` = umbral detectado (alerta), `ip_rate_limit` = IP bloqueada (acción tomada). Se agrega `collection: '_ipRateLimits'` al entry para coherencia con el resto de logs (el campo es opcional en `AbuseLogEntry`).
+
+### Export en `functions/src/index.ts`
+
+```typescript
+export { adminListIpRateLimits, adminResetIpRateLimit } from './admin/ipRateLimits';
+```
+
+> Nota no-append (worktrees): si se trabaja en worktree paralelo, dejar este export al merge. En este caso es un feature único, se agrega directamente.
+
+## Seed Data
+
+No aplica. El feature NO crea colecciones nuevas ni agrega campos requeridos. `_ipRateLimits` ya existe y es poblada en runtime por `ipRateLimiter.ts`. El inspector lee lo que ya escribe el sistema. Si se quisiera data de QA, se puede sembrar manualmente en el emulador, pero no es requerido por el plan.
+
+## Componentes
+
+### `IpRateLimitsSection.tsx` (nuevo, `src/components/admin/alerts/`)
+
+Espejo de `RateLimitsSection.tsx`. Sin props (igual que `RateLimitsSection`). Renderizado por `AbuseAlerts` cuando `innerTab === 'ipRateLimits'`.
+
+- Estado: `actionFilter` (TextField o select), `ipHashFilter` (TextField), `useDeferredValue` sobre el filtro activo.
+- `fetcher = useCallback(() => listAdminIpRateLimits(filtros), [deferred...])` → `useAsyncData(fetcher)`.
+- Dedup de analytics: `viewedEmittedRef` (useRef) emite `EVT_ADMIN_IP_RATE_LIMIT_VIEWED` una vez por mount en el primer load exitoso (patrón idéntico a `RateLimitsSection` líneas 77-83).
+- Caption visible: aclara que **IP Hash es un hash SHA-256 de la IP, no la IP real**.
+- Tabla (`AdminPanelWrapper` envuelve loading/error). Columnas:
+  - **IP Hash**: `Tooltip` con hash completo, monospace truncado (`{ipHash.slice(0,8)}…`).
+  - **Acción** (`action`): `Chip` con `CHIP_SMALL_SX`.
+  - **Fecha** (`date`): texto `YYYY-MM-DD`.
+  - **Count** (`count`): align right.
+  - **Estado**: `Chip` `Activa`/`Expirada` por `windowActive` (success/default).
+  - **Acción** (S2): botón "Resetear" `color="error"`, `disabled={isOffline}`, `Tooltip` con `MSG_OFFLINE.requiresConnection` cuando offline, `aria-label` descriptivo con hash truncado + acción. `minHeight: 44`.
+- Dialog reset: `role="alertdialog"`, `aria-labelledby`/`aria-describedby`, body explica que desbloquea esa IP+acción hasta el reset diario. Handler `handleConfirmReset` con try/catch: success → `MSG_ADMIN.ipRateLimitResetSuccess` + `trackEvent(EVT_ADMIN_IP_RATE_LIMIT_RESET, { action })` + refetch; `not-found` (`isAlreadyResetError`) → `toast.info(MSG_ADMIN.ipRateLimitAlreadyReset)` + refetch; otro → `logger.error` + `toast.error(MSG_ADMIN.ipRateLimitResetError)`.
+
+Estimación: ~230 líneas (igual que `RateLimitsSection`, 253). Si excede 300, extraer helper `parseAndTruncateHash`/`isAlreadyResetError` a un helper compartido en `alerts/` — pero `isAlreadyResetError` ya está duplicado localmente en `RateLimitsSection`; mantener el patrón local para no acoplar archivos en worktree.
+
+### `AbuseAlerts.tsx` (modificado, `src/components/admin/`)
+
+- Línea 32: `useState<'alerts' | 'reincidentes' | 'rateLimits' | 'ipRateLimits'>('alerts')`.
+- Línea 33: `useAbuseLogsRealtime(200, innerTab !== 'rateLimits' && innerTab !== 'ipRateLimits')` — el subtab IP, como rateLimits, no necesita el realtime de abuseLogs (suspender la suscripción).
+- Línea 157: `const isRateLimitsTab = innerTab === 'rateLimits' || innerTab === 'ipRateLimits';` (renombrar conceptualmente a "tab que no usa abuseLogs"; o agregar `const isCallableTab = ...`). Esto hace que `AdminPanelWrapper` no muestre loading/error de abuseLogs ni los KPIs en el subtab IP.
+- Línea 174: el `onChange` del `<Tabs>` actualiza el union type → agregar `'ipRateLimits'` al tipo del callback.
+- Agregar `<Tab value="ipRateLimits" label="Rate Limits IP" />` después del de "Rate Limits".
+- Agregar render condicional: `{innerTab === 'ipRateLimits' && <IpRateLimitsSection />}`.
+- Import: `import IpRateLimitsSection from './alerts/IpRateLimitsSection';`.
+
+### Mutable prop audit
+
+No aplica. `IpRateLimitsSection` no recibe datos mutables como props (sin props, obtiene datos vía su servicio). El reset es un write vía callable + refetch, no muta props del parent.
+
+## Textos de usuario
+
+| Texto | Donde se usa | Notas |
+|-------|-------------|-------|
+| "Rate Limits IP" | label del `<Tab>` en AbuseAlerts | — |
+| "IP Hash" | header de columna en IpRateLimitsSection | — |
+| "Acción" | header de columna + label de filtro | tilde en Acción |
+| "Fecha" | header de columna | — |
+| "Count" | header de columna | término consistente con RateLimitsSection |
+| "Estado" | header de columna | — |
+| "Activa" / "Expirada" | chip de estado | — |
+| "Resetear" | botón + título dialog | consistente con RateLimitsSection |
+| "Se muestra un hash SHA-256 de la IP, no la dirección real." | caption en IpRateLimitsSection | tildes: dirección |
+| "Filtrar por acción" | label del filtro action | tilde en acción |
+| "Filtrar por IP Hash" | label del filtro ipHash | — |
+| "Limpiar" / "Limpiar filtro" | botón clear + aria-label | — |
+| "Sin entradas." / "Sin resultados para este filtro." | empty states | — |
+| "¿Resetear rate limit de IP?" | título dialog | signo apertura ¿ |
+| "Desbloquea esta IP para la acción {action} hasta el reset diario." | body dialog (ventana activa) | tildes: acción |
+| "Limpia esta entrada (la ventana del día ya expiró). Es housekeeping." | body dialog (expirada) | tilde: día, expiró |
+| `MSG_ADMIN.ipRateLimitResetSuccess` = "Reseteado correctamente" | toast success | — |
+| `MSG_ADMIN.ipRateLimitResetError` = "No se pudo resetear. Verificá tu sesión admin." | toast error | voseo: Verificá; tilde: sesión |
+| `MSG_ADMIN.ipRateLimitAlreadyReset` = "Esta entrada ya fue reseteada por otro admin. Refrescamos la tabla." | toast info | — |
+
+Los 3 últimos se agregan a `src/constants/messages/admin.ts` (sección nueva `// #348 — IP rate limits inspector`).
+
+## Hooks
+
+Ninguno nuevo. Se reutiliza `useAsyncData` (existente), `useToast`, `useConnectivity`. El emit dedup usa `useRef` inline (patrón de `RateLimitsSection`, no es un hook extraído).
+
+## Servicios
+
+### `src/services/admin/ipRateLimits.ts` (nuevo, archivo de dominio)
+
+Espejo de `services/admin/rateLimits.ts`. Solo wrappers `httpsCallable` (sin queries Firestore → no requiere `measureAsync`).
+
+```typescript
+export async function listAdminIpRateLimits(
+  params: { action?: string; ipHash?: string; limit?: number } = {},
+): Promise<AdminIpRateLimitItem[]>
+// httpsCallable<Req, { items: AdminIpRateLimitItem[] }>(functions, 'adminListIpRateLimits')
+// arma request solo con campos definidos (igual que listAdminRateLimits)
+
+export async function resetAdminIpRateLimit(docId: string): Promise<void>
+// httpsCallable<{ docId: string }, { success: true }>(functions, 'adminResetIpRateLimit')
+```
+
+Re-export en `src/services/admin/index.ts` (barrel existente, línea 56 vecina):
+
+```typescript
+export { listAdminIpRateLimits, resetAdminIpRateLimit } from './ipRateLimits';
+```
+
+## Integracion
+
+- `AbuseAlerts.tsx` importa `IpRateLimitsSection` y agrega el subtab (4 puntos de cambio: union type línea 32, `useAbuseLogsRealtime` guard línea 33, `isRateLimitsTab`/guard de KPIs línea 157, `onChange` tipo + `<Tab>` + render condicional líneas 174-248).
+- `IpRateLimitsSection` consume `listAdminIpRateLimits`/`resetAdminIpRateLimit` desde `../../../services/admin` (barrel).
+- `functions/src/index.ts` exporta los 2 callables nuevos.
+- `authBlocking.ts` emite `ip_rate_limit`.
+- Analytics: `admin.ts` (constants) + `analyticsReport.ts` (GA4_EVENT_NAMES) + `ga4FeatureDefinitions.ts` (card `admin_metrics`).
+
+### Preventive checklist
+
+- [x] **Service layer**: `IpRateLimitsSection` NO importa `firebase/functions` — solo el servicio `services/admin/ipRateLimits.ts`.
+- [x] **Duplicated constants**: `DOC_ID_REGEX`/`isAlreadyResetError` se duplican localmente (no se importa el privado de `rateLimits.ts`) por regla no-append. Las constantes de analytics van a `constants/analyticsEvents/admin.ts`, no inline.
+- [x] **Context-first data**: no hay `getDoc` de cliente. Datos vía callable (única vía posible para `_ipRateLimits`).
+- [x] **Silent .catch**: el catch del handler de reset usa `logger.error` + `toast.error`. El callable usa `captureException` + `logger.error`.
+- [x] **Stale props**: `IpRateLimitsSection` no recibe props mutables.
+
+## Tests
+
+| Archivo test | Que testear | Tipo |
+|-------------|-------------|------|
+| `functions/src/admin/__tests__/ipRateLimits.test.ts` | `adminListIpRateLimits`: `assertAdmin` rechaza no-admin; rate limit por admin invocado (`admin_ip_rate_limits_{uid}`, 30); validación `action` regex / `ipHash` regex hex16 / `limit` clamp `[1,100]`+default 50; mapeo doc→`AdminIpRateLimitItem` con `windowActive` true (date==hoy) y false; filtro por `action` (where), por `ipHash` (where, action client-side post-fetch), sin filtro (orderBy date desc); catch → `HttpsError('internal')`; `trackFunctionTiming` en happy + catch. `adminResetIpRateLimit`: borra doc; escribe `abuseLog` `config_edit` con `_ipRateLimits` + detalle parseado; `not-found` cuando no existe; rate limit 20; `docId` regex inválido → `invalid-argument`; `trackFunctionTiming` ambos paths | Callable |
+| `functions/src/__tests__/triggers/authBlocking.test.ts` (modificar) | El bloqueo por IP (`exceeded`) emite `abuseLog` con `type: 'ip_rate_limit'` (severity high); el umbral (`currentCount >= threshold`) sigue emitiendo `anon_flood`; ambos coexisten en el flujo de exceso | Trigger |
+| `src/services/admin/__tests__/ipRateLimits.test.ts` | `listAdminIpRateLimits` llama `'adminListIpRateLimits'` con payload correcto (solo campos definidos); mapea `result.data.items`; propaga error. `resetAdminIpRateLimit` llama `'adminResetIpRateLimit'` con `{ docId }`; propaga error | Service (smoke) |
+| `src/components/admin/alerts/__tests__/IpRateLimitsSection.test.tsx` | render tabla; estados loading/error/empty vía `AdminPanelWrapper`; emite `EVT_ADMIN_IP_RATE_LIMIT_VIEWED` una vez por mount; truncado de hash + Tooltip; dialog reset (open/confirm); botón disabled offline (`useConnectivity` mock); toast success / error / already-reset (`not-found`); filtro action/ipHash | Component |
+| `src/components/admin/__tests__/AbuseAlerts.test.tsx` (modificar) | el subtab "Rate Limits IP" se renderiza y monta `IpRateLimitsSection`; `useAbuseLogsRealtime` se suspende en ese subtab | Component |
+| `functions/src/admin/__tests__/analyticsReport` o test de constantes | el evento `admin_ip_rate_limit_viewed`/`_reset` está en `GA4_EVENT_NAMES` (cobertura vía test existente de ga4FeatureDefinitions) | Constants |
+
+### Mock strategy
+
+- **Callable (functions)**: mock de `firebase-admin/firestore` (`FieldValue`, `collection().doc().get/delete`, `runTransaction` no aplica aquí), mock de `assertAdmin`, `checkCallableRateLimit`, `logAbuse`, `trackFunctionTiming`, `captureException`. Patrón de `rateLimits.test.ts`.
+- **Service**: mock de `firebase/functions` (`httpsCallable` devuelve fn que resuelve `{ data: { items } }`), mock de `config/firebase`.
+- **Component**: mock de `services/admin` (`listAdminIpRateLimits`/`resetAdminIpRateLimit`), `utils/analytics` (`trackEvent`), `context/ToastContext`, `context/ConnectivityContext`, `utils/logger`.
+
+### Criterio de aceptación
+
+- Cobertura >= 80% del código nuevo. Todos los paths condicionales (filtro vs sin filtro, `windowActive` true/false, doc exists/not-found, offline true/false) cubiertos. Side effects (abuseLog, trackFunctionTiming, trackEvent) verificados.
+
+## Analytics
+
+Nuevos en `src/constants/analyticsEvents/admin.ts`:
+
+```typescript
+// #348 — IP rate limits inspector
+export const EVT_ADMIN_IP_RATE_LIMIT_VIEWED = 'admin_ip_rate_limit_viewed';
+export const EVT_ADMIN_IP_RATE_LIMIT_RESET = 'admin_ip_rate_limit_reset';
+```
+
+| Evento | Cuándo | Parámetros |
+|--------|--------|-----------|
+| `admin_ip_rate_limit_viewed` | Una vez por mount de `IpRateLimitsSection`, primer load exitoso | — |
+| `admin_ip_rate_limit_reset` | Reset confirmado y exitoso | `{ action: string }` |
+
+Registro:
+
+- `functions/src/admin/analyticsReport.ts` → agregar `'admin_ip_rate_limit_viewed'` y `'admin_ip_rate_limit_reset'` a `GA4_EVENT_NAMES` (array líneas 145-152).
+- `src/components/admin/features/ga4FeatureDefinitions.ts` → agregar ambos a `eventNames` de la card `admin_metrics` (línea 194).
+
+---
+
+## Offline
+
+### Cache strategy
+
+| Dato | Estrategia | TTL | Storage |
+|------|-----------|-----|---------|
+| Listado `_ipRateLimits` | sin persistencia (callable requiere red) | — | — |
+
+### Writes offline
+
+| Operacion | Mecanismo | Conflict resolution |
+|-----------|-----------|-------------------|
+| Reset IP rate limit | NO se encola — botón disabled offline (`useConnectivity`) | N/A — acción admin auditada, no apta para offline queue |
+
+### Fallback UI
+
+- Read: `AdminPanelWrapper` muestra error state con reintentar (no skeleton infinito).
+- Write: botón "Resetear" `disabled` cuando `isOffline` + `Tooltip` con `MSG_OFFLINE.requiresConnection`. Botón confirmar del dialog también `disabled={submitting || isOffline}`.
+
+---
+
+## Accesibilidad y UI mobile
+
+| Componente | Elemento | aria-label | Min touch target | Error state |
+|-----------|----------|------------|-----------------|-------------|
+| IpRateLimitsSection | Botón Resetear | `Resetear rate limit de IP {hashShort} (acción {action})` | `minHeight: 44` | `AdminPanelWrapper` |
+| IpRateLimitsSection | Botón Limpiar filtro | `Limpiar filtro` | `minHeight: 44` | — |
+| IpRateLimitsSection | Dialog reset | `role="alertdialog"` + `aria-labelledby` + `aria-describedby` | — | — |
+| AbuseAlerts | `<Tab>` Rate Limits IP | semántica tablist nativa MUI | nativo MUI | — |
+
+### Reglas aplicadas
+
+- Botones tienen `aria-label` descriptivo. Sin `<Typography onClick>` ni `<Box onClick>`.
+- Touch targets `minHeight: 44`.
+- Tabla con error state vía `AdminPanelWrapper`.
+- No hay `<img>` con URL dinámica.
+- `Tooltip` sobre el hash truncado con valor completo.
+
+## Textos y copy
+
+| Texto | Donde | Regla aplicada |
+|-------|-------|----------------|
+| "Verificá tu sesión admin." | toast error | voseo + tilde sesión |
+| "Se muestra un hash SHA-256 de la IP, no la dirección real." | caption | tilde dirección |
+| "Filtrar por acción" | label filtro | tilde acción |
+| "¿Resetear rate limit de IP?" | título dialog | signo apertura ¿ |
+| "la ventana del día ya expiró" | body dialog | tildes día, expiró |
+
+### Reglas de copy
+
+- Voseo en mensajes accionables ("Verificá").
+- Tildes: acción, sesión, dirección, día, expiró.
+- Terminología consistente con `RateLimitsSection` (Count, Resetear, Activa/Expirada).
+- Strings reutilizables en `src/constants/messages/admin.ts` (`MSG_ADMIN`).
+
+---
+
+## Decisiones tecnicas
+
+- **No-append a `rateLimits.ts`**: callable y servicio en archivos de dominio nuevos (`ipRateLimits.ts`) para respetar la regla de no-append y mantener archivos < 400 líneas. Constantes locales (`DOC_ID_REGEX`, `isAlreadyResetError`) se duplican en vez de importarse de `rateLimits.ts` (export privado + worktree boundary).
+- **Sin índice compuesto**: se replica el patrón de `adminListRateLimits` — `where` simple o `orderBy` simple, nunca combinados sobre campos distintos. Cuando ambos filtros (`ipHash` + `action`) están presentes, se filtra `action` client-side post-fetch sobre el resultado del `where('ipHash')`. Alternativa rechazada: declarar índice compuesto `ipHash+action` (overkill para un inspector admin de bajo volumen).
+- **Opción A (emitir) vs B (eliminar)**: A elegida porque el inspector da sentido a un tipo de alerta distinto para bloqueos por IP y el cambio es de ~3 líneas en `authBlocking.ts`. B tocaría 5 archivos (`abuseLogger.ts`, `alertsHelpers.ts` SEVERITY_MAP+ALL_TYPES, `types/admin.ts`, `constants/admin.ts` labels+colors) — mayor superficie, peor ROI.
+- **`windowActive` por `date`**: la colección no tiene `resetAt`; la ventana es diaria por string `date`. `windowActive = (date === todayUTC)`. Coherente con la semántica de `ipRateLimiter.ts` (que usa `new Date().toISOString().slice(0,10)`).
+
+---
+
+## Hardening de seguridad
+
+### Firestore rules requeridas
+
+Ninguna. `_ipRateLimits` mantiene `allow read, write: if false`. El acceso es 100% Admin SDK vía callable. No se modifica `firestore.rules`.
+
+### Rate limiting
+
+| Coleccion / superficie | Limite | Implementacion |
+|-----------|--------|---------------|
+| `adminListIpRateLimits` (callable) | 30/día por admin | `checkCallableRateLimit(db, 'admin_ip_rate_limits_{uid}', 30, uid)` |
+| `adminResetIpRateLimit` (callable) | 20/día por admin | `checkCallableRateLimit(db, 'admin_ip_rate_limit_reset_{uid}', 20, uid)` |
+| `_ipRateLimits` (writes) | N/A | Ya controlado server-side en `ipRateLimiter.ts` (no escribible por usuarios) |
+
+### Vectores de ataque mitigados
+
+| Ataque | Mitigacion | Archivo |
+|--------|-----------|---------|
+| no-admin scrapea hashes de IP / patrones de abuso | `assertAdmin` + App Check (`ENFORCE_APP_CHECK_ADMIN`) + rate limit 30/día | `functions/src/admin/ipRateLimits.ts` |
+| admin comprometido borra masivamente entradas para deshabilitar anti-flood | rate limit 20/día + `abuseLog` audit + `docId` regex (no wildcard delete) | `functions/src/admin/ipRateLimits.ts` |
+| inyección en `ipHash`/`action` para forzar query costosa o index scan | regex estricto (`/^[a-f0-9]{16}$/`, `/^[a-z0-9_]{1,40}$/`) + `limit` clamp + sin orderBy compuesto sin índice | `functions/src/admin/ipRateLimits.ts` |
+| de-anonimización de IP | la colección solo guarda `ipHash`; el callable no acepta ni deriva IPs raw | `functions/src/utils/ipRateLimiter.ts` (sin cambios) |
+
+---
+
+## Deuda tecnica: mitigacion incorporada
+
+Consultado en el PRD: `--label security` y `--label "tech debt"` no devuelven resultados con esos labels exactos; los tech-debt activos usan `enhancement` (#341-#349 + #168).
+
+| Issue | Que se resuelve | Paso del plan |
+|-------|----------------|---------------|
+| #348 (este) | inspector `_ipRateLimits` + cierre del tipo `ip_rate_limit` muerto | Todas las fases |
+| #327 (asimetría) | `_rateLimits` tenía inspector pero `_ipRateLimits` no — se cierra | Fase 1 + 3 |
+| #347 (count queries sin `measureAsync`) | no se agrava — el callable usa `trackFunctionTiming` (backend), el servicio no hace queries Firestore | Fase 1 + 3 |
+
+No se agrava ninguna deuda existente. Los archivos tocados (`authBlocking.ts`, `AbuseAlerts.tsx`, `analyticsReport.ts`, `ga4FeatureDefinitions.ts`, `messages/admin.ts`, `types/admin.ts`, barrels) reciben cambios acotados que respetan sus convenciones.
+
+---
+
+## Validacion Tecnica
+
+## Revisión Técnica (Gate Diego)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Revisor:** Diego (solution architect)
+
+**Observaciones:** El spec es un espejo verificado linea por linea del patron #327 (`rateLimits.ts` / `RateLimitsSection.tsx` / `AbuseAlerts.tsx`): las lineas referenciadas (useState:32, useAbuseLogsRealtime:33, isRateLimitsTab:157, Tabs onChange:174), el barrel `services/admin/index.ts`, los sitios de analytics (`GA4_EVENT_NAMES` ~149-151, card `admin_metrics` :194), `MSG_OFFLINE.requiresConnection`, la rule `_ipRateLimits: allow read, write: if false` (firestore.rules:762) y el trigger `authBlocking.ts` (bloque exceeded con severity:'high') fueron todos confirmados contra el codigo real. Cobertura PRD->specs completa con las decisiones de Sofia (S2 in-scope, Opcion A) bien integradas. Security model completo (assertAdmin + App Check + rate-limit + audit + regex). Dos observaciones que el plan.md debe respetar, ninguna bloqueante: (1) **orderBy('date','desc') sin tie-breaker** — al no haber filtro, todos los docs de la misma `date` (los de hoy) carecen de orden estable entre hashes; el spec dice "criterio estable" pero `date` no lo es dentro del dia. Aceptable para un inspector de bajo volumen con `limit`, pero el plan debe documentar que el orden intra-dia es no-deterministico (no introducir un orderBy compuesto que requeriria indice). (2) **parseo del docId `{ipHash}_{action}_{date}`** — `action` ('anon_create') contiene underscore; el helper `parseIpRateLimitDocId` (primer segmento=ipHash, ultimo=date, medio=action via join) maneja el caso, pero el plan debe incluir un test explicito para un action multi-segmento, ya que es donde un split naive por '_' fallaria. El campo `action` en el audit detail es best-effort, lo cual el spec ya declara — correcto.

--- a/docs/feat/content/help-docs-tabbar-source-of-truth/plan.md
+++ b/docs/feat/content/help-docs-tabbar-source-of-truth/plan.md
@@ -1,0 +1,185 @@
+# Plan: features.md describe un SideMenu inexistente — alinear la fuente de verdad con la navegacion real (TabBar)
+
+**Specs:** [specs.md](specs.md)
+**PRD:** [prd.md](prd.md)
+**Issue:** #349
+**Fecha:** 2026-06-12
+
+> Basado en `specs.md` (VALIDADO CON OBSERVACIONES por Diego, 2026-06-12). Feature de **documentacion pura**: no se toca `src/`, rules, Firestore, Cloud Functions, Storage ni `scripts/guards/checks.mjs`. Solo 2 archivos de doc: `docs/reference/features.md` y `docs/reference/guards/311-help-docs.md`.
+
+---
+
+## Estimacion de tamaño de archivos
+
+| Archivo | LOC actual | LOC estimado post-cambio | Estrategia si supera 400 |
+|---------|-----------|--------------------------|--------------------------|
+| `docs/reference/features.md` | ~471 | ~471-480 (reescritura del bloque 50-74 + ediciones puntuales de 13 lineas) | N/A — doc, sin limite de componente |
+| `docs/reference/guards/311-help-docs.md` | ~96 | ~105-110 (documentar R2 + sync de tabs) | N/A |
+
+Sin archivos de runtime. No aplica el limite de 400 LOC de componentes.
+
+---
+
+## Fases de implementacion
+
+**Branch:** `fix/349-help-docs-tabbar-source-of-truth` (desde `new-home`)
+
+**Owner:** unico — `documentation` (delegado por `manu`). Sin paralelismo entre agentes → sin conflictos de ownership. Sin codigo de produccion, por lo que no intervienen `luna`/`nico`.
+
+### Fase 1: Reescritura de la seccion de navegacion (S1) — `features.md` lineas 50-74
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `docs/reference/features.md` | Renombrar header `## Menu lateral (SideMenu)` → `## Navegacion principal (TabBar + tabs)` (cierra la mencion `SideMenu` de la linea 50 y la frase "menu lateral" del mismo header). |
+| 2 | `docs/reference/features.md` | Describir la `BottomNavigation` de 5 tabs segun `src/components/layout/TabBar.tsx`: **Inicio / Social / Buscar / Listas / Perfil**, con el `SearchFab` central elevado (`src/components/layout/SearchFab.tsx`, prop `active`) y los badges de `Badge` en Social (recomendaciones) y Perfil (notificaciones). |
+| 3 | `docs/reference/features.md` | Describir el ruteo de `TabShell.tsx` a las 5 pantallas (`HomeScreen`, `SocialScreen`, `SearchScreen`, `ListsScreen`, `ProfileScreen`), tabpanels via `display:none`, `useNavLayout` (bottom/left) y fallback `Suspense` con `React.lazy`. |
+| 4 | `docs/reference/features.md` | Mapear cada seccion previamente bajo "Menu lateral" al tab donde vive hoy, usando la tabla de mapeo de specs (§"Mapeo de ids del registry → tab"). **Preservar todo el detalle funcional**; solo cambiar el contenedor de navegacion. Eliminar/reescribir comportamientos de drawer sin analogo (`SwipeableDrawer`, "borde izquierdo", `swipeAreaWidth=20px`, "footer del SideMenu", "lazy en SideMenu") → su equivalente real (tabs con `React.lazy`/`Suspense`, footer de version en `ProfileScreen`/`SettingsPanel`). |
+| 5 | `docs/reference/features.md` | **OBS DIEGO #2 (R1 ids fragiles):** preservar como **literal** la version humana de `primeros_pasos` ("primeros pasos") y de `estadisticas` ("estadisticas") dentro del bloque reescrito — hoy matchean R1 EXCLUSIVAMENTE en lineas 52 y 69, dentro del bloque que se reescribe. Si la reescritura los parafrasea, R1 suma MISSING nuevos. Verificar con `grep -qiE "\bprimeros pasos\b"` y `grep -qiE "\bestadisticas\b"` antes de cerrar. |
+| 6 | `docs/reference/features.md` | **Cerrar el MISSING preexistente de R1:** incluir el literal `modooscuro` (slug del item de ayuda) en la seccion Ajustes/Apariencia, ademas de la prosa "modo oscuro" (la regla R1 hace `_`→espacio y `modooscuro` no tiene underscore → no matchea "modo oscuro"). Decision adoptada en specs (D1). |
+| 7 | (verificacion) | `grep -qiE "\b(inicio\|buscar\|social\|listas\|perfil)\b"` siguen presentes (labels de tab) — preservados naturalmente por el mapeo por tab. |
+
+### Fase 2: Barrido de las 13 menciones residuales de `SideMenu` (S2) — `features.md`
+
+**OBS DIEGO #1:** las 13 lineas reales con el token `SideMenu` son **50, 56, 59, 94, 103, 133, 134, 150, 151, 155, 182, 323, 392** (la 323 "Seccion Pendientes" no debe omitirse). Ademas las lineas **37 y 50** con la frase "menu lateral" deben dar 0 en `grep -ci`.
+
+| Paso | Linea | Token | Sustitucion (segun tabla de specs §S2) |
+|------|-------|-------|-----------------------------------------|
+| 1 | 50 | `SideMenu` | header → `## Navegacion principal (TabBar + tabs)` (ya hecho en Fase 1 paso 1) |
+| 2 | 37 | `menu lateral` (prosa, **no** token) | "En la lista de comentarios del perfil (tab Perfil), las preguntas muestran badge..." |
+| 3 | 56 | `SideMenu` | "Lazy-loaded. Accesible desde tab Listas (Recientes) y, como historial, tab Perfil" |
+| 4 | 59 | `SideMenu` | "Badge en el tab Social (`TabBar`) con conteo de no leidas" |
+| 5 | 94 | `SideMenu` | "badge del tab Perfil, etc." |
+| 6 | 103 | `SideMenu` | "Badge en el tab Perfil y en SettingsPanel" |
+| 7 | 133 | `SideMenu` | "Seccion Seguidos en el tab Social" |
+| 8 | 134 | `SideMenu` | "Seccion Actividad en el tab Social" |
+| 9 | 150 | `SideMenu` | "seccion Recomendaciones en el tab Social" |
+| 10 | 151 | `SideMenu` | "el tab Social (`TabBar`) muestra badge..." |
+| 11 | 155 | `SideMenu` | "lazy-loaded en el tab Social" |
+| 12 | 182 | `SideMenu` | "Accesible desde link en el footer de ProfileScreen (DEV)" |
+| 13 | 323 | `SideMenu` | "**Seccion Pendientes** (cola de acciones offline): visible solo si hay acciones pendientes; se expone en el tab **Perfil** (`ProfileScreen`)." La cola vive en `src/components/profile/PendingActionsSection.tsx` (tab Perfil), confirmado por Diego — usar ese contenedor. |
+| 14 | 392 | `SideMenu` | "navega al tab Listas (Recientes)", "navega al tab Listas" (SpecialsSection) |
+| 15 | (verificacion) | — | `grep -c "SideMenu" docs/reference/features.md` → **0**; `grep -ci "menu lateral" docs/reference/features.md` → **0**. |
+
+> Nota fuera de scope: `helpGroups.tsx` contiene la frase "menu lateral" en descripciones (`primeros_pasos`, `checkin`). NO se toca el registry (Out of Scope del PRD) y NO afecta R2 (R2 solo lee `features.md`).
+
+### Fase 3: Item `notificaciones` + skeleton loaders (S2b) — `features.md`
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `docs/reference/features.md` | Reforzar en la prosa de "Notificaciones in-app" (linea ~80) que la campana vive en la **barra de busqueda** (tab Buscar), no en ningun menu lateral. El registry ya lo dice — no se toca. |
+| 2 | `docs/reference/features.md` | Agregar mencion de `TabLoader` (`src/components/ui/TabLoader.tsx`) como fallback de `Suspense` al cambiar de tab en `TabShell` (skeleton loaders del mapa/BusinessSheet/CommentsList ya documentados en lineas 15/44/65). |
+
+### Fase 4: Sync de la doc del guard (S3) — `docs/reference/guards/311-help-docs.md`
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `docs/reference/guards/311-help-docs.md` | En "Reglas", documentar `R2-features-sidemenu-drift`: falla si `features.md` menciona `SideMenu`/`Menu lateral` y no existe `src/components/layout/SideMenu.tsx`; la navegacion real es `TabBar` (`BottomNavigation`) orquestada por `TabShell`; referencia #349. |
+| 2 | `docs/reference/guards/311-help-docs.md` | Reemplazar las menciones a `SideMenu` por la estructura de tabs; "secciones del SideMenu" → "secciones agrupadas por tab". |
+| 3 | `docs/reference/guards/311-help-docs.md` | Dejar el ejemplo de mensaje de error consistente con el `desc` real del codigo (`checks.mjs:512-513`). **NO** crear regla nueva ni tocar `checks.mjs` (R2 ya existe en checks.mjs:511-514). |
+
+### Fase 5: Verificacion de cierre (gate de regresion)
+
+**OBS DIEGO #3 — condicion de cierre:** correr la logica COMPLETA de R1 y R2 con el guard runner, no solo verificar los ids tabulados.
+
+| Paso | Comando | Criterio |
+|------|---------|----------|
+| 1 | `node scripts/guards/run.mjs --rule 311/R2-features-sidemenu-drift` (o `npm run guards` filtrando R2) | **0 violaciones** (antes del fix: 1). |
+| 2 | `node scripts/guards/run.mjs --rule 311/R1-helpgroups-coverage` | **0 lineas MISSING** (cierra el preexistente `modooscuro` y no suma nuevos por la reescritura). |
+| 3 | `grep -c "SideMenu" docs/reference/features.md` | **0** |
+| 4 | `grep -ci "menu lateral" docs/reference/features.md` | **0** |
+| 5 | `npm run guards:check` | baseline no sube (no se introducen violaciones nuevas en otras reglas). |
+
+---
+
+## Orden de implementacion
+
+```
+1. Fase 1 paso 1        (rename header — desbloquea S1 y cierra mencion linea 50)
+2. Fase 1 pasos 2-6     (reescritura del bloque por tab + literales R1 fragiles + modooscuro)
+3. Fase 1 paso 7        (verificar tokens de tab presentes)
+4. Fase 2 pasos 1-14    (barrido de las 13 lineas SideMenu + linea 37 "menu lateral")
+5. Fase 2 paso 15       (grep de cierre SideMenu/menu lateral = 0)
+6. Fase 3               (notificaciones + TabLoader)
+7. Fase 4               (sync doc del guard 311)
+8. Fase 5               (guard runner COMPLETO R1+R2 = 0/0 — gate de cierre)
+9. /merge → docs-site-maintainer regenera sidebar/index si aplica
+```
+
+Dependencia clave: Fase 2 depende de Fase 1 (el rename del header y la reescritura tocan lineas que se solapan). Fase 5 requiere Fases 1-4 terminadas. Todo en un solo branch, commits atomicos por fase.
+
+---
+
+## Riesgos
+
+| Riesgo | Mitigacion |
+|--------|-----------|
+| La reescritura del bloque 50-74 parafrasea `primeros pasos` / `estadisticas` y R1 suma MISSING nuevos (OBS Diego #2) | Preservar ambos literales (Fase 1 paso 5) y verificar con grep dedicado + guard runner completo (Fase 5 paso 2) antes de cerrar. |
+| Se omite la linea 323 ("Seccion Pendientes en SideMenu") y R2 queda en 1 (OBS Diego #1) | La tabla de Fase 2 incluye explicitamente la 323 con su sustitucion verificada (`PendingActionsSection.tsx`, tab Perfil). El grep de cierre (paso 15) lo captura. |
+| `modooscuro` sigue MISSING tras el fix | Fase 1 paso 6 incluye el literal `modooscuro`; Fase 5 paso 2 lo valida con el guard runner. |
+| Las lineas se corren al editar y los numeros de specs dejan de coincidir | Editar por contenido (match de string unico), no por numero de linea; re-leer el archivo tras la reescritura grande de Fase 1 antes de Fase 2. |
+| Drift de `SideMenu` en los otros 8 docs | Fuera de scope (R2 solo valida `features.md`). Followup propuesto en specs §"Followup propuesto" — abrir issue aparte, no en este PR. |
+
+## Guardrails de modularidad
+
+- [x] Ningun componente nuevo importa `firebase/*` — N/A (sin codigo)
+- [x] Archivos nuevos en carpeta de dominio correcta — N/A (solo docs existentes)
+- [x] Logica de negocio en hooks/services — N/A
+- [x] Si se toca archivo con deuda, se incluye el fix — el feature ES el fix de deuda doc
+- [x] Ningun archivo de runtime — N/A al limite de 400 LOC
+
+## Guardrails de seguridad
+
+- [x] Colecciones/campos/rules/CF/Storage — N/A (sin codigo de produccion)
+- [x] No hay secrets, admin emails ni credenciales en archivos commiteados — verificado (solo prosa de doc)
+
+## Guardrails de observabilidad
+
+- [x] CF trigger / service / `trackEvent` nuevos — N/A
+- [x] `logger.error` fuera de `import.meta.env.DEV` — N/A
+
+## Guardrails de accesibilidad y UI
+
+- [x] `IconButton`/`Typography onClick`/touch targets/`<img>` onError/`httpsCallable` — N/A (sin UI nueva)
+
+## Guardrails de copy
+
+- [x] Voseo en prosa user-facing-equivalente — aplicar en Fases 1-3
+- [x] Tildes obligatorias (navegacion, busqueda, ubicacion, configuracion) — el guard #309 corre sobre `features.md`
+- [x] Terminologia: "comercios" (no "negocios"), "resenas" (no "reviews") — verificar en la reescritura
+- [x] Strings reutilizables en `src/constants/messages/` — N/A (contenido de doc, no UI)
+
+## Criterios de done
+
+- [ ] `## Navegacion principal (TabBar + tabs)` describe los 5 tabs + `SearchFab` + ruteo `TabShell` (SC#1)
+- [ ] Cada seccion previa de "Menu lateral" mapeada a su tab real, sin perder detalle (SC#2)
+- [ ] Item `notificaciones` aclara campana en barra de busqueda; `TabLoader` documentado (SC#3)
+- [ ] `grep -c "SideMenu" docs/reference/features.md` → 0 (las 13 lineas: 50,56,59,94,103,133,134,150,151,155,182,323,392)
+- [ ] `grep -ci "menu lateral" docs/reference/features.md` → 0 (lineas 37 y 50)
+- [ ] `311-help-docs.md` documenta `R2-features-sidemenu-drift` y refleja tabs (SC#4)
+- [ ] Literales `primeros pasos` y `estadisticas` preservados; `modooscuro` incluido (OBS Diego #2 + cierre preexistente)
+- [ ] Guard runner COMPLETO: R1 = 0 MISSING **y** R2 = 0 violaciones (OBS Diego #3, gate de cierre)
+- [ ] `npm run guards:check` no sube baseline
+- [ ] No se toco `src/`, rules, Firestore, CF ni `scripts/guards/checks.mjs`
+
+---
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Ciclo:** 1
+
+**Observaciones para el implementador:**
+
+1. **Sellos previos OK.** PRD VALIDADO CON OBSERVACIONES por Sofia (prd.md:269-275); specs VALIDADO CON OBSERVACIONES por Diego (specs.md:274-280). Habilitado a revisar plan.
+
+2. **Cobertura specs->plan completa y verificada contra el repo.** Las 13 lineas con token `SideMenu` (50,56,59,94,103,133,134,150,151,155,182,323,392) y las 2 lineas "menu lateral" (37,50) coinciden exactamente con `grep` real. `PendingActionsSection.tsx` (tab Perfil) y `TabLoader.tsx` existen. R1 (checks.mjs:504) y R2 (checks.mjs:511) existen. Literales fragiles confirmados: "primeros pasos" (linea 52) y "estadisticas" (linea 69) viven DENTRO del bloque 50-74 que se reescribe; "modooscuro" NO existe hoy (MISSING preexistente real). Las 3 OBS de Diego tienen mitigacion agendada en la tabla de Riesgos.
+
+3. **Ordering y granularidad correctos.** Owner unico (`documentation`), sin paralelismo -> cero riesgo de overlap de ownership. Fase 1 (reescritura) antes de Fase 2 (barrido); Fase 5 (gate) despues de 1-4. Commits atomicos por fase. Rollback trivial (revert de commit de doc, reversible, sin migracion de datos).
+
+4. **IMPORTANTE (no bloqueante): linea 50 editada en dos tablas.** Fase 1 paso 1 renombra el header y Fase 2 paso 1 la lista como "ya hecho". El orden es correcto, pero tras la reescritura grande de Fase 1 los numeros de linea corren. Editar SIEMPRE por contenido (match de string unico), no por numero de linea, y re-leer `features.md` antes de empezar Fase 2. El plan ya lo contempla (Riesgos, linea 119) — solo reforzarlo en ejecucion.
+
+5. **OBSERVACION — gate Fase 5 paso 5 (`guards:check`): el problema es que el baseline BAJA, no que sube.** `check-baseline.mjs` (lineas 11-12) falla en AMBOS sentidos: si una regla sube (regresion) Y si una regla baja (exige `--update` con justificacion). El fix de #349 reduce R1 (1->0) y R2 (1->0), por lo que `npm run guards:check` va a FALLAR con "rule REDUCED" hasta que se corra `npm run guards:baseline` para registrar los nuevos counts 0/0. El criterio del plan ("baseline no sube") es incompleto: agregar paso explicito de actualizar el baseline tras cerrar R1/R2 (o documentarlo como parte del gate de cierre). Esto lo va a frenar en el push si no esta previsto.
+
+**Listo para pasar a implementacion:** Si, con las observaciones 4 y 5. Ningun bloqueante. No se abre ciclo con specs-plan-writer.

--- a/docs/feat/content/help-docs-tabbar-source-of-truth/prd.md
+++ b/docs/feat/content/help-docs-tabbar-source-of-truth/prd.md
@@ -1,0 +1,275 @@
+# PRD: Tech debt — features.md describe un SideMenu inexistente; alinear la fuente de verdad con la navegacion real (TabBar)
+
+**Feature:** help-docs-tabbar-source-of-truth
+**Categoria:** content
+**Fecha:** 2026-06-09
+**Issue:** #349
+**Prioridad:** Media (severidad MEDIUM en /health-check)
+
+---
+
+## Contexto
+
+`docs/reference/features.md` (lineas 50-74) describe toda la navegacion principal de la app como un **"Menu lateral (SideMenu)"** con secciones lazy-loaded, pero el codigo real implementa una **BottomNavigation de 5 tabs** (`src/components/layout/TabBar.tsx`: Inicio / Social / Buscar / Listas / Perfil) mas un `SearchFab` central, orquestada por `TabShell.tsx` que rutea a `HomeScreen`, `SocialScreen`, `SearchScreen`, `ListsScreen` y `ProfileScreen`. No existe ningun archivo `SideMenu.tsx` en `src/`. El registry `helpGroups.tsx` / `HelpSection.tsx` ya esta alineado a la estructura de tabs (ids `inicio`, `social`, `buscar`, `listas`, `perfil`, etc.), por lo que es `features.md` — la fuente de verdad declarada por el guard #311 — el que quedo desincronizado (drift).
+
+## Problema
+
+- `features.md` describe un componente `SideMenu` que no existe en el codigo; un lector (humano o agente) que tome ese doc como fuente de verdad razonara sobre una arquitectura de navegacion equivocada (drawer lateral vs bottom tabs).
+- El guard #311 declara `features.md` como la fuente de verdad contra la que se valida la Ayuda in-app. Si la fuente de verdad esta drifteada, el guard `R1-helpgroups-coverage` valida contra texto incorrecto y pierde su valor contractual: un item del registry podria "matchear" una seccion mal descrita.
+- Gaps menores de documentacion en la Ayuda: la campana de notificaciones vive en la barra de busqueda (no en un menu), el item `notificaciones` no lo aclara; y los skeleton loaders / estados de carga no estan documentados.
+
+## Solucion
+
+Esta es una tarea de **documentacion y guard**, sin cambios en codigo de produccion. El trabajo se concentra en reescribir la seccion de navegacion de `features.md` para reflejar la realidad (`TabBar` + `TabShell`), barrer el resto de menciones a `SideMenu` en la doc, y endurecer el guard #311 para que detecte este tipo de drift en el futuro.
+
+### S1 — Reescribir la seccion de navegacion en `features.md`
+
+- Renombrar el header `## Menu lateral (SideMenu)` (linea 50) a algo como `## Navegacion principal (TabBar + tabs)`.
+- Describir la `BottomNavigation` de 5 tabs (Inicio / Social / Buscar / Listas / Perfil) con su `SearchFab` central, segun `src/components/layout/TabBar.tsx`, y el ruteo de `TabShell.tsx` a las 5 pantallas (`HomeScreen`, `SocialScreen`, `SearchScreen`, `ListsScreen`, `ProfileScreen`).
+- Mapear cada seccion que hoy esta listada bajo "Menu lateral" (Mis visitas, Seguidos, Actividad, Recomendaciones, Recientes, Sugeridos, Sorprendeme, Mis Listas, Favoritos, Comentarios, Calificaciones, Rankings, Feedback, Estadisticas, Configuracion, Ayuda) al **tab donde vive hoy**. Usar el agrupamiento por tab que ya define `helpGroups.tsx` como referencia de mapeo (Inicio / Buscar / Social / Listas / Perfil / Ajustes).
+- Preservar todo el detalle funcional existente de cada seccion (no borrar contenido util); solo corregir el contenedor de navegacion y la ubicacion.
+- Reescribir las menciones a comportamiento de drawer que ya no aplican (`SwipeableDrawer`, abrir desde el borde izquierdo, swipeAreaWidth, footer del SideMenu) por su equivalente real o eliminarlas si no tienen analogo en la UI de tabs.
+
+### S2 — Barrer menciones residuales de `SideMenu` en `features.md`
+
+Corregir las 13 menciones detectadas (referencias como `SideMenuNav`, "badge SideMenu", "lazy-loaded en SideMenu", "footer del SideMenu", "seccion X en SideMenu"). Para cada una, sustituir por el contenedor real (tab Perfil, tab Social, tab Listas, barra de busqueda, etc.). Verificar tambien que `SpecialsSection` (linea ~392) no describa navegacion "abre la seccion X en SideMenu" — debe apuntar al tab real.
+
+> Nota de scope: otros docs de referencia (`architecture.md`, `coding-standards.md`, `files.md`, `patterns.md`, `issues.md`, `file-size-directive.md`, `perf-audit-recommendations.md`, `project-reference.md`) tambien mencionan `SideMenu`. Ver "Out of Scope" y la decision de producto pendiente.
+
+### S3 — Alinear la doc del guard #311
+
+- El check automatizado anti-drift **ya existe**: `scripts/guards/checks.mjs` define la regla `R2-features-sidemenu-drift` (grupo `311 help-docs`) que falla si `features.md` menciona `SideMenu`/`Menu lateral` y no existe `src/components/layout/SideMenu.tsx`. La regla referencia explicitamente #349. **Hoy esta regla esta fallando** porque `features.md` aun tiene el drift; corregir el doc (S1/S2) la pone en verde. No hay que escribir el check, solo satisfacerlo.
+- Actualizar la **doc** del guard `docs/reference/guards/311-help-docs.md` para: (a) documentar la regla `R2-features-sidemenu-drift` en la seccion "Reglas" (hoy solo describe la cobertura 1:1 contra SideMenu); (b) reemplazar las referencias a `SideMenu` por la estructura de tabs (`TabBar`/`TabShell`) en el texto del guard. El check de codigo y su doc deben quedar consistentes.
+
+> Verificacion (2026-06-09): `R2-features-sidemenu-drift` existe en `scripts/guards/checks.mjs` (linea ~511). El check S3b que un primer draft de este PRD proponia crear ya esta implementado — el trabajo de S3 es satisfacerlo y documentarlo, no crearlo.
+
+### Consideraciones UX
+
+Ninguna. No hay cambios de UI; la navegacion real (TabBar) ya esta en produccion. El unico "consumidor" del cambio es la documentacion y los agentes/lectores que la usan como fuente de verdad.
+
+### Consideraciones de seguridad
+
+Ninguna superficie de ataque nueva. No se tocan rules, callables, Firestore ni inputs de usuario. Ver seccion Seguridad.
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| S1 — Reescribir seccion de navegacion en `features.md` (header + mapeo por tab) | Alta | M |
+| S2 — Barrer 13 menciones residuales de `SideMenu` en `features.md` | Alta | S |
+| S2b — Aclarar item `notificaciones` (campana en barra de busqueda) + documentar skeleton loaders | Baja | S |
+| S3 — Actualizar doc del guard `311-help-docs.md` (documentar `R2-features-sidemenu-drift` + estructura de tabs) | Media | S |
+
+**Esfuerzo total estimado:** M
+
+> El check de codigo anti-drift (`R2-features-sidemenu-drift`) ya existe en `scripts/guards/checks.mjs`; no es un item de scope. El trabajo de docs (S1/S2) lo pone en verde.
+
+---
+
+## Out of Scope
+
+- Cambios en codigo de produccion (`src/`), componentes, hooks o servicios — la navegacion real ya es correcta.
+- Reescribir las menciones a `SideMenu` en los **otros** docs de referencia (`architecture.md`, `coding-standards.md`, `files.md`, etc.). Decision de producto: ver "Deuda tecnica". Por defecto este PRD solo cubre `features.md` (la fuente de verdad del guard #311) + el guard mismo.
+- Cambios en `helpGroups.tsx` / `HelpSection.tsx`: el registry ya esta alineado a tabs; solo se ajusta si el barrido revela un item que aun describe drawer.
+- Renombrar el directorio `src/components/profile/` o reorganizar componentes por tab.
+
+---
+
+## Tests
+
+Esta es una tarea de documentacion + guard. No agrega codigo de produccion con logica condicional, por lo que la politica de cobertura >=80% no aplica a codigo nuevo de runtime. El testing relevante es la verificacion del guard.
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `scripts/guards/checks.mjs` | Guard script (ya existe `R2-features-sidemenu-drift`) | Correr el guard y confirmar que `R2-features-sidemenu-drift` pasa (verde) tras el fix de docs; antes del fix debe estar fallando |
+| `docs/reference/features.md` | Doc (no testeable por unit) | Verificacion: 0 ocurrencias de `SideMenu`/`Menu lateral`; cada id de `helpGroups.tsx` matchea un header/seccion de tab |
+
+### Criterios de testing
+
+- El check `R2-features-sidemenu-drift` (ya existente en `scripts/guards/checks.mjs`) pasa tras el fix: `grep -qiE "SideMenu|Menu lateral" docs/reference/features.md` no debe encontrar nada que dispare la regla.
+- Verificacion CI-friendly: `grep -c "SideMenu" docs/reference/features.md` debe dar `0` tras el fix.
+- El check `R1-helpgroups-coverage` existente debe seguir pasando contra el `features.md` reescrito (cada id del registry encuentra su mencion — slug literal o version humana con `_` -> espacio).
+- No aplica cobertura >=80% (no hay codigo de runtime nuevo). No se agregan tests unitarios nuevos: el guard ya esta cubierto por su propio mecanismo de ejecucion en el guard runner.
+
+---
+
+## Seguridad
+
+Esta feature no escribe ni lee Firestore, no agrega endpoints, no toca rules ni Storage, no procesa input de usuario. No hay superficie de ataque nueva.
+
+- [x] Sin secretos en codigo: el PRD y los docs no exponen credenciales, infra interna ni emails.
+- [x] PR description profesional, sin detalles de infraestructura interna.
+- [x] No se agregan colecciones, callables ni inputs de usuario.
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| Ninguna nueva | N/A — cambio de documentacion + guard | N/A |
+
+No aplica: el feature no escribe a Firestore, no agrega campos a `userSettings`, no lee datos de usuario ni expone superficie para scraping.
+
+---
+
+## Deuda tecnica y seguridad
+
+```bash
+gh issue list --label security --state open --json number,title   # -> [] (sin issues abiertos)
+gh issue list --label "tech debt" --state open --json number,title # -> [] (sin issues abiertos)
+```
+
+No hay issues abiertos con label `security` ni `tech debt` al momento de redactar (2026-06-09). El propio #349 es un item de deuda tecnica de documentacion.
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| #311 (guard help-docs / fuente de verdad) | afecta | El guard valida la Ayuda contra `features.md`; corregir la fuente de verdad y endurecer el guard como parte de este feature |
+| #328 (helpGroups coverage, +7 tests) | contexto | El registry ya esta alineado a tabs; sirve como referencia de mapeo seccion->tab |
+| #309 (guard voseo) | no agravar | Cualquier texto reescrito en `features.md` mantiene voseo rioplatense consistente |
+
+### Mitigacion incorporada
+
+- **Cerrar el loop del drift detectado por /health-check**: el guard `R2-features-sidemenu-drift` (ya implementado en `scripts/guards/checks.mjs`, referencia #349) detecta automaticamente este tipo de drift. Hoy esta en rojo; corregir `features.md` (S1/S2) lo pone en verde y cierra el loop. S3 sincroniza la doc del guard con el check de codigo.
+- **No empeorar el drift en otros docs**: este PRD documenta explicitamente que otros docs aun mencionan `SideMenu` y deja la decision de barrerlos como item de producto, en vez de fixearlos a medias.
+
+---
+
+## Robustez del codigo
+
+No se agregan hooks ni componentes async. Si S3b agrega un check al guard script:
+
+### Checklist de hooks async
+
+- [x] N/A — no hay `useEffect`, handlers async ni `setState`.
+- [x] El check del guard (si se agrega) es sincrono (lectura de archivo + grep), sin side effects.
+- [x] No se agregan archivos en `src/hooks/` ni constantes de localStorage.
+- [x] `features.md` y el guard no superan limites de lineas de codigo (son docs).
+
+### Checklist de observabilidad
+
+- [x] N/A — no hay Cloud Function trigger, service con queries ni `trackEvent` nuevo.
+
+### Checklist offline
+
+- [x] N/A — no hay formularios ni writes a Firestore.
+
+### Checklist de documentacion
+
+- [x] No hay nuevas secciones de HomeScreen (no se toca `homeSections.ts`).
+- [x] No hay analytics events nuevos.
+- [x] No hay tipos nuevos.
+- [x] `docs/reference/features.md` se actualiza (es el objetivo central del feature).
+- [ ] `docs/reference/firestore.md`: N/A — no hay colecciones/campos nuevos.
+- [ ] `docs/reference/patterns.md`: evaluar si conviene barrer su mencion a `SideMenu` (ver Out of Scope / decision de producto).
+- [x] `docs/reference/guards/311-help-docs.md` se actualiza a la estructura de tabs.
+
+---
+
+## Offline
+
+No aplica. El feature no introduce data flows: no lee ni escribe Firestore, no llama APIs externas, no agrega UI.
+
+### Data flows
+
+| Operacion | Tipo (read/write) | Estrategia offline | Fallback UI |
+|-----------|-------------------|-------------------|-------------|
+| Ninguna | N/A | N/A | N/A |
+
+### Checklist offline
+
+- [x] Reads de Firestore: N/A — ninguno.
+- [x] Writes: N/A — ninguno.
+- [x] APIs externas: N/A — ninguna.
+- [x] UI: N/A — no hay UI nueva.
+- [x] Datos criticos: N/A.
+
+### Esfuerzo offline adicional: S (nulo)
+
+---
+
+## Modularizacion y % monolitico
+
+No se toca codigo de UI, layout ni estado global. El feature no puede aumentar el % monolitico porque no agrega imports, contextos ni componentes.
+
+### Checklist modularizacion
+
+- [x] No se agrega logica de negocio (solo docs + guard script).
+- [x] No se agregan componentes.
+- [x] No se agregan `useState` a AppShell/SideMenu (SideMenu ni existe).
+- [x] No hay props ni dependencias a contextos de layout.
+- [x] No hay handlers de accion (no hay UI).
+- [x] Ningun archivo nuevo importa de `firebase/firestore`, `firebase/functions` ni `firebase/storage`.
+- [x] No se agregan archivos en `src/hooks/`.
+- [x] Ningun archivo nuevo de codigo (el guard check ya existe en `scripts/guards/checks.mjs`).
+- [x] No se agregan converters.
+- [x] No se agregan archivos en `components/menu/` (no existe).
+- [x] No se necesita estado global nuevo.
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | = | No se tocan componentes |
+| Estado global | = | No se toca estado |
+| Firebase coupling | = | No se toca Firebase |
+| Organizacion por dominio | = | Solo docs + guard; sin cambios en `src/` |
+
+---
+
+## Accesibilidad y UI mobile
+
+No se agregan componentes interactivos ni UI. La navegacion real (TabBar) ya esta en produccion y fuera de scope.
+
+### Checklist de accesibilidad
+
+- [x] N/A — no hay `IconButton`, elementos clickables, touch targets, imagenes ni formularios nuevos.
+
+### Checklist de copy
+
+- [x] Todos los textos reescritos en `features.md` en espanol con tildes correctas.
+- [x] Tono consistente: voseo donde corresponda (alineado con guard #309).
+- [x] Terminologia: "comercios" (no "negocios"), "resenas" (no "reviews").
+- [ ] Strings reutilizables centralizados: N/A — son textos de documentacion, no UI.
+- [x] Mensajes de error del guard (si se agrega check) accionables: ej "features.md menciona SideMenu (componente inexistente); usar TabBar/tabs".
+
+---
+
+## Success Criteria
+
+1. `grep -c "SideMenu" docs/reference/features.md` devuelve `0`; la seccion de navegacion describe la `BottomNavigation` de 5 tabs (Inicio/Social/Buscar/Listas/Perfil) + `SearchFab` segun `TabBar.tsx`/`TabShell.tsx`.
+2. Cada seccion previamente listada bajo "Menu lateral" queda mapeada al tab real donde vive hoy, sin perder detalle funcional, usando el agrupamiento de `helpGroups.tsx` como referencia.
+3. El item `notificaciones` aclara que la campana vive en la barra de busqueda; los skeleton loaders quedan documentados como minimo a nivel de mencion.
+4. El guard `R2-features-sidemenu-drift` (ya existente en `scripts/guards/checks.mjs`) pasa (verde) tras el fix; `docs/reference/guards/311-help-docs.md` documenta esa regla y refleja la estructura de tabs.
+5. El check `R1-helpgroups-coverage` existente sigue pasando contra el `features.md` reescrito (cada id del registry encuentra su mencion).
+
+---
+
+## Validacion Funcional
+
+**Analista**: Sofia
+**Fecha**: 2026-06-10
+**Estado**: VALIDADO CON OBSERVACIONES
+
+### Hallazgos cerrados en esta iteracion
+
+- IMPORTANTE: "El PRD proponia crear un check anti-drift (S3b) que ya existe" → resuelto: se verifico que `R2-features-sidemenu-drift` ya esta implementado en `scripts/guards/checks.mjs` (linea ~511, referencia #349). Se reescribio S3 para satisfacer/documentar el check existente en vez de crearlo, y se ajustaron Scope, Tests, Deuda tecnica y Success Criteria en consecuencia.
+- IMPORTANTE: "Count de menciones de SideMenu incorrecto (14 vs 13)" → corregido en S2 y Scope tras verificar con `grep -c`.
+- OBSERVACION: "La mayoria de las categorias de edge-case (auth, offline, billing, privacy, multi-tab, race conditions, mobile UI) son N/A" → justificado: el feature no introduce codigo de runtime, solo documentacion + sincronizacion de doc de guard. Las secciones lo marcan N/A correctamente.
+
+### Observaciones abiertas para el implementador
+
+- Decision de producto (Gonzalo): el "Out of Scope" deja explicitamente afuera el barrido de menciones a `SideMenu` en los otros 8 docs de referencia (`architecture.md`, `coding-standards.md`, `files.md`, `patterns.md`, `issues.md`, `file-size-directive.md`, `perf-audit-recommendations.md`, `project-reference.md`). Riesgo bajo: el guard `R2-features-sidemenu-drift` solo valida `features.md`, asi que el otro drift no rompe CI, pero sigue siendo desinformacion para lectores/agentes. Evaluar al armar el plan si se abre un issue de followup o se incluye en este scope.
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** R1-helpgroups-coverage YA falla hoy por el id 'modooscuro' — reformular SC#5 a 'R1 no suma nuevos MISSING' o incluir el literal en features.md. Path real: src/components/profile/helpGroups.tsx. Asegurar que inicio/buscar/social/listas/perfil sigan como texto literal.

--- a/docs/feat/content/help-docs-tabbar-source-of-truth/specs.md
+++ b/docs/feat/content/help-docs-tabbar-source-of-truth/specs.md
@@ -1,0 +1,280 @@
+# Specs: features.md describe un SideMenu inexistente; alinear la fuente de verdad con la navegacion real (TabBar)
+
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-10
+**Issue:** #349
+
+---
+
+## Naturaleza del feature
+
+Tarea de **documentacion + sincronizacion de doc de guard**. No hay codigo de produccion nuevo: no se tocan `src/` (runtime), rules, Firestore, Cloud Functions, Storage ni inputs de usuario. Por lo tanto, las secciones de modelo de datos, rules, functions, seed, componentes, hooks, servicios, offline, analytics y seguridad estan marcadas N/A con su justificacion.
+
+El trabajo concreto es:
+
+1. **S1** — Reescribir la seccion `## Menu lateral (SideMenu)` de `docs/reference/features.md` (lineas 50-74) como `## Navegacion principal (TabBar + tabs)`, describiendo la `BottomNavigation` de 5 tabs y mapeando cada seccion al tab real.
+2. **S2** — Barrer las 13 menciones residuales de `SideMenu` en `docs/reference/features.md` (verificado con `grep -c "SideMenu"` → 13).
+3. **S2b** — Aclarar el item `notificaciones` (campana en barra de busqueda) y documentar skeleton loaders.
+4. **S3** — Actualizar `docs/reference/guards/311-help-docs.md` para documentar la regla `R2-features-sidemenu-drift` (ya implementada en codigo) y reemplazar las referencias a `SideMenu` por la estructura de tabs.
+
+---
+
+## Modelo de datos
+
+N/A — no se agregan ni modifican colecciones, campos ni tipos. No se toca `src/types/`.
+
+## Firestore Rules
+
+N/A — no se modifican rules. El feature no escribe ni lee Firestore.
+
+### Rules impact analysis
+
+N/A — sin queries nuevas.
+
+### Field whitelist check
+
+N/A — sin campos nuevos.
+
+## Cloud Functions
+
+N/A — sin triggers, scheduled ni callables nuevos.
+
+## Seed Data
+
+N/A — no se crean colecciones ni campos requeridos. No se toca `scripts/seed-admin-data.*` ni `scripts/seed-staging.ts`.
+
+## Componentes
+
+N/A — no se crean ni modifican componentes React. `helpGroups.tsx` y `HelpSection.tsx` quedan **sin cambios** (el registry ya esta alineado a tabs; el barrido de S2 solo toca `features.md`).
+
+### Mutable prop audit
+
+N/A — sin componentes editables nuevos.
+
+## Textos de usuario
+
+N/A para UI. Los unicos textos que se escriben son **contenido de documentacion** en `features.md` y `311-help-docs.md`, no strings user-facing. Aplican igual las reglas de copy (voseo, tildes) por el guard #309.
+
+## Hooks
+
+N/A — sin hooks nuevos ni modificados.
+
+## Servicios
+
+N/A — sin servicios nuevos ni modificados.
+
+---
+
+## Trabajo de documentacion (el core del feature)
+
+### Estado verificado de los guards (2026-06-10)
+
+Ejecucion manual de la logica de ambas reglas contra el repo actual:
+
+| Regla | Estado HOY | Causa | Estado objetivo post-fix |
+|-------|-----------|-------|--------------------------|
+| `R1-helpgroups-coverage` (checks.mjs:504) | **ROJO — 1 MISSING** | El id `modooscuro` no matchea: la regla hace `_`→espacio, pero `modooscuro` no tiene underscore (`human === id === "modooscuro"`), y en `features.md` solo existe "modo oscuro" **con espacio** (linea 70). `grep -qiE "\b(modooscuro)\b"` no encuentra nada. **Fallo PREEXISTENTE, independiente de #349.** | Cerrar el MISSING incluyendo el literal `modooscuro` en el `features.md` reescrito (ver S1) → R1 verde. |
+| `R2-features-sidemenu-drift` (checks.mjs:511) | **ROJO — 1 violacion** | `features.md` menciona `SideMenu`/`Menu lateral` (13 hits) y no existe `src/components/layout/SideMenu.tsx`. | S1+S2 dejan 0 menciones de `SideMenu`/`Menu lateral` → R2 verde. |
+
+> **Como cuenta violaciones el runner** (`scripts/guards/run.mjs:44-46`): toda linea de stdout no vacia cuenta como una violacion (`lines.length`). Por eso R1 emite una linea `MISSING in features.md: <id> ...` por cada id no cubierto, y cada una suma. Hoy R1 emite exactamente 1 linea (`modooscuro`).
+
+### Mapeo de ids del registry → tab (referencia para S1)
+
+`ALL_TAB_IDS = ['inicio', 'social', 'buscar', 'listas', 'perfil']` (`src/types/navigation.ts:3`). `TabShell.tsx` rutea cada tab a su Screen (`HomeScreen`, `SocialScreen`, `SearchScreen`, `ListsScreen`, `ProfileScreen`). El registro `HELP_GROUPS` (`src/components/profile/helpGroups.tsx`) ya agrupa por tab. La seccion reescrita de `features.md` debe seguir este agrupamiento:
+
+| Grupo HELP_GROUPS | ids del registry | Tab real / ubicacion |
+|-------------------|------------------|----------------------|
+| Inicio | `inicio`, `sorprendeme`, `tus_intereses_home`, `primeros_pasos` | tab **Inicio** → `HomeScreen` |
+| Buscar | `buscar`, `comercio`, `checkin`, `confirmacion_salir`, `offline` | tab **Buscar** → `SearchScreen` |
+| Social | `social`, `rankings`, `perfil_publico`, `recomendaciones` | tab **Social** → `SocialScreen` |
+| Listas | `listas`, `colaborativas` | tab **Listas** → `ListsScreen` |
+| Perfil | `perfil`, `tus_intereses_perfil`, `estadisticas`, `logros`, `notificaciones` | tab **Perfil** → `ProfileScreen` |
+| Ajustes | `cuenta`, `onboarding`, `configuracion`, `modooscuro`, `feedback` | dentro de **Perfil** → `SettingsPanel` / `HelpSection` |
+
+### S1 — Reescritura de la seccion de navegacion (`features.md` lineas 50-74)
+
+- Renombrar el header `## Menu lateral (SideMenu)` → `## Navegacion principal (TabBar + tabs)`.
+- Describir la `BottomNavigation` de 5 tabs segun `src/components/layout/TabBar.tsx`: **Inicio / Social / Buscar / Listas / Perfil**, con el `SearchFab` central elevado (`src/components/layout/SearchFab.tsx`, prop `active`). Mencionar los badges de `Badge` en Social (recomendaciones) y Perfil (notificaciones).
+- Describir el ruteo de `TabShell.tsx` a las 5 pantallas (`HomeScreen`, `SocialScreen`, `SearchScreen`, `ListsScreen`, `ProfileScreen`) con tabpanels via `display: none` y `useNavLayout` (posicion bottom/left).
+- Mapear cada seccion previamente bajo "Menu lateral" al tab donde vive hoy, usando la tabla de mapeo de arriba. **Preservar todo el detalle funcional** de cada seccion; solo cambiar el contenedor de navegacion.
+- Eliminar/reescribir las menciones de comportamiento de drawer sin analogo: `SwipeableDrawer`, "abrir desde el borde izquierdo", `swipeAreaWidth=20px`, "footer del SideMenu", "lazy-loaded en SideMenu" → su equivalente real (tabs con `React.lazy`/`Suspense` en `TabShell`, footer de version en `ProfileScreen`/`SettingsPanel`).
+
+**Constraints de cobertura R1 dentro de S1 (criticos):**
+
+- **Preservar como texto LITERAL** los tokens `inicio`, `buscar`, `social`, `listas`, `perfil` (hoy todos matchean R1; ver tabla en "Verificacion R1" mas abajo). El rename del header a "Navegacion principal (TabBar + tabs)" + el mapeo por tab los preserva naturalmente (los labels de tab son "Inicio/Social/Buscar/Listas/Perfil"), pero hay que verificarlo explicitamente con grep antes de cerrar.
+- **Incluir el literal `modooscuro`** en algun punto del `features.md` reescrito para cerrar el MISSING preexistente de R1. Recomendacion: en la seccion Ajustes/Apariencia, agregar referencia al id del topic, p.ej. una linea que mencione el slug del item de ayuda `modooscuro` (ademas de la prosa "modo oscuro"). Alternativa formalmente equivalente: dejar el MISSING de `modooscuro` como **preexistente fuera de scope** y reformular SC#5 (ver Success Criteria). Decision adoptada en este specs: **cerrar el MISSING** incluyendo el literal, porque el costo es una sola linea y deja R1 totalmente verde.
+
+### S2 — Barrido de las 13 menciones residuales de `SideMenu`
+
+Hay dos conjuntos de menciones a barrer, con tokens distintos (verificado con `grep -in`, 2026-06-12):
+
+- **Token `SideMenu`** (13 lineas): **50, 56, 59, 94, 103, 133, 134, 150, 151, 155, 182, 323, 392**. Estas son las que cuentan para R2 (que matchea el string `SideMenu`). **Todas deben quedar en 0** para `grep -c "SideMenu"`.
+- **Frase `menu lateral`** en prosa, sin el token `SideMenu` (2 lineas, case-insensitive): **37 y 50** (la 50 ya esta cubierta por el rename del header en S1). La 37 es prosa ("En el menu lateral, las preguntas...") y NO contiene el token `SideMenu`; se corrige para que `grep -ci "menu lateral"` → 0 (SC#1), pero **no** es una mencion del token `SideMenu`.
+
+Sustituciones:
+
+| Linea | Token | Mencion actual | Sustitucion |
+|-------|-------|----------------|-------------|
+| 37 | `menu lateral` (prosa, **no** `SideMenu`) | "En el menu lateral, las preguntas muestran badge..." | "En la lista de comentarios del perfil (tab Perfil), las preguntas muestran badge..." |
+| 50 | `SideMenu` | `## Menu lateral (SideMenu)` (header) | `## Navegacion principal (TabBar + tabs)` (S1) |
+| 56 | `SideMenu` | "Lazy-loaded en SideMenu" (Mis visitas) | "Lazy-loaded. Accesible desde tab Listas (Recientes) y, como historial, tab Perfil" — segun ubicacion real de check-ins |
+| 59 | `SideMenu` | "Badge en SideMenuNav con conteo de no leidas" | "Badge en el tab Social (`TabBar`) con conteo de no leidas" |
+| 94 | `SideMenu` | "badge SideMenu, etc." | "badge del tab Perfil, etc." |
+| 103 | `SideMenu` | "Badge en SideMenu y SettingsPanel" | "Badge en el tab Perfil y en SettingsPanel" |
+| 133 | `SideMenu` | "Seccion Seguidos en SideMenu" | "Seccion Seguidos en el tab Social" |
+| 134 | `SideMenu` | "Seccion Actividad en SideMenu" | "Seccion Actividad en el tab Social" |
+| 150 | `SideMenu` | "seccion Recomendaciones en SideMenu" | "seccion Recomendaciones en el tab Social" |
+| 151 | `SideMenu` | "`SideMenuNav` muestra badge..." | "el tab Social (`TabBar`) muestra badge..." |
+| 155 | `SideMenu` | "lazy-loaded en SideMenu" | "lazy-loaded en el tab Social" |
+| 182 | `SideMenu` | "Accesible desde link en footer del SideMenu" | "Accesible desde link en el footer de ProfileScreen (DEV)" |
+| 323 | `SideMenu` | "**Seccion Pendientes en SideMenu**: visible solo si hay acciones pendientes..." | "**Seccion Pendientes** (cola de acciones offline): visible solo si hay acciones pendientes; hoy se expone en el tab **Perfil** (`ProfileScreen`). **VERIFICAR con el componente real** la ubicacion exacta de la cola de pendientes antes de cerrar (puede vivir en `ProfileScreen` o en un panel de sincronizacion); reemplazar el token `SideMenu` por el contenedor real que se confirme." |
+| 392 | `SideMenu` | "abre la seccion Recientes en SideMenu", "abre la seccion Listas en SideMenu" (SpecialsSection) | "navega al tab Listas (Recientes)", "navega al tab Listas" |
+
+> Verificacion de cierre de S2: `grep -c "SideMenu" docs/reference/features.md` debe dar `0` (las 13 lineas con el token: 50, 56, 59, 94, 103, 133, 134, 150, 151, 155, 182, 323, 392) y `grep -ci "menu lateral" docs/reference/features.md` debe dar `0` (lineas 37 y 50). Cuidado adicional: el registry `helpGroups.tsx` contiene la frase "menu lateral" en descripciones (`primeros_pasos`, `checkin`) — **eso esta fuera de scope** (no se toca el registry, ver Out of Scope del PRD) y NO afecta R2 (R2 solo lee `features.md`).
+
+### S2b — Item `notificaciones` y skeleton loaders
+
+- En la prosa de notificaciones (seccion "Notificaciones in-app", ya correcta en linea 80: "Campana con badge ... en la barra de busqueda"), reforzar que la campana **no** vive en ningun menu lateral sino en la barra de busqueda del tab Buscar. El registry ya lo dice ("Tocá la campana o andá a Perfil > Notificaciones") — no se toca el registry.
+- Documentar skeleton loaders al menos a nivel de mencion: el mapa ya lo documenta (linea 15), el BusinessSheet (linea 44) y CommentsList (linea 65). Agregar mencion de `TabLoader` (`src/components/ui/TabLoader.tsx`) como fallback de `Suspense` al cambiar de tab en `TabShell`.
+
+### S3 — Actualizar `docs/reference/guards/311-help-docs.md`
+
+- En la seccion "Reglas", agregar la regla `R2-features-sidemenu-drift` documentando: que falla si `features.md` menciona `SideMenu`/`Menu lateral` y no existe `src/components/layout/SideMenu.tsx`; que la navegacion real es `TabBar` (`BottomNavigation`) orquestada por `TabShell`; referencia #349.
+- Reemplazar en el texto del guard las menciones a `SideMenu` por la estructura de tabs. En particular el bloque "Reglas → 1. Cobertura 1:1" ("debe reflejar toda seccion listada en features.md") esta OK, pero cualquier texto que asuma "secciones del SideMenu" debe pasar a "secciones agrupadas por tab".
+- Dejar consistente el ejemplo de mensaje de error del guard con el `desc` real del codigo (`checks.mjs:512`).
+
+> **Nota sobre el otro guard mencionado por Sofia (R2-features-sidemenu-drift ya existe):** el fix es doc-fix (`features.md`) + sync de la doc del guard (`311-help-docs.md`). **NO** se crea ninguna regla nueva ni se toca `scripts/guards/checks.mjs`. El check ya esta implementado (checks.mjs:511-514).
+
+### Verificacion R1 post-reescritura (ids que deben seguir matcheando)
+
+Todos los ids de `HELP_GROUPS` deben encontrar mencion en `features.md` reescrito. Estado actual verificado por id (los 5 tab tokens, el preexistente y los ids FRAGILES que matchean solo dentro del bloque reescrito):
+
+| id | Match HOY | Donde matchea | Accion en el fix |
+|----|-----------|---------------|------------------|
+| `inicio` | SI | label de tab | preservar literal (label de tab) |
+| `buscar` | SI | label de tab | preservar literal (label de tab) |
+| `social` | SI | label de tab | preservar literal (label de tab) |
+| `listas` | SI | label de tab | preservar literal (label de tab) |
+| `perfil` | SI | label de tab | preservar literal (label de tab) |
+| `modooscuro` | **NO (preexistente)** | — | incluir literal `modooscuro` → cerrar MISSING |
+| `primeros_pasos` | SI | **FRAGIL — solo linea 52, dentro del bloque 50-74 que S1 reescribe** | **preservar el literal** "primeros pasos" (version humana de `primeros_pasos`, la regla R1 hace `_`→espacio) en el `features.md` reescrito. Verificar con `grep -qiE "\bprimeros pasos\b"` antes de cerrar. **Riesgo:** si la reescritura por tab elimina/parafrasea la prosa de "Primeros pasos", R1 suma un MISSING nuevo. |
+| `estadisticas` | SI | **FRAGIL — solo linea 69, dentro del bloque 50-74 que S1 reescribe** | **preservar el literal** "estadisticas" en el `features.md` reescrito (tab Perfil). Verificar con `grep -qiE "\bestadisticas\b"` antes de cerrar. **Riesgo:** si la reescritura elimina/parafrasea la prosa de "Estadisticas", R1 suma un MISSING nuevo. |
+| resto (`sorprendeme`, `comercio`, `checkin`, `rankings`, ...) | SI | fuera del bloque 50-74 (safe) | no romper al reescribir |
+
+> **Chequeo definitivo (generalizado):** despues de la reescritura de S1+S2, **correr la logica completa de R1** (`scripts/guards/run.mjs --rule 311/R1-helpgroups-coverage`), NO solo verificar los ids tabulados. La tabla destaca los ids fragiles conocidos (`primeros_pasos`, `estadisticas`) porque matchean exclusivamente dentro del bloque que se reescribe, pero el guard runner es el chequeo definitivo: solo se cierra el feature si R1 emite 0 lineas MISSING.
+
+---
+
+## Integracion
+
+El unico "consumidor" del cambio es la documentacion y los lectores/agentes que la usan como fuente de verdad, mas el guard runner que valida R1/R2 contra `features.md`.
+
+### Preventive checklist
+
+- [x] **Service layer**: N/A — no se toca codigo.
+- [x] **Duplicated constants**: N/A.
+- [x] **Context-first data**: N/A.
+- [x] **Silent .catch**: N/A — no se agrega codigo. `checks.mjs` no se toca.
+- [x] **Stale props**: N/A.
+
+## Tests
+
+No se agrega codigo de runtime → no aplica cobertura >=80%. El "test" relevante es la ejecucion del guard runner sobre las reglas existentes.
+
+| Archivo test | Que testear | Tipo |
+|-------------|-------------|------|
+| `scripts/guards/run.mjs --rule 311/R2-features-sidemenu-drift` | Verde tras el fix de docs (0 violaciones). Antes del fix: 1 violacion | Guard runner (existente) |
+| `scripts/guards/run.mjs --rule 311/R1-helpgroups-coverage` | No suma nuevos MISSING tras la reescritura; cierra el MISSING preexistente `modooscuro` (0 violaciones) | Guard runner (existente) |
+| `docs/reference/features.md` | `grep -c "SideMenu"` → `0`; `grep -ci "menu lateral"` → `0`; cada id de `helpGroups.tsx` matchea | Verificacion CI grep (no unit) |
+
+> No se agregan tests unitarios nuevos: `__tests__/helpGroups.test.ts` (ids unicos / voseo) ya cubre el registry y no se modifica el registry.
+
+## Analytics
+
+N/A — sin `logEvent`/`trackEvent` nuevos.
+
+---
+
+## Offline
+
+N/A — el feature no introduce data flows (no lee/escribe Firestore, no llama APIs, no agrega UI).
+
+### Cache strategy / Writes offline / Fallback UI
+
+N/A.
+
+---
+
+## Accesibilidad y UI mobile
+
+N/A — no se agregan componentes ni elementos interactivos. La navegacion real (`TabBar`) ya esta en produccion y fuera de scope.
+
+## Textos y copy
+
+Los textos escritos son contenido de `features.md` y `311-help-docs.md` (documentacion). Aplican las reglas de copy del guard #309 al texto en espanol.
+
+### Reglas de copy aplicadas
+
+- Voseo donde corresponda en prosa user-facing-equivalente.
+- Tildes obligatorias: navegacion, busqueda, ubicacion, configuracion, etc.
+- Terminologia: "comercios" (no "negocios"), "resenas" (no "reviews").
+- Mensaje de error del guard accionable (ya presente en `checks.mjs:513`): "describe SideMenu inexistente; la navegacion real es TabBar (BottomNavigation)".
+
+---
+
+## Decisiones tecnicas
+
+1. **Cerrar el MISSING preexistente `modooscuro` en vez de declararlo fuera de scope.** Sofia detecto que R1 ya falla hoy por `modooscuro` (el id no tiene underscore, asi que la regla `_`→espacio no produce el match con "modo oscuro"). Dado que estamos reescribiendo `features.md` igual, incluir el literal `modooscuro` cuesta una linea y deja R1 totalmente verde. Alternativa rechazada: reformular SC#5 a "R1 no suma nuevos MISSING" y dejar el fallo abierto — rechazada porque deja un guard rojo evitable. SC#5 se reformula igual (ver abajo) para ser explicito sobre que el criterio es "R1 no suma nuevos MISSING **y** se cierra el preexistente".
+2. **No tocar el registry `helpGroups.tsx`.** Ya esta alineado a tabs. Las frases "menu lateral" que contiene son descripciones de ayuda y no afectan R2 (que solo lee `features.md`). Tocarlo seria fuera de scope del PRD.
+3. **No crear ninguna regla de guard.** `R2-features-sidemenu-drift` ya existe (checks.mjs:511). S3 es solo sincronizacion de su doc.
+4. **Drift de `SideMenu` en los otros 8 docs queda fuera de scope.** R2 solo valida `features.md`, asi que no rompe CI. Decision de seguimiento documentada abajo.
+
+---
+
+## Hardening de seguridad
+
+N/A — el feature no introduce superficie de ataque (sin rules, callables, Firestore, Storage ni inputs de usuario). Ver seccion Seguridad del PRD.
+
+### Firestore rules requeridas / Rate limiting / Vectores de ataque
+
+N/A.
+
+---
+
+## Deuda tecnica: mitigacion incorporada
+
+```bash
+gh issue list --label security --state open --json number,title   # -> [] (PRD: sin issues)
+gh issue list --label "tech debt" --state open --json number,title # -> [] (PRD: sin issues)
+```
+
+El propio #349 es el item de deuda tecnica de documentacion que se resuelve.
+
+| Issue | Que se resuelve | Paso del plan |
+|-------|----------------|---------------|
+| #349 | Drift `features.md` SideMenu → TabBar + sync doc guard | Fases 1-3 |
+| #349 (sub) | MISSING preexistente `modooscuro` en R1 | Fase 1, paso de cierre R1 |
+
+### Followup propuesto (decision de producto, fuera de scope #349)
+
+Los 8 docs restantes que mencionan `SideMenu` (`architecture.md`, `coding-standards.md`, `files.md`, `patterns.md`, `issues.md`, `file-size-directive.md`, `perf-audit-recommendations.md`, `project-reference.md`) siguen drifteados. Riesgo bajo (R2 no los valida), pero es desinformacion para lectores/agentes. **Recomendacion: abrir issue de followup** para barrerlos en un PR aparte. No incluir en este scope (lo confirma el "Out of Scope" del PRD). Nota: `patterns.md` menciona `SideMenu` (lineas ~55, 80, 84, 100, 101) — incluido en ese followup, no aca.
+
+---
+
+## Success Criteria (reformulados con observaciones de Sofia)
+
+1. `grep -c "SideMenu" docs/reference/features.md` devuelve `0` y `grep -ci "menu lateral" docs/reference/features.md` devuelve `0`; la seccion de navegacion describe la `BottomNavigation` de 5 tabs (Inicio/Social/Buscar/Listas/Perfil) + `SearchFab` segun `TabBar.tsx`/`TabShell.tsx`.
+2. Cada seccion previamente bajo "Menu lateral" queda mapeada al tab real, sin perder detalle funcional, usando el agrupamiento de `helpGroups.tsx`.
+3. El item `notificaciones` aclara que la campana vive en la barra de busqueda; los skeleton loaders (incl. `TabLoader`) quedan documentados como minimo a nivel de mencion.
+4. El guard `R2-features-sidemenu-drift` (existente en `scripts/guards/checks.mjs:511`) pasa (0 violaciones) tras el fix; `docs/reference/guards/311-help-docs.md` documenta esa regla y refleja la estructura de tabs.
+5. **(Reformulado)** El guard `R1-helpgroups-coverage` **no suma nuevos MISSING** por la reescritura **y** cierra el MISSING preexistente `modooscuro` → R1 verde (0 violaciones). Los tokens literales `inicio`/`buscar`/`social`/`listas`/`perfil` siguen presentes en `features.md`.
+
+---
+
+## Revisión Técnica (Gate Diego)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Revisor:** Diego (solution architect)
+
+**Observaciones:** Dos bloqueantes detectados y cerrados en esta iteracion. (1) La tabla de S2 omitia la linea 323 ("Seccion Pendientes en SideMenu") e incluia mal categorizada la 37 ("menu lateral", prosa, no token `SideMenu`): las 13 lineas reales con el token `SideMenu` son 50, 56, 59, 94, 103, 133, 134, 150, 151, 155, 182, 323, 392 — todas deben quedar en 0; ademas las lineas 37 y 50 con "menu lateral" deben dar 0 en `grep -ci`. La cola de pendientes se confirmo en `src/components/profile/PendingActionsSection.tsx` (tab Perfil), la sustitucion propuesta es correcta. (2) Los ids R1 `primeros_pasos` (linea 52) y `estadisticas` (linea 69) matchean EXCLUSIVAMENTE dentro del bloque 50-74 que S1 reescribe; si la reescritura los parafrasea, R1 suma MISSING nuevos. El plan debe respetar: preservar esos dos literales/versiones humanas, y como condicion de cierre correr la logica COMPLETA de R1 y R2 con el guard runner (no solo verificar los ids tabulados) — 0 lineas MISSING en R1 y 0 violaciones en R2. Sin cambios en codigo de runtime, rules, Firestore ni Functions: N/A correctamente justificados.

--- a/docs/feat/fix/copy-tildes-naming-baneado/plan.md
+++ b/docs/feat/fix/copy-tildes-naming-baneado/plan.md
@@ -1,0 +1,175 @@
+# Plan de implementación: Copy — tildes faltantes y naming baneado (¡Sorpresa!) (#346)
+
+**Specs:** [specs.md](specs.md)
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-12
+
+> Basado en `specs.md` (VALIDADO CON OBSERVACIONES por Diego, 2026-06-12) y `prd.md` (VALIDADO CON OBSERVACIONES por Sofia, 2026-06-10).
+
+---
+
+## Estrategia y staging de riesgo
+
+Feature de copy puro: tres ediciones de strings estáticos, ninguna toca lógica de negocio. Las fases se ordenan de menor a mayor acoplamiento con tests. S1 y S2 son cambios aislados de string sin tests asociados; S3+S3b se agrupan en un solo commit porque el fix de producción rompe el suite si no se actualizan las aserciones en simultáneo (observación 3 de Diego).
+
+| Fase | Riesgo | Notas |
+|------|--------|-------|
+| F1 — Naming baneado en `onboarding.ts` (S1) | Bajo | Solo valor de constante; consumidor vía constante, sin propagación |
+| F2 — Tuteo en `helpGroups.tsx` (S2) | Bajo | 1 string inline; sin cobertura de guard (review manual) |
+| F3 — Tildes en `CronCard.tsx` + tests (S3+S3b) | Bajo | Producción y test en el MISMO commit para no dejar el suite en rojo |
+
+**Branch:** `fix/346-copy-tildes-naming-baneado`
+
+---
+
+## Fase 1 — Naming baneado en toast de onboarding (S1)
+
+- **Archivo:** `src/constants/messages/onboarding.ts` (línea 4).
+- **Cambio:** reemplazar el valor de `surpriseSuccess`:
+  ```ts
+  // Antes:
+  surpriseSuccess: (name: string) => `¡Sorpresa! Descubrí ${name}`,
+  // Después:
+  surpriseSuccess: (name: string) => `¡Sorprendeme eligió ${name}!`,
+  ```
+- **Restricciones (guard #309):** sin `Sorpresa`/`Sorpréndeme`/`Sorprendeme!` (el `!` cierra la frase completa, no pegado al naming — regla 3); abre `¡` y cierra `!` (regla 5); `eligió` con tilde (regla 2).
+- **No tocar** `src/hooks/useSurpriseMe.ts`: consume `MSG_ONBOARDING.surpriseSuccess(pick.name)` (línea 44) y se propaga automáticamente.
+- **File ownership:** `src/constants/messages/onboarding.ts` (único archivo de esta fase).
+- **Test:** ninguno nuevo. Verificar que `src/hooks/useSurpriseMe.test.ts:94` sigue verde — la aserción compara contra `MSG_ONBOARDING.surpriseSuccess(...)` (la constante, no un literal `¡Sorpresa!`). Confirmar que no quede ningún literal `¡Sorpresa!` hardcodeado en el test.
+  - `npm run test:run -- useSurpriseMe` → verde sin editar el test.
+- **Commit:** `fix(#346): eliminar naming baneado "Sorpresa" del toast surpriseSuccess`
+- **Rollback:** revert del único archivo.
+
+## Fase 2 — Tuteo peninsular en helpGroups (S2)
+
+- **Archivo:** `src/components/profile/helpGroups.tsx` (línea 74).
+- **Cambio:** dentro de la `description` del item `id: 'inicio'`, reemplazar **únicamente** `Sección "Para ti"` → `Sección "Para vos"`.
+  - **Observación 2 de Diego (respetar):** NO tocar los términos canónicos `Sorprendeme` presentes en la MISMA línea 74; el reemplazo se acota exactamente al substring `Para ti` → `Para vos`.
+- **Alcance:** 1 sola ocurrencia (corrección de scope de Sofia). La línea 88 dice `"Tus intereses"`, NO `"Para ti"` — no se toca. El `"Para ti"` en comentario de `useTabNavigation.ts:8` es fuera de scope (no user-facing).
+- **No se agregan/quitan items** de `HELP_GROUPS` → sin impacto en guard #311 (sincronización 1:1 con `features.md`).
+- **File ownership:** `src/components/profile/helpGroups.tsx` (único archivo de esta fase).
+- **Test:** ninguno. S2 no tiene cobertura de guard (#309 no detecta tuteo peninsular) → validación **solo por review manual** (observación 3 de Diego / decisión Sofia). Validar visualmente que la ayuda del item `inicio` ahora referencia `"Para vos"`, coincidiendo con `ForYouSection.tsx:51`.
+- **Commit:** `fix(#346): alinear ayuda "Para ti" -> "Para vos" en helpGroups (voseo + match UI)`
+- **Rollback:** revert del único archivo.
+
+## Fase 3 — Tildes faltantes en CronCard (admin) + aserciones (S3 + S3b)
+
+> **Observación 3 de Diego (respetar):** S3 (producción) y S3b (test) van en el **MISMO commit**. El fix de producción rompe el suite porque las aserciones asertan el texto sin tilde; agruparlos evita dejar el suite en rojo entre commits.
+
+### Paso 1 — Producción (S3)
+
+- **Archivo:** `src/components/admin/CronCard.tsx`.
+- **Cambios:**
+  - Línea 48: `Ultima ejecucion: {formatRelativeTime(...)}` → `Última ejecución: {formatRelativeTime(...)}`.
+  - Línea 52: `Duracion: {formatDuration(...)}` → `Duración: {formatDuration(...)}`.
+
+### Paso 2 — Tests (S3b, mismo commit)
+
+- **Archivo:** `src/components/admin/__tests__/CronCard.test.tsx`.
+- **Cambio:** actualizar las 4 aserciones `getByText(...)`. **Observación 1 de Diego (respetar):** son strings COMPLETOS, no solo el prefijo. Editar el string entero:
+  - Línea 52: `'Duracion: 5.0s'` → `'Duración: 5.0s'`
+  - Línea 86: `'Duracion: 150ms'` → `'Duración: 150ms'`
+  - Línea 97: `'Duracion: 250ms'` → `'Duración: 250ms'`
+  - Línea 108: `'Duracion: 12.5s'` → `'Duración: 12.5s'`
+- **No hay aserción sobre `Ultima ejecucion`** en el test actual (verificado: solo `Duracion:` en esas 4 líneas). No se agregan casos nuevos.
+
+- **File ownership:** `src/components/admin/CronCard.tsx` + `src/components/admin/__tests__/CronCard.test.tsx` (ambos en el mismo commit).
+- **Test:** `npm run test:run -- CronCard` → verde con las 4 aserciones actualizadas.
+- **Commit (único, ambos archivos):** `fix(#346): tildes en CronCard (Última ejecución / Duración) + aserciones`
+- **Rollback:** revert del commit (restaura producción y test juntos, manteniendo el suite verde).
+
+---
+
+## Orden de implementación
+
+1. **F1** — `src/constants/messages/onboarding.ts` (independiente; valida `useSurpriseMe.test.ts` no rompe).
+2. **F2** — `src/components/profile/helpGroups.tsx` (independiente; review manual).
+3. **F3** — `src/components/admin/CronCard.tsx` + `__tests__/CronCard.test.tsx` (mismo commit; valida suite `CronCard`).
+
+Las tres fases son independientes entre sí (archivos disjuntos). El orden es indicativo; F3 es la única con acoplamiento producción↔test que obliga a commit atómico.
+
+---
+
+## Test plan global
+
+- **F1:** `npm run test:run -- useSurpriseMe` → verde SIN editar el test (aserción vía constante).
+- **F3:** `npm run test:run -- CronCard` → verde con las 4 aserciones `Duración:` actualizadas.
+- **Global:** `npm run test:run` completo verde; cobertura global no baja (no se agrega código nuevo, solo strings).
+- **Guard:** `npm run guards -- --guard 309` → ninguna de las 3 rutas editadas (`onboarding.ts:4`, `helpGroups.tsx:74`, `CronCard.tsx:48,52`) aparece en el output. NO se exige count global 0 (hay 27 violaciones preexistentes fuera de scope — SC#5 reformulado por Sofia). S2 (`Para ti`) NO es verificable por guard → review manual.
+- **Lint/build:** `npm run lint` sin errores; build verde.
+
+---
+
+## Rollback global
+
+Tres commits independientes y revertibles. F3 es el único commit que toca producción + test juntos: su revert restaura ambos en simultáneo, manteniendo el suite verde. No hay migraciones, datos, ni cambios de rules que revertir.
+
+---
+
+## Guardrails (verificación)
+
+### Modularidad
+- [x] Ningún componente importa `firebase/firestore` directamente (no se toca Firebase).
+- [x] Archivos en su carpeta de dominio correcta (`constants/messages/`, `components/profile/`, `components/admin/`). No se toca `components/menu/`.
+- [x] Sin lógica de negocio nueva en componentes; solo strings.
+- [x] Ningún archivo supera 400 líneas (`helpGroups.tsx` ~270, sin crecer).
+- [x] No se crea archivo en `src/hooks/`; no se agrega estado global.
+
+### Seguridad
+- [x] Sin colecciones/escrituras/lecturas nuevas → no aplica `hasOnly()`, rate limits ni rules.
+- [x] `name` interpolado en `surpriseSuccess` proviene de `pick.name` (dato estático de `businesses.json`); MUI Snackbar lo renderiza como texto plano. Sin inyección.
+- [x] Sin secrets ni credenciales en archivos commiteados.
+
+### Observabilidad
+- [x] Sin CF triggers, services con queries, ni `trackEvent` nuevos (el evento `surprise_me` no cambia).
+- [x] No se toca `logger.error`.
+
+### Accesibilidad y UI
+- [x] Sin `<IconButton>`, `<Typography onClick>`, touch targets, estados de carga ni `<img>` nuevos.
+- [x] Mejora de copy beneficia a screen readers (texto correcto en español).
+
+### Copy
+- [x] Voseo: `Para vos` (no `Para ti`); naming `Sorprendeme` (no `Sorpresa`/`Sorpréndeme`).
+- [x] Tildes: `Última`, `ejecución`, `Duración`, `eligió`.
+- [x] `surpriseSuccess` ya centralizado en `constants/messages/`. Textos de ayuda y admin son de 1 solo call site (no requieren centralización — regla 4 #309).
+
+---
+
+## Fase final — Documentación
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `docs/reference/features.md` | Verificar que no mencione `"Para ti"` ni `¡Sorpresa!`; si lo hace, alinear a `"Para vos"` / nuevo toast (guard #311 exige sincronización help↔features). Confirmar al implementar. |
+
+Filas eliminadas por no aplicar: `security.md` (sin rules/auth), `firestore.md` (sin colecciones/campos), `patterns.md` (sin patrones nuevos), `project-reference.md` (sin feature visible nuevo), `HelpSection.tsx` (comportamiento sin cambios; solo el copy de `helpGroups.tsx` que ya se edita en F2).
+
+---
+
+## Riesgos
+
+1. **Match parcial en aserciones de test (F3).** `getByText` usa string completo (`'Duración: 5.0s'`, etc.); editar solo el prefijo `Duracion:` → `Duración:` sin el valor rompería el match. **Mitigación:** editar los 4 strings completos según observación 1 de Diego (valores confirmados: `5.0s`, `150ms`, `250ms`, `12.5s`).
+2. **Re-introducción de término baneado en F1.** Usar `Sorprendeme!` (con `!` pegado) o `Sorpréndeme` volvería a disparar #309. **Mitigación:** forma exacta `¡Sorprendeme eligió ${name}!` (validada en specs decisión técnica 1).
+3. **Edición fuera de scope en F2.** `replace_all` o un match laxo podría tocar los `Sorprendeme` canónicos de la línea 74 o el `"Tus intereses"` de la 88. **Mitigación:** reemplazo acotado al substring exacto `Sección "Para ti"` → `Sección "Para vos"` (observación 2 de Diego).
+
+---
+
+## Criterios de done
+
+- [ ] S1: toast sin `Sorpresa`/`Sorpréndeme`/`Sorprendeme!`, con `¡...!` (SC#1).
+- [ ] S2: ayuda del item `inicio` dice `Sección "Para vos"` (SC#2, review manual).
+- [ ] S3+S3b: `CronCard` muestra `Última ejecución:` y `Duración:`; las 4 aserciones `Duración:` verdes (SC#3).
+- [ ] `npm run test:run` completo verde; cobertura no baja (SC#4).
+- [ ] Las 3 rutas editadas no aparecen en `npm run guards -- --guard 309` (SC#5 reformulado).
+- [ ] `npm run lint` sin errores; build verde.
+- [ ] `docs/reference/features.md` verificado/alineado si referenciaba copy viejo.
+
+---
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO
+**Fecha:** 2026-06-12
+**Ciclo:** 1
+
+**Observaciones para el implementador:** F3 (CronCard.tsx) y F3b (CronCard.test.tsx) van en el MISMO commit — no separar, o el suite queda en rojo entre commits (las 4 aserciones `getByText` usan string completo: `'Duración: 5.0s'`, `'Duración: 150ms'`, `'Duración: 250ms'`, `'Duración: 12.5s'`; editar prefijo + valor, no solo el prefijo). F1/F2/F3 tienen archivos disjuntos: si se paraleliza (luna/nico) no hay overlap, pero F1 toca `src/constants/messages/onboarding.ts` — usar Edit (patrón aditivo de constantes), nunca Write. La fila de documentación (`features.md`) es verificación defensiva: grep confirmó que hoy no menciona `"Para ti"` ni `¡Sorpresa!`, así que probablemente sea no-op — confirmar al implementar, no asumir cambio. S2 sin cobertura de guard #309: validar por review manual que `helpGroups.tsx:74` queda `Sección "Para vos"` sin tocar los `Sorprendeme` canónicos ni `"Tus intereses"` de la misma descripción. El pre-push (tsc + vite build) y el guard 309 (ausencia de las 3 rutas editadas, no count global 0) deben correr antes del merge.

--- a/docs/feat/fix/copy-tildes-naming-baneado/prd.md
+++ b/docs/feat/fix/copy-tildes-naming-baneado/prd.md
@@ -1,0 +1,260 @@
+# PRD: Tech debt copy — tildes faltantes y naming baneado (¡Sorpresa!)
+
+**Feature:** copy-tildes-naming-baneado
+**Categoria:** fix
+**Fecha:** 2026-06-09
+**Issue:** #346
+**Prioridad:** Media (severidad MEDIUM en el issue; label `enhancement`)
+
+---
+
+## Contexto
+
+El audit `/health-check` detecto 3 regresiones de copy en `new-home` que violan las convenciones de copywriting del proyecto (espanol argentino con tildes, voseo rioplatense, naming canonico) y el guard #309. Son cambios acotados de texto en 3 archivos, sin logica de negocio, pero uno de ellos (`CronCard`) requiere actualizar tambien las aserciones del test que validan el texto sin tilde.
+
+## Problema
+
+- `src/constants/messages/onboarding.ts:4` usa el termino **prohibido por guard #309 regla 3**: `surpriseSuccess` = `` `¡Sorpresa! Descubrí ${name}` ``. La superficie canonica es **"Sorprendeme"** (sin tilde, voseo). El toast es frecuente: se dispara en cada seleccion exitosa de `useSurpriseMe.ts:44`.
+- `src/components/profile/helpGroups.tsx:74,88` usa **tuteo peninsular** `"Para ti"` en dos descripciones de ayuda, ademas con **mismatch contra la UI real**, que renderiza `"Para vos"` (`ForYouSection.tsx:51`). El usuario lee en la ayuda un nombre de seccion que no existe en pantalla.
+- `src/components/admin/CronCard.tsx:48,52` tiene **tildes faltantes** en el panel admin: `Ultima ejecucion` → `Última ejecución`, `Duracion` → `Duración`. Las aserciones de `CronCard.test.tsx` (lineas 52, 86, 97, 108) asertan el texto SIN tilde, por lo que el fix de produccion rompe los tests si no se actualizan en el mismo cambio.
+
+## Solucion
+
+Tres ediciones de copy puntuales, alineadas con el guard #309 y el patron de copywriting (`docs/reference/patterns.md` > Copywriting). Ninguna toca logica: solo strings y aserciones de test que validan esos strings.
+
+### S1 — Naming baneado en toast de onboarding
+
+En `src/constants/messages/onboarding.ts`, reemplazar el valor de `surpriseSuccess` para eliminar el termino prohibido "Sorpresa" sin reintroducirlo. Sugerencia del issue: `` `¡Sorprendeme eligió ${name}!` ``. Debe respetar:
+
+- Guard #309 regla 3: **no** puede contener `Sorpresa`, `Sorpréndeme` ni `Sorprendeme!` (con exclamacion pegada al naming). La forma canonica es `Sorprendeme` (sin tilde). El signo `!` de cierre va al final de la frase completa (`...eligió ${name}!`), no pegado al naming.
+- Guard #309 regla 5: la frase es exclamativa, debe abrir con `¡` y cerrar con `!`.
+- Guard #309 regla 1: voseo (`eligió`, 3ra persona, es correcto; la app "elige").
+- El cambio es solo del valor de la constante: `useSurpriseMe.ts` ya consume `MSG_ONBOARDING.surpriseSuccess(pick.name)` y no necesita tocarse.
+
+### S2 — Tuteo peninsular en helpGroups
+
+En `src/components/profile/helpGroups.tsx`, reemplazar las dos ocurrencias de `"Para ti"` (lineas 74 y 88) por `"Para vos"`, alineando el texto de ayuda con el label real renderizado en `ForYouSection.tsx:51`. Mantiene la regla 1 de #309 (voseo) y cierra el mismatch ayuda↔UI. No se agregan ni quitan entradas del array `HELP_GROUPS` (sin impacto en el guard #311 de sincronizacion 1:1 con `features.md`, ya que el nombre de la seccion no cambia, solo se corrige el termino).
+
+### S3 — Tildes faltantes en CronCard (admin) + tests
+
+En `src/components/admin/CronCard.tsx`:
+
+- Linea 48: `Ultima ejecucion:` → `Última ejecución:`
+- Linea 52: `Duracion:` → `Duración:`
+
+En `src/components/admin/__tests__/CronCard.test.tsx`, actualizar las 4 aserciones que asertan `Duracion:` sin tilde (lineas 52, 86, 97, 108) a `Duración:`. No hay asercion sobre "Ultima ejecucion" en el test actual, pero verificar al implementar que ninguna otra asercion (presente o futura) dependa del texto sin tilde.
+
+> Nota: el path real del test es `src/components/admin/__tests__/CronCard.test.tsx` (no `src/components/admin/CronCard.test.tsx` como cita el issue).
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| S1 — `surpriseSuccess` sin termino "Sorpresa" (onboarding.ts) | Alta | S |
+| S2 — `"Para ti"` → `"Para vos"` x2 (helpGroups.tsx) | Media | S |
+| S3 — Tildes `Última ejecución` / `Duración` (CronCard.tsx) | Media | S |
+| S3b — Actualizar 4 aserciones `Duración:` en CronCard.test.tsx | Media | S |
+
+**Esfuerzo total estimado:** S
+
+---
+
+## Out of Scope
+
+- Auditoria global de tildes/voseo en otros archivos no listados por el issue #346.
+- Centralizar nuevos strings en `MSG_COMMON` (estos no superan el umbral de >= 2 call sites del guard #309 regla 4; `surpriseSuccess` ya esta centralizado).
+- Cambiar el texto completo de las descripciones de ayuda mas alla de `"Para ti"` → `"Para vos"`.
+- Modificar el comportamiento de `useSurpriseMe`, `CronCard` o `HelpSection` (solo strings).
+- Agregar el diccionario de guard #309 al CI o tocar `scripts/guards/`.
+
+---
+
+## Tests
+
+Politica `docs/reference/tests.md`: cambios de copy puro no requieren tests nuevos, pero S3 **rompe** tests existentes que asertan el texto sin tilde, asi que esas aserciones DEBEN actualizarse en el mismo cambio (no es test nuevo, es mantener verde el suite).
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `src/components/admin/__tests__/CronCard.test.tsx` | Update aserciones | Cambiar `Duración:` en las 4 aserciones (lineas 52, 86, 97, 108) para que matcheen el texto con tilde. Sin casos nuevos. |
+| `src/hooks/useSurpriseMe.test.ts` | Verificar (no romper) | La asercion (linea 94) usa `MSG_ONBOARDING.surpriseSuccess(...)` (la constante, no un literal), por lo que sigue verde tras S1. Confirmar que no quede ningun literal `¡Sorpresa!` hardcodeado en el test. |
+
+### Criterios de testing
+
+- Suite `CronCard.test.tsx` verde tras el cambio (`npm run test:run -- CronCard`).
+- Suite `useSurpriseMe.test.ts` verde sin modificaciones (asercion via constante).
+- No se introducen tests nuevos: el codigo afectado es copy sin logica condicional (excepcion documentada en `tests.md` seccion 3).
+- Cobertura global del repo no baja (no se agrega codigo nuevo, solo strings).
+
+---
+
+## Seguridad
+
+Sin superficie de seguridad nueva. No hay endpoints, escrituras a Firestore, inputs de usuario, lecturas masivas ni cambios de rules. Son tres cadenas de texto estatico (dos en componentes, una en una constante de mensajes).
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| Ninguna | N/A — solo strings estaticos, sin entrada de usuario ni I/O | N/A |
+
+- [x] No escribe a Firestore — checklist de rules no aplica.
+- [x] No agrega campos a `userSettings` — converters/defaults no aplican.
+- [x] No lee datos — no habilita scraping.
+- [x] El valor de `surpriseSuccess(name)` interpola `name`, que proviene de `pick.name` (dato estatico de `businesses.json`, no input de usuario). Sin riesgo de inyeccion. El toast lo renderiza MUI Snackbar como texto plano (no `dangerouslySetInnerHTML`).
+
+---
+
+## Deuda tecnica y seguridad
+
+Este feature **resuelve** deuda de copy abierta y **previene** una regresion del guard #309 (que ya cerro #270/#282/#292/#309). No introduce deuda nueva.
+
+```bash
+gh issue list --label security --state open --json number,title
+gh issue list --label "tech debt" --state open --json number,title
+```
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| #346 (este) | resuelve | Cierra los 3 hallazgos del `/health-check` de copy |
+| #309 (guard copy) | mitiga | Restaura el invariante del guard #309 (regla 2 tildes, regla 3 naming "Sorprendeme", regla 1 voseo). El detection pattern `R2-tildes-prohibidas` ya cubre `Sorpresa` y la forma sin tilde de `Última`/`Duración`/`ejecución` |
+| #311 (guard help-docs) | no agravar | S2 no agrega/quita entradas de `HELP_GROUPS`, mantiene la sincronizacion 1:1 con `features.md` |
+
+### Mitigacion incorporada
+
+- Eliminar el termino baneado `Sorpresa` del codigo (cierra hit de `R2-tildes-prohibidas` / regla 3 del guard #309), sin reintroducir `Sorpréndeme` ni `Sorprendeme!`.
+- Corregir tildes faltantes (`Última`, `ejecución`, `Duración`) detectables por el diccionario `always_tilded` del guard #309.
+- Tras el cambio, correr `npm run guards -- --guard 309` para confirmar que el count de hits no sube (idealmente baja).
+
+---
+
+## Robustez del codigo
+
+No hay hooks ni operaciones async nuevas. Solo edicion de strings.
+
+### Checklist de hooks async
+
+- [x] N/A — sin `useEffect`, sin async, sin `setState`. Solo strings.
+- [x] No se exporta nada nuevo.
+- [x] No se crea archivo en `src/hooks/`.
+- [x] No se agregan keys de localStorage.
+- [x] Ningun archivo supera 300/400 lineas (helpGroups.tsx ~270 lineas, sin crecer).
+- [x] No se toca `logger.error`.
+
+### Checklist de observabilidad
+
+- [x] N/A — no hay Cloud Function trigger nuevo.
+- [x] N/A — no hay service nuevo con queries.
+- [x] N/A — no hay `trackEvent` nuevo (el `surprise_me` existente no cambia).
+
+### Checklist offline
+
+- [x] N/A — no hay formularios/dialogs que escriban a Firestore.
+- [x] El toast `surpriseSuccess` ya se muestra en todos los environments (es `toast.success`, no envuelto en DEV).
+
+### Checklist de documentacion
+
+- [ ] No se agregan secciones de HomeScreen ni de `HELP_GROUPS`.
+- [ ] No hay analytics events nuevos.
+- [ ] No hay tipos nuevos.
+- [ ] `docs/reference/features.md`: verificar que no mencione `"Para ti"` ni `¡Sorpresa!`; si lo hace, alinear (el guard #311 exige sincronizacion help↔features). Confirmar al implementar.
+- [ ] `docs/reference/firestore.md`: sin cambios (no hay colecciones/campos).
+- [ ] `docs/reference/patterns.md`: sin patrones nuevos.
+
+---
+
+## Offline
+
+Sin flujos de datos. El toast de `useSurpriseMe` se dispara client-side a partir de datos estaticos (`allBusinesses`), funciona identico online y offline. `CronCard` y `helpGroups` son render estatico.
+
+### Data flows
+
+| Operacion | Tipo (read/write) | Estrategia offline | Fallback UI |
+|-----------|-------------------|-------------------|-------------|
+| Ninguna | N/A | N/A — solo strings estaticos | N/A |
+
+### Checklist offline
+
+- [x] Reads de Firestore: ninguna involucrada.
+- [x] Writes: ninguno.
+- [x] APIs externas: ninguna.
+- [x] UI: el toast funciona offline (datos estaticos).
+- [x] Datos criticos: N/A.
+
+### Esfuerzo offline adicional: S (cero)
+
+---
+
+## Modularizacion y % monolitico
+
+Cambios puramente de copy. No se mueve logica, no se agregan imports cruzados, no se toca AppShell/SideMenu, no se crean contextos.
+
+### Checklist modularizacion
+
+- [x] No se agrega logica de negocio a componentes de layout.
+- [x] Los strings ya viven en su capa correcta (`constants/messages/` para el toast; texto inline en el registry declarativo `helpGroups.tsx`, que es contenido especifico del feature por diseno #311; texto inline en `CronCard.tsx`, componente de dominio admin).
+- [x] No se agrega `useState` a AppShell/SideMenu.
+- [x] No se introducen dependencias implicitas a contextos de layout.
+- [x] No hay props de accion nuevas (sin noop).
+- [x] Ningun componente nuevo importa de `firebase/*`.
+- [x] No se crea archivo en `src/hooks/`.
+- [x] Ningun archivo supera 400 lineas.
+- [x] No se agregan converters.
+- [x] Los 3 archivos editados ya estan en su carpeta de dominio correcta (`constants/messages/`, `components/profile/`, `components/admin/`). No se toca `components/menu/`.
+- [x] No se necesita estado global nuevo.
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | = | Solo strings; sin nuevos imports |
+| Estado global | = | Sin estado nuevo |
+| Firebase coupling | = | Sin Firebase |
+| Organizacion por dominio | = | Archivos ya en su dominio |
+
+---
+
+## Accesibilidad y UI mobile
+
+Sin nuevos elementos interactivos. Mejora de copy que beneficia a screen readers (texto correcto en espanol, naming consistente).
+
+### Checklist de accesibilidad
+
+- [x] No se agregan `IconButton` ni elementos clickables.
+- [x] No cambia la semantica de ningun elemento.
+- [x] Touch targets sin cambios.
+- [x] Sin estados de carga nuevos.
+- [x] Sin imagenes nuevas.
+- [x] Sin formularios nuevos.
+
+### Checklist de copy
+
+- [x] Todos los textos en espanol con tildes correctas (`Última`, `ejecución`, `Duración`).
+- [x] Voseo consistente: `"Para vos"` (no `"Para ti"`); naming `Sorprendeme` (no `Sorpresa`/`Sorpréndeme`).
+- [x] Terminologia: se mantiene "comercios", "reseñas" (sin cambios en estos terminos).
+- [x] Strings reutilizables centralizados: `surpriseSuccess` ya esta en `constants/messages/onboarding.ts`. Los textos de ayuda y admin son de un solo call site (no requieren centralizacion, regla 4 #309).
+- [x] Mensajes accionables: N/A (no son mensajes de error).
+
+---
+
+## Success Criteria
+
+1. El toast de "Sorprendeme" ya no contiene el termino prohibido `Sorpresa` (ni `Sorpréndeme` ni `Sorprendeme!`), y abre/cierra con `¡...!` segun guard #309 reglas 3 y 5.
+2. Las descripciones de ayuda en `helpGroups.tsx` dicen `"Para vos"`, coincidiendo con el label real de `ForYouSection.tsx`.
+3. `CronCard` muestra `Última ejecución:` y `Duración:` con tildes, y `CronCard.test.tsx` queda verde con las 4 aserciones actualizadas a `Duración:`.
+4. `npm run test:run` pasa completo (CronCard + useSurpriseMe sin regresiones) y la cobertura global no baja.
+5. `npm run guards -- --guard 309` no reporta hits nuevos para `Sorpresa`/tildes en estos archivos (idealmente reduce el count del baseline).
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** Solo hay 1 ocurrencia de 'Para ti' (helpGroups.tsx:74), no 2 (la 88 es 'Tus intereses'). SC#5 no testeable: el guard 309 tiene 27 violaciones preexistentes — reformular a 'las 3 rutas editadas no aparecen en el output del guard 309'. S2 ('Para ti') no tiene cobertura de guard (solo review manual).

--- a/docs/feat/fix/copy-tildes-naming-baneado/specs.md
+++ b/docs/feat/fix/copy-tildes-naming-baneado/specs.md
@@ -1,0 +1,272 @@
+# Specs: Tech debt copy — tildes faltantes y naming baneado (¡Sorpresa!)
+
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-10
+**Issue:** #346
+
+---
+
+## Resumen
+
+Tres ediciones de copy puntuales detectadas por el `/health-check`, alineadas con el guard #309 y el patron de copywriting (`docs/reference/patterns.md` > Copywriting). Ninguna toca logica de negocio: solo strings estaticos y las aserciones de test que validan esos strings.
+
+| Cambio | Archivo | Tipo |
+|--------|---------|------|
+| S1 — naming baneado `Sorpresa` | `src/constants/messages/onboarding.ts:4` | string en constante |
+| S2 — tuteo `"Para ti"` → `"Para vos"` (1 ocurrencia) | `src/components/profile/helpGroups.tsx:74` | string inline |
+| S3 — tildes faltantes | `src/components/admin/CronCard.tsx:48,52` | strings inline |
+| S3b — aserciones `Duración:` | `src/components/admin/__tests__/CronCard.test.tsx:52,86,97,108` | test assertions |
+
+> **Correccion de scope (Sofia, VALIDADO CON OBSERVACIONES):** S2 tiene **1** sola ocurrencia de `"Para ti"` en `helpGroups.tsx:74`. La linea 88 dice `"Tus intereses"` (NO `"Para ti"`). El PRD original mencionaba 2 ocurrencias; se reduce a 1.
+
+---
+
+## Modelo de datos
+
+Sin cambios. No hay colecciones, documentos, campos ni indexes nuevos. No se tocan tipos de `src/types/`.
+
+## Firestore Rules
+
+Sin cambios. No hay escrituras ni lecturas nuevas.
+
+### Rules impact analysis
+
+| Query (service file) | Collection | Auth context | Rule que lo permite | Cambio necesario? |
+|---------------------|------------|-------------|--------------------|-------------------|
+| N/A — feature de copy puro, sin queries | — | — | — | No |
+
+### Field whitelist check
+
+| Collection | Campo nuevo/modificado | En create `hasOnly()`? | En update `affectedKeys().hasOnly()`? | Cambio de rule? |
+|-----------|----------------------|----------------------|--------------------------------------|-----------------|
+| N/A — sin escrituras | — | — | — | No |
+
+## Cloud Functions
+
+Sin cambios. No hay triggers, scheduled ni callables nuevos.
+
+## Seed Data
+
+N/A. No se crean colecciones ni se agregan campos requeridos a colecciones existentes. Seccion omitida por inaplicable.
+
+## Componentes
+
+No se crean componentes nuevos. Se modifican strings inline en dos componentes existentes:
+
+### `helpGroups.tsx` (modificado — solo string)
+
+- Ubicacion: `src/components/profile/helpGroups.tsx`.
+- Cambio: en la `description` del item `id: 'inicio'` (linea 74), reemplazar la unica ocurrencia de `Sección "Para ti"` por `Sección "Para vos"`.
+- Rationale: el label real renderizado en `src/components/home/ForYouSection.tsx` es `"Para vos"`. La ayuda referenciaba un nombre de seccion que no existe en pantalla (`"Para ti"`, tuteo peninsular).
+- Sin cambios en el array `HELP_GROUPS` (no se agregan/quitan items → no afecta guard #311 de sincronizacion 1:1 con `features.md`).
+- **No tocar** las apariciones validas del termino canonico `Sorprendeme` en las lineas 74 y 79-81 (ya estan correctas, sin tilde y voseo).
+
+### `CronCard.tsx` (modificado — solo strings)
+
+- Ubicacion: `src/components/admin/CronCard.tsx`.
+- Cambio linea 48: `Ultima ejecucion: {formatRelativeTime(...)}` → `Última ejecución: {formatRelativeTime(...)}`.
+- Cambio linea 52: `Duracion: {formatDuration(...)}` → `Duración: {formatDuration(...)}`.
+- Componente de dominio admin; render estatico, sin logica condicional nueva.
+
+### Mutable prop audit
+
+| Component | Prop | Editable fields | Local state needed? | Parent callback |
+|-----------|------|----------------|-------------------|-----------------|
+| N/A — ningun componente editable nuevo | — | — | No | — |
+
+## Textos de usuario
+
+| Texto | Donde se usa | Notas |
+|-------|-------------|-------|
+| `¡Sorprendeme eligió ${name}!` | toast `toast.success` en `useSurpriseMe.ts` (via `MSG_ONBOARDING.surpriseSuccess`) | naming canonico `Sorprendeme` (sin tilde, regla 3 #309); abre `¡` cierra `!` (regla 5); `eligió` con tilde |
+| `Para vos` | `description` del item `inicio` en `helpGroups.tsx:74` | voseo (regla 1 #309); coincide con label de `ForYouSection.tsx` |
+| `Última ejecución:` | label en `CronCard.tsx:48` (panel admin) | tildes en `Última` y `ejecución` (regla 2 #309) |
+| `Duración:` | label en `CronCard.tsx:52` (panel admin) | tilde en `Duración` (regla 2 #309) |
+
+## Hooks
+
+Sin cambios. `useSurpriseMe.ts` ya consume `MSG_ONBOARDING.surpriseSuccess(pick.name)` y **no se toca** — el cambio es solo del valor de la constante.
+
+## Servicios
+
+Sin cambios. No hay servicios involucrados.
+
+## Constantes (modificado — solo string)
+
+### `src/constants/messages/onboarding.ts`
+
+Cambiar el valor de `surpriseSuccess`:
+
+```ts
+// Antes (linea 4):
+surpriseSuccess: (name: string) => `¡Sorpresa! Descubrí ${name}`,
+// Despues:
+surpriseSuccess: (name: string) => `¡Sorprendeme eligió ${name}!`,
+```
+
+Restricciones de guard #309 que debe respetar el nuevo valor:
+- **Regla 3 (naming):** no contiene `Sorpresa`, `Sorpréndeme`, ni `Sorprendeme!` (con `!` pegado al naming). La forma canonica es `Sorprendeme` (sin tilde). El `!` de cierre va al final de la frase completa (`...${name}!`), no pegado al naming.
+- **Regla 5 (exclamativas):** abre con `¡` y cierra con `!`.
+- **Regla 1 (voseo):** `eligió` (3ra persona, la app elige) es correcto.
+- **Regla 4 (centralizacion):** ya esta centralizado; sin cambios de estructura.
+
+## Integracion
+
+El cambio de `surpriseSuccess` se propaga automaticamente a `useSurpriseMe.ts:44` (consume la constante). No hay cambios de firma ni de call sites. Los cambios de `helpGroups.tsx` y `CronCard.tsx` son strings inline sin propagacion.
+
+### Preventive checklist
+
+- [x] **Service layer**: ningun componente importa `firebase/firestore` para escrituras (no aplica, sin escrituras).
+- [x] **Duplicated constants**: no se definen arrays/objetos nuevos. `surpriseSuccess` sigue centralizado.
+- [x] **Context-first data**: no hay `getDoc` nuevo.
+- [x] **Silent .catch**: no se agrega ningun `.catch`.
+- [x] **Stale props**: no hay componente que reciba props y mute esa data.
+
+## Tests
+
+| Archivo test | Que testear | Tipo |
+|-------------|-------------|------|
+| `src/components/admin/__tests__/CronCard.test.tsx` | Actualizar las 4 aserciones `Duracion:` (lineas 52, 86, 97, 108) → `Duración:` para que matcheen el texto con tilde. Sin casos nuevos. | Update aserciones |
+| `src/hooks/useSurpriseMe.test.ts` | **Verificar (no romper):** la asercion de linea 94 usa `MSG_ONBOARDING.surpriseSuccess(...)` (la constante, no un literal), por lo que sigue verde tras S1. Confirmar que no quede ningun literal `¡Sorpresa!` hardcodeado. **No requiere edicion.** | Verificacion |
+
+**Mock strategy:** sin cambios. `CronCard.test.tsx` ya mockea `formatRelativeTime`; las aserciones de duracion usan el `formatDuration` real (no mockeado). El cambio de tilde es solo en el prefijo del label, no en el formato del valor.
+
+**Criterio de aceptacion:**
+- Suite `CronCard` verde: `npm run test:run -- CronCard`.
+- Suite `useSurpriseMe` verde sin modificaciones.
+- No se introducen tests nuevos (copy sin logica condicional — excepcion documentada en `tests.md` seccion "Politica de Testing" > Excepciones).
+- Cobertura global del repo no baja (no se agrega codigo nuevo, solo strings).
+
+## Analytics
+
+Sin cambios. El evento `surprise_me` existente no se modifica.
+
+---
+
+## Offline
+
+Sin flujos de datos. El toast de `useSurpriseMe` se dispara client-side a partir de datos estaticos (`allBusinesses`), funciona identico online y offline. `CronCard` y `helpGroups` son render estatico.
+
+### Cache strategy
+
+| Dato | Estrategia | TTL | Storage |
+|------|-----------|-----|---------|
+| N/A — solo strings estaticos | — | — | — |
+
+### Writes offline
+
+| Operacion | Mecanismo | Conflict resolution |
+|-----------|-----------|-------------------|
+| Ninguna | — | — |
+
+### Fallback UI
+
+Ninguno. El toast `surpriseSuccess` ya se muestra en todos los environments (`toast.success`, no envuelto en `import.meta.env.DEV`).
+
+---
+
+## Accesibilidad y UI mobile
+
+Sin nuevos elementos interactivos. Mejora de copy que beneficia a screen readers (texto correcto en espanol, naming consistente).
+
+| Componente | Elemento | aria-label | Min touch target | Error state |
+|-----------|----------|------------|-----------------|-------------|
+| N/A — sin elementos interactivos nuevos | — | — | — | — |
+
+### Reglas
+- [x] No se agregan `<IconButton>`.
+- [x] No se introduce `<Typography onClick>`.
+- [x] No cambian touch targets.
+- [x] No hay componentes con fetch nuevos.
+- [x] No hay `<img>` con URL dinamica nueva.
+
+## Textos y copy
+
+| Texto | Donde | Regla aplicada |
+|-------|-------|----------------|
+| `¡Sorprendeme eligió ${name}!` | toast en `useSurpriseMe.ts` (via constante) | naming canonico (regla 3), exclamativa `¡...!` (regla 5), tilde en `eligió` (regla 2) |
+| `Para vos` | `helpGroups.tsx:74` (descripcion ayuda) | voseo (regla 1) |
+| `Última ejecución:` | `CronCard.tsx:48` (admin) | tildes (regla 2) |
+| `Duración:` | `CronCard.tsx:52` (admin) | tilde (regla 2) |
+
+### Reglas de copy aplicadas
+- Voseo: `Para vos` (no `Para ti`). Naming `Sorprendeme` (no `Sorpresa`/`Sorpréndeme`).
+- Tildes obligatorias: `Última`, `ejecución`, `Duración`, `eligió`.
+- Terminologia "comercios"/"reseñas" sin cambios.
+- `surpriseSuccess` ya centralizado en `src/constants/messages/onboarding.ts`. Los textos de ayuda y admin son de un solo call site → no requieren centralizacion (regla 4 #309).
+
+---
+
+## Success Criteria (reformulados — Sofia)
+
+1. El toast de "Sorprendeme" ya no contiene el termino prohibido `Sorpresa` (ni `Sorpréndeme` ni `Sorprendeme!`), y abre/cierra con `¡...!` (guard #309 reglas 3 y 5).
+2. La descripcion de ayuda del item `inicio` en `helpGroups.tsx:74` dice `Sección "Para vos"`, coincidiendo con el label real de `ForYouSection.tsx:51`.
+3. `CronCard` muestra `Última ejecución:` y `Duración:` con tildes, y `CronCard.test.tsx` queda verde con las **4 aserciones `Duración:`** actualizadas (lineas 52, 86, 97, 108).
+4. `npm run test:run` pasa completo (CronCard + useSurpriseMe sin regresiones) y la cobertura global no baja.
+5. **(reformulado)** Tras el fix, **ninguna de las 3 rutas editadas** (`onboarding.ts:4`, `helpGroups.tsx:74`, `CronCard.tsx:48,52`) aparece en el output de `npm run guards -- --guard 309`. NO se exige count global 0: el guard tiene **27 violaciones preexistentes fuera de scope** que este feature no toca. El criterio es la ausencia de estas 3 rutas en el output, no un baseline limpio.
+
+> **Nota sobre la cobertura de S2:** el cambio `"Para ti"` → `"Para vos"` **no tiene cobertura de guard** (el #309 R2 detecta tildes faltantes y naming baneado via diccionario, pero NO tiene regla de deteccion de tuteo peninsular `"Para ti"`). S2 se valida **solo por review manual** (confirmado por Sofia). Por eso S2 no figura en el SC#5 reformulado: solo S1 (`onboarding.ts:4`) y S3 (`CronCard.tsx:48,52`) son verificables por el guard 309.
+
+## Decisiones tecnicas
+
+1. **Forma del naming en S1.** Se elige `¡Sorprendeme eligió ${name}!` (sugerencia del issue ligeramente ajustada). El `!` de cierre va al final de la frase, NO pegado al naming, para no disparar la variante prohibida `Sorprendeme!` del guard #309 regla 3. La forma canonica `Sorprendeme` (sin tilde) coincide con el title del item `sorprendeme` en `helpGroups.tsx:79` y con la accion rapida del Inicio.
+
+2. **No se toca `useSurpriseMe.ts`.** El hook consume la constante; cambiar el valor centralizado es suficiente. Evita propagacion innecesaria y mantiene `useSurpriseMe.test.ts:94` verde via la constante (no via literal). **El fix de S1 NO rompe `useSurpriseMe.test.ts`** porque la asercion compara contra `MSG_ONBOARDING.surpriseSuccess(...)` (resuelve dinamicamente el nuevo valor), no contra un literal `¡Sorpresa!`.
+
+3. **S2 = 1 sola ocurrencia (correccion de scope de Sofia).** El PRD original citaba 2 ocurrencias de `"Para ti"` en `helpGroups.tsx` (lineas 74 y 88). **Verificado: solo hay 1**, en la linea 74 (dentro de la `description` del item `inicio`, en `Sección "Para ti"`). La linea 88 dice `"Tus intereses"`, NO `"Para ti"`. Tambien hay un `"Para ti"` en un comentario de codigo en `useTabNavigation.ts:8`, pero NO es user-facing y queda **fuera de scope**. S2 edita exactamente 1 string.
+
+4. **S2 sin cobertura de guard.** No existe regla de tuteo en el guard #309 (solo voseo positivo via diccionario, sin deteccion de `"Para ti"`). El cambio `"Para ti"` → `"Para vos"` se valida **solo por review manual** (confirmado por Sofia). No es regresion automatizable. Por eso queda excluido del SC#5.
+
+5. **Aserciones de test como parte del mismo cambio (S3b).** El fix de produccion de `CronCard` (S3) rompe `CronCard.test.tsx` porque las aserciones asertan `Duracion:` sin tilde. Actualizar las **4 aserciones `Duración:`** (lineas 52, 86, 97, 108) en el mismo commit NO es agregar tests nuevos: es mantener el suite verde (politica `tests.md`). No hay asercion sobre `Ultima ejecucion` en el test actual (verificado: el test solo aserta `Duracion:` en esas 4 lineas).
+
+---
+
+## Hardening de seguridad
+
+Sin superficie de seguridad nueva. Son tres cadenas de texto estatico (dos en componentes, una en constante de mensajes).
+
+### Firestore rules requeridas
+
+Ninguna. No hay escrituras ni lecturas.
+
+### Rate limiting
+
+| Coleccion | Limite | Implementacion |
+|-----------|--------|---------------|
+| N/A — sin escrituras | — | — |
+
+### Vectores de ataque mitigados
+
+| Ataque | Mitigacion | Archivo |
+|--------|-----------|---------|
+| Inyeccion via `name` interpolado en `surpriseSuccess(name)` | `name` proviene de `pick.name` (dato estatico de `businesses.json`, no input de usuario); MUI Snackbar lo renderiza como texto plano (no `dangerouslySetInnerHTML`) | `useSurpriseMe.ts` / `onboarding.ts` |
+
+- [x] No escribe a Firestore.
+- [x] No lee datos (no habilita scraping).
+- [x] No agrega campos a colecciones.
+
+---
+
+## Deuda tecnica: mitigacion incorporada
+
+| Issue | Que se resuelve | Paso del plan |
+|-------|----------------|---------------|
+| #346 (este) | Cierra los 3 hallazgos del `/health-check` de copy | Fases 1-3 |
+| #309 (guard copy) | Elimina la regresion: termino baneado `Sorpresa` (regla 3) + tildes faltantes `Última`/`ejecución`/`Duración` (regla 2). Detectables por `R2-tildes-prohibidas` | Fases 1 y 3 |
+| #311 (guard help-docs) | No agravar: S2 no agrega/quita entradas de `HELP_GROUPS`, mantiene la sincronizacion 1:1 con `features.md` | Fase 2 |
+
+No introduce deuda nueva.
+
+---
+
+## Validacion Tecnica
+
+(pendiente — sello de Diego)
+
+## Revisión Técnica (Gate Diego)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Revisor:** Diego (solution architect)
+
+**Observaciones:** Cobertura PRD→specs completa y verificada contra código (onboarding.ts:4, helpGroups.tsx:74 con 1 sola ocurrencia de "Para ti", CronCard.tsx:48,52, CronCard.test.tsx:52/86/97/108, useSurpriseMe.ts:44 y .test.ts:94 que aserta vía constante). Sin superficie de data model / rules / functions / offline. Patrones respetados (constante en constants/messages/, strings inline en componentes de dominio). Observaciones que el plan DEBE respetar: (1) las 4 aserciones de CronCard.test.tsx usan `getByText('Duracion: <valor>')` como string completo — deben editarse como string completo (`'Duración: 5.0s'`, `'Duración: 150ms'`, `'Duración: 250ms'`, `'Duración: 12.5s'`), no solo el prefijo, o el match rompe. (2) En helpGroups.tsx:74 cambiar ÚNICAMENTE `Sección "Para ti"` → `Sección "Para vos"`; NO tocar los términos canónicos `Sorprendeme` presentes en la misma línea. (3) S2 sin cobertura de guard (validación solo por review manual, confirmado). (4) S3 y S3b deben ir en el mismo commit para no dejar el suite en rojo.

--- a/docs/feat/fix/loading-infinito-authcontext-perfil/plan.md
+++ b/docs/feat/fix/loading-infinito-authcontext-perfil/plan.md
@@ -1,0 +1,93 @@
+# Plan de implementación: Loading infinito en AuthContext (#341)
+
+> Basado en `specs.md` (VALIDADO CON OBSERVACIONES por Sofia, 2026-06-10; VALIDADO CON OBSERVACIONES por Diego, ver specs.md:522-538).
+> **S1 (loading infinito) es independiente de S2 (avatar) y se mergea primero.** D1 fue RESUELTA por producto (Gonzalo) = camino (a) = SÍ: se permite user doc con `avatarId` sin `displayName` (specs.md:24-30). Camino (b) descartado.
+
+## Estrategia y staging de riesgo
+
+| Fase | Riesgo | Depende de | Mergeable solo |
+|------|--------|-----------|----------------|
+| F1 — Fix loading infinito (S1) | Bajo | — | ✅ Sí |
+| F2 — `avatarId` size cap en rules (S2a) | Bajo | — | ✅ Sí |
+| F3 — `updateUserAvatar` fallback setDoc + rule create solo-avatar (S2b) | Medio | F1/F2 | ✅ Sí, detrás de F1/F2 (D1 resuelta; depende de F2 por el cap de `avatarId`, no de una decisión abierta) |
+
+## Fase 1 — Fix del loading infinito (S1) `[independiente, prioridad máxima]`
+
+- **Archivo:** `src/context/AuthContext.tsx` (callback de `onAuthStateChanged`, ~líneas 96-124).
+- **Cambio:** envolver `await fetchUserProfileDoc(uid)` en `try/catch`; mover `setIsLoading(false)` a un bloque `finally`. En el `catch`: `logger.error(...)` (→ Sentry) y degradar a sesión sin perfil (no quedar colgado).
+- **Test:** `AuthContext.test.tsx` — nuevo caso: `fetchUserProfileDoc` rechaza (red/offline/regla) → `isLoading` termina en `false`, la app no queda en pantalla de carga; se emite `logger.error`.
+- **Commit:** `fix(#341): reset isLoading en finally del onAuthStateChanged (evita loading infinito)`
+- **Rollback:** revert del commit; sin migración ni cambio de datos.
+
+## Fase 2 — Límite `avatarId .size() <= 50` en rules (S2a) `[independiente de D1]`
+
+- **Archivo:** `firestore.rules` (bloque `users`, paths create y **update**).
+- **Cambio:** agregar `request.resource.data.avatarId.size() <= 50` tanto en create como en update (hoy solo valida `is string`). Observación Sofia: aplicar también al update existente.
+- **Test:** `tests/rules/users.rules.test.ts` — avatarId > 50 chars rechazado en create y update; <= 50 aceptado.
+- **Commit:** `fix(#341): cap avatarId a 50 chars en users rules (create + update)`
+- **Rollback:** revert del bloque de rules.
+
+## Fase 3 — `updateUserAvatar` con fallback de creación + rule create solo-avatar (S2b) `[D1 resuelta = camino (a)]`
+
+> D1 RESUELTA (specs.md:24-30): se permite user doc con `avatarId` sin `displayName`. Esta fase implementa el **camino (a)** confirmado. Depende de F1/F2 (cap de `avatarId`), no de una decisión abierta.
+
+- **Cambio 1 — service (`src/services/userProfile.ts`, `updateUserAvatar`, ~158-161):** branch de existencia con paridad con `updateUserDisplayName` — `setDoc(ref, { avatarId, createdAt: serverTimestamp() })` si el doc no existe, `updateDoc(ref, { avatarId })` si existe (specs.md:240-256). El fallback `setDoc` no debe lanzar `not-found`.
+- **Cambio 2 — rule de create solo-avatar (`firestore.rules`, bloque `users`, path create, reemplaza L28-45):** relajar la **obligatoriedad** de `displayName`/`displayNameLower` — **ambos ausentes (create solo-avatar) XOR ambos presentes-y-sincronizados** — manteniendo `hasOnly` (whitelist de 4 campos, sin agregar ninguno), ownership por doc ID, `createdAt` server-side, y la invariante #322 R12 (`displayNameLower == displayName.lower()`). Regla exacta en specs.md:117-160.
+- **Coordinación con #344:** ver nota al final del plan ("Coordinación con #344"). Capas distintas, no colisionan; ambos PRs tocan archivos del mismo dominio — quien mergee segundo rebasa y NO revierte el fallback `setDoc` de #341.
+- **Test:**
+  - `userProfile.test.ts` — `updateUserAvatar` sobre doc **inexistente** → ejecuta `setDoc`, no lanza `not-found`; sobre doc **existente** → ejecuta `updateDoc`.
+  - `users.rules.test.ts` — create solo-avatar (`{ avatarId, createdAt }`, ambos display ausentes) ACEPTADO; create con `displayNameLower` sin `displayName` DENEGADO; create con display sincronizado ACEPTADO.
+- **Commit:** `fix(#341): updateUserAvatar fallback setDoc + rule create solo-avatar (camino a de D1)`
+- **Rollback:** revert conjunto **service + rules** (un solo commit atómico para los dos cambios de la fase).
+
+## Test plan global
+
+- Unit: `AuthContext.test.tsx` (F1), `userProfile.test.ts` (F3 — branch existencia: inexistente→setDoc, existente→updateDoc).
+- Rules: `users.rules.test.ts` (F2 — cap avatarId; F3 — create solo-avatar aceptado, `displayNameLower` solo denegado).
+- Regresión: `npm run guards` verde; cobertura branches >= 80%.
+
+## Rollback global
+
+Cada fase es un commit atómico revertible. F1 y F2 no tocan datos. F3 toca service + rules en un solo commit — revert conjunto rules+servicio. Sin backfill ni migración de datos en ninguna fase.
+
+## Coordinación con #344 (offline custom tags / profile mutations)
+
+#341 y #344 tocan archivos del mismo dominio pero en **capas distintas que no colisionan**:
+
+- **#344 Fase 5** (`docs/feat/infra/offline-custom-tags-profile-mutations/plan.md:101-111`) agrega un guard `navigator.onLine` early-return en `setAvatarId`/`setDisplayName` **dentro de `AuthContext`** (callsite / context layer).
+- **#341 Fase 3** toca el **cuerpo de `updateUserAvatar`** (`src/services/userProfile.ts`, service layer): el branch de existencia con fallback `setDoc`.
+
+Solapamiento de archivos: #341 toca `AuthContext.tsx` (F1) + `userProfile.ts` (F3); #344 toca `AuthContext.tsx` (F5).
+
+**Regla para quien mergee segundo:** rebasar sobre el primero y **NO revertir** ni el fallback `setDoc` de #341 (en `userProfile.ts`) ni el guard `navigator.onLine` de #344 (en `AuthContext.tsx`). Son cambios complementarios en capas separadas. Dejar esta nota en el PR.
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Ciclo:** 2
+
+**Gates previos verificados:** PRD sellado por Sofia (VALIDADO CON OBSERVACIONES, prd.md:284-288). Specs sellado por Diego (VALIDADO CON OBSERVACIONES, specs.md:522-538). D1 RESUELTA por Gonzalo = camino (a) = SI (specs.md:24-30). El plan ahora refleja camino (a): Fase 3 reescrita (service `setDoc` branch + rule de create solo-avatar), camino (b) eliminado, tabla de staging actualizada (F3 ya no "bloqueada por D1").
+
+**Cerrado en esta iteracion (Ciclo 2):**
+- BLOQUEANTE Ciclo 1 "gates previos faltantes (Diego + D1)" → resuelto: ambos sellados.
+- BLOQUEANTE "Fase 3 con camino indefinido (a|b)" → resuelto: el plan fija camino (a). Fase 3 = service (`updateUserAvatar` setDoc/updateDoc branch, specs.md:240-256) + rule create solo-avatar (specs.md:117-160) + tests de ambos. Commit message fija "camino a de D1".
+- IMPORTANTE "rule de create solo-avatar no listada como cambio explicito de la fase" → resuelto: Cambio 2 de Fase 3 la lista; rollback conjunto service+rules.
+- IMPORTANTE "coordinacion con #344 (mismo dominio AuthContext.tsx + updateUserAvatar)" → resuelto: seccion propia con separacion por capas (context guard `navigator.onLine` de #344 F5 vs service body de #341 F3) y regla explicita de no-revert para quien mergee segundo.
+
+**Observaciones para el implementador:**
+
+1. **Orden de merge entre #341 y #344 — no es paralelo limpio, hay solape en `AuthContext.tsx`.** #341 F1 toca el callback de `onAuthStateChanged` (try/finally) y #344 F5 toca los callbacks `setAvatarId`/`setDisplayName` del MISMO archivo. Son bloques distintos del archivo (lineas 96-124 vs 134-145), no colisionan logicamente, pero git puede pedir rebase si ambos editan cerca. Quien mergee segundo rebasa y NO revierte: ni el try/finally de #341 F1, ni el fallback `setDoc` de #341 F3 (en `userProfile.ts`), ni el guard `navigator.onLine` de #344 F5. La nota ya esta en ambos planes; mantenerla en los PRs.
+
+2. **F1 mergea primero y solo — es el core del bug (loading infinito), bajo riesgo, sin tocar rules ni datos.** No esperar a F2/F3. Es el fix que la app necesita ya.
+
+3. **F3 es un solo commit atomico con DOS archivos (service + rules).** El rollback es conjunto. Asignar la fase a UN solo owner (nico: rules + service + sus tests) para no fragmentar el commit atomico. El test de rules (`users.rules.test.ts`) y el de service (`userProfile.test.ts`) van EN la fase, no diferidos.
+
+4. **Test plan integrado por fase, no al final.** F1 trae su test de AuthContext; F2 su test de cap avatarId; F3 sus tests de service+rules. Correcto — thanos no va a encontrar rules sin test.
+
+5. **Pre-push hook (tsc + vite build) y blocker de 400 lineas:** ningun archivo de produccion supera 400 (specs.md:507-518, AuthContext ~272, userProfile ~169). Sin riesgo de gate de tamano. `firestore.rules` no cuenta para el limite de TS.
+
+6. **Documentacion:** el PRD agenda (prd.md:176-180) posibles updates a `patterns.md` (nota auth/finally), `tests.md` (checkbox `users`), `firestore.md` (path create solo-avatar). El plan los referencia via specs pero NO los agenda como paso propio. No es bloqueante (el skill `/merge` corre el audit de docs y los exige ahi), pero conviene que el owner de F3 actualice `tests.md` (checkbox `users`) y `firestore.md` (nuevo path valido de create) en la misma fase para no chocar con el gate de docs del merge.
+
+**Listo para pasar a implementacion:** Si, con observaciones. Sin bloqueantes. Delegar F1 primero (merge solo), luego F2, luego F3 (un owner, commit atomico service+rules+tests). Coordinar el solape de `AuthContext.tsx` con #344 (rebase, no-revert).

--- a/docs/feat/fix/loading-infinito-authcontext-perfil/prd.md
+++ b/docs/feat/fix/loading-infinito-authcontext-perfil/prd.md
@@ -1,0 +1,288 @@
+# PRD: Loading infinito en AuthContext ante fallo de lectura de perfil
+
+**Feature:** loading-infinito-authcontext-perfil
+**Categoria:** fix
+**Fecha:** 2026-06-09
+**Issue:** #341
+**Prioridad:** Alta (correctness — bloqueo total de la app)
+
+---
+
+## Contexto
+
+El callback de `onAuthStateChanged` en `src/context/AuthContext.tsx` (lineas 96-124) hace `await fetchUserProfileDoc(firebaseUser.uid)` sin try/catch, y `setIsLoading(false)` (linea 121) esta fuera de cualquier guard. Como AuthContext envuelve toda la app y el splash de loading depende de `isLoading`, cualquier rechazo de ese `getDoc` (regla de Firestore que deniega, error de red transitorio, primer arranque offline) deja la app atascada en pantalla de loading permanente, sin posibilidad de recuperarse salvo recarga manual.
+
+## Problema
+
+- `fetchUserProfileDoc` esta en el camino critico de autenticacion pero **no** tiene proteccion contra fallos: ni en el service (`userProfile.ts:131-135`) ni en el caller (`AuthContext.tsx:104`). Si el `getDoc` rechaza, el callback async lanza y `setIsLoading(false)` nunca se ejecuta → loading infinito.
+- Contraste evidente: `fetchUserProfile` (la version agregada, `userProfile.ts:80-81`) **si** envuelve su `getDoc` con `.catch(() => null)` justamente porque sabe que la lectura del user doc puede fallar (las rules restringen lectura a owner/admin). La version del camino critico no heredo esa proteccion.
+- Bug relacionado: `updateUserAvatar` (`userProfile.ts:158-161`) usa `updateDoc` sin fallback a `setDoc`, a diferencia de `updateUserDisplayName` (`userProfile.ts:141-153`) que si crea el doc si no existe. Si un usuario cambia el avatar antes de que exista su user doc, `updateDoc` lanza `not-found`, el optimistic update se revierte (`AuthContext.tsx:142`) y el avatar nunca persiste.
+
+## Solucion
+
+### S1 — Blindar el camino critico de auth (loading infinito)
+
+El callback de `onAuthStateChanged` debe garantizar que `setIsLoading(false)` se ejecute siempre, pase lo que pase con la lectura del perfil.
+
+- Envolver la lectura del perfil (`fetchUserProfileDoc`) en try/catch dentro del callback, y mover `setIsLoading(false)` a un `finally`. Tambien envolver el branch del `signInAnonymously` (que hoy ya tiene su propio try/catch interno) de modo que el `finally` cubra ambas ramas.
+- Defense-in-depth en el service: agregar `.catch` en `fetchUserProfileDoc` para que devuelva `null` ante fallo, igual que `fetchUserProfile` ya hace. Esto alinea ambas funciones del service con el mismo contrato ("la lectura del user doc es best-effort, puede fallar"). El error se loguea via `logger.error` (siempre, nunca dentro de `if (DEV)` — patron #294) para que Sentry lo capture.
+- Resultado esperado: ante un fallo de lectura de perfil, la app entra igual (sin `displayName`/`avatarId` cargados desde el doc; se rehidrataran en el proximo auth state change o cuando el usuario los setee). Nunca queda en loading infinito.
+
+Patron de referencia: el branch de `signInAnonymously` (AuthContext.tsx:114-118) ya demuestra el estilo de manejo de error con `logger.error` sin re-throw. La diferencia es que ahi el error no rompia el flujo porque estaba aislado; el de `fetchUserProfileDoc` esta en el path principal sin aislamiento.
+
+### S2 — `updateUserAvatar` con fallback setDoc (paridad con updateUserDisplayName)
+
+`updateUserAvatar` debe seguir el mismo patron que `updateUserDisplayName`: chequear si el doc existe y hacer `setDoc` (con `createdAt: serverTimestamp()`) si no, o `updateDoc` si si.
+
+**Restriccion confirmada en `firestore.rules` (lineas 22-43):** la regla de `create` de `users` HOY exige `displayName is string` con `size() > 0` y `<= 30`, ademas de `displayNameLower == displayName.lower()`. Es decir, un `setDoc` con solo `avatarId` + `createdAt` (sin displayName) seria **DENEGADO** por las rules. Esto es un dato duro, no una hipotesis. Por lo tanto el path "doc no existe → crear" de `updateUserAvatar` NO puede crear un doc solo-avatar bajo las rules actuales.
+
+Caminos posibles (decision de producto + tecnica, ver mas abajo):
+
+- **(a) Relajar la regla de create** para permitir un create solo-avatar: `displayName`/`displayNameLower` opcionales en el create siempre que ambos esten ausentes o ambos presentes-y-sincronizados. Mantiene `hasOnly` estricto y la invariante #322 R12. Es el camino preferido por el PRD por ser el mas limpio (un usuario puede legitimamente tener avatar antes que nombre).
+- **(b) NO crear el doc en `updateUserAvatar`**: si el doc no existe, dejar el optimistic update en memoria (UI muestra el avatar) y persistirlo recien cuando exista displayName (o cuando el usuario lo setee). En este caso `updateUserAvatar` NO alcanza paridad total con `updateUserDisplayName` — solo evita el throw `not-found` capturando el error y dejando el estado optimista. El avatar se persiste en la proxima oportunidad.
+
+**Decision requerida (Gonzalo):** ¿es valido que exista un user doc con avatarId pero sin displayName? Si SI → camino (a). Si NO (el displayName es el campo primario y el doc no debe existir sin el) → camino (b). El PRD recomienda (a) pero la decision afecta el modelo de datos y debe confirmarse antes de specs. Ver seccion "Decisiones pendientes".
+
+### S4 — Aclaracion de comportamiento observable post-fix (auth transicional + multi-tab)
+
+- **Estado transicional de auth:** tras el fix, si la lectura de perfil falla, `displayName`/`avatarId` quedan `null` momentaneamente. La app no re-dispara la lectura automaticamente (out of scope el retry). Se rehidratan en el proximo `onAuthStateChanged` (ej: token refresh) o cuando el usuario abre Ajustes/Perfil. Esto es identico al estado de un anonimo nuevo, ya soportado.
+- **Multi-tab / multi-device:** el fix no introduce writes que compitan entre tabs mas alla de los ya existentes (`updateUserAvatar` ya existia). Dos tabs que escriben avatar concurrentemente es last-write-wins en un solo campo idempotente — no es un caso nuevo introducido por este PRD.
+- **Sin loops de billing:** el fix solo agrega un `getDoc` que ya existia (no se agregan reads) y, en el camino (a)/(b), a lo sumo un `getDoc` de existencia en `updateUserAvatar` (que ya hace `updateUserDisplayName`). No hay listener nuevo ni trigger nuevo.
+
+### S3 — UX: la app degrada con gracia, no bloquea
+
+- No se agrega UI nueva. El comportamiento observable es: la app carga normalmente aunque el perfil no se pueda leer. `displayName`/`avatarId` quedan en `null` hasta que esten disponibles, lo que ya es un estado soportado por la app (usuarios anonimos nuevos arrancan asi).
+- No hay cambios en SideMenu, AppShell ni ningun componente de layout. Es un fix acotado a `AuthContext.tsx` + `userProfile.ts` + `firestore.rules`.
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| S1: try/finally en callback de onAuthStateChanged | Alta | S |
+| S1: `.catch` defensivo en `fetchUserProfileDoc` | Alta | S |
+| S2: fallback setDoc en `updateUserAvatar` | Media | S |
+| S2: ajustar `firestore.rules` users create para create solo-avatar | Media | S |
+| Tests: AuthContext loading-false-on-profile-error | Alta | S |
+| Tests: userProfile updateUserAvatar create/update paths | Media | S |
+| Tests: rules users allow+deny create solo-avatar | Media | S |
+
+**Esfuerzo total estimado:** S
+
+---
+
+## Out of Scope
+
+- Cambios de UI/UX visibles (banners de error de auth, retry button, etc.). El fix es de correctness, no de presentacion.
+- Refactor del split AuthStateContext/AuthActionsContext o cualquier reorganizacion estructural de AuthContext.
+- Retry/backoff de la lectura de perfil. El fix solo garantiza que la app no se cuelgue; no reintenta la lectura proactivamente (se rehidrata en el proximo auth state change).
+- Cambios en `fetchUserProfile` (la version de agregacion del perfil publico) — ya tiene su `.catch`, no se toca.
+
+---
+
+## Tests
+
+Politica del proyecto: cobertura >= 80% del codigo nuevo/modificado, paths condicionales cubiertos, side effects verificados (`docs/reference/tests.md`).
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `src/context/AuthContext.test.tsx` (existe, 35 casos) | Context | Nuevo caso: `fetchUserProfileDoc` rechaza → `isLoading` queda `false` (no infinito). Caso: rechaza → `displayName`/`avatarId` quedan `null` y la app no crashea. Verificar `logger.error` invocado. |
+| `src/services/__tests__/userProfile.test.ts` (existe, 8 casos) | Service | `fetchUserProfileDoc` con `getDoc` que rechaza → devuelve `null` (no lanza). `updateUserAvatar`: doc existe → `updateDoc`; doc no existe → `setDoc` con `createdAt`. |
+| `tests/rules/users.rules.test.ts` (existe, harness #332) | Rules | ALLOW: owner crea user doc solo con `avatarId` + `createdAt` (sin displayName). DENY: create con campo fuera del `hasOnly`. Marcar checkbox `users` allow+deny en inventario de tests.md. |
+
+### Criterios de testing
+
+- Cobertura >= 80% del codigo nuevo
+- Tests de validacion para todos los inputs del usuario
+- Todos los paths condicionales cubiertos (profile null, profile rechaza, doc existe/no existe)
+- Side effects verificados (`logger.error` se llama, `setIsLoading(false)` siempre corre, optimistic revert de avatar solo en error real)
+
+---
+
+## Seguridad
+
+Items relevantes del checklist (`docs/reference/security.md`):
+
+- [ ] Si se toma el camino (a): el nuevo path de create de `users` (solo-avatar) mantiene `keys().hasOnly(['displayName','displayNameLower','avatarId','createdAt'])` como whitelist estricta — no agrega campos. La regla actual (firestore.rules:29) ya tiene este `hasOnly`; lo que cambia es relajar la **obligatoriedad** de `displayName`, no la whitelist.
+- [ ] `createdAt == request.time` (timestamp server-side) se valida en el create solo-avatar.
+- [ ] Ownership: `request.auth.uid == userId` (doc ID) se mantiene en el create.
+- [ ] `logger.error` del catch NUNCA dentro de `if (import.meta.env.DEV)` (rompe Sentry — #294).
+- [ ] El fix no expone datos de otros usuarios: la lectura sigue restringida a owner/admin; solo cambia el manejo de su fallo.
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| `users` create solo-avatar (path nuevo) | Crear docs `users/{otroUid}` con avatarId arbitrario | Regla ya valida `request.auth.uid == userId` (doc ID) — el create solo-avatar debe heredar el mismo guard, no relajarlo |
+| `updateUserAvatar` (write) | Spam de writes a `users` | `users` no tiene trigger de rate limit hoy; el avatar es 1 campo idempotente por usuario. El riesgo es bajo (no es coleccion de items). No se introduce nueva superficie de items. |
+
+El feature escribe a Firestore (`users` collection, path de create nuevo):
+
+- [ ] Create rule tiene `hasOnly()` con whitelist de campos permitidos (ya existe: `['displayName','displayNameLower','avatarId','createdAt']`).
+- [ ] CADA campo en `hasOnly()` tiene validacion de tipo. Verificar que `avatarId` valide `is string` y tenga limite de longitud razonable en la regla (los avatarIds son IDs cortos predefinidos — validar `is string` y `.size() <= 50`).
+- [ ] (camino a) El create solo-avatar NO debe permitir saltear la sincronizacion `displayNameLower == displayName.lower()` (#322 R12): si el create no incluye `displayName`, tampoco debe incluir `displayNameLower`; la regla debe permitir ambos ausentes XOR ambos presentes-y-sincronizados en el create solo-avatar. Confirmado que la regla actual exige ambos presentes (firestore.rules:30-43) — el cambio debe ser preciso para no abrir un hueco de desincronizacion.
+- [ ] `users` no requiere trigger de rate limit nuevo (no es coleccion de items escribibles masivamente; 1 doc por usuario, campos idempotentes).
+
+`users` NO es userSettings — no aplica el checklist de userSettings. `avatarId` ya existe en el converter (`userConverters.ts`) y en las rules; no se agrega campo nuevo.
+
+---
+
+## Deuda tecnica y seguridad
+
+Issues abiertos consultados: no existen labels `security` ni `tech debt` poblados; los issues de deuda usan label `enhancement` con prefijo "Tech debt:". Issues relevantes abiertos: #342 (deps vulnerables + secrets), #343-#349 (varios tech debt), #168 (Vite 8/ESLint 10).
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| #344 (offline — profile mutations sin offline guard) | afecta | `setAvatarId`/`updateUserAvatar` es exactamente una "profile mutation". Coordinar para no pisar: este PRD agrega el fallback setDoc; #344 deberia agregar el offline guard sobre el mismo path. Documentar el cruce en specs. |
+| #322 R12 (`displayNameLower == displayName.lower()` en users rules) | afecta | El nuevo path de create solo-avatar NO debe romper esta invariante. La regla debe permitir create sin `displayName`/`displayNameLower` (ambos ausentes) sin abrir un hueco donde se envie `displayNameLower` desincronizado. |
+| #332 (rules tests harness) | mitiga | Aprovechar el harness existente (`users.rules.test.ts`) para agregar el test allow+deny del create solo-avatar y marcar el checkbox `users` en el inventario. |
+
+### Mitigacion incorporada
+
+- Alinear `fetchUserProfileDoc` con el contrato best-effort de `fetchUserProfile` (ambas funciones del mismo service tendran el mismo `.catch` defensivo) — elimina la inconsistencia que origino el bug.
+- `updateUserAvatar` alcanza paridad con `updateUserDisplayName` (ambos crean el doc si no existe) — elimina la divergencia de comportamiento entre dos mutadores del mismo doc.
+
+---
+
+## Robustez del codigo
+
+### Checklist de hooks async
+
+- [ ] El `useEffect` de `onAuthStateChanged` ya retorna `unsubscribe` (cleanup). El callback async interno NO debe quedar sin `finally` para `setIsLoading(false)` — este es el core del fix.
+- [ ] El callback de auth corre en respuesta a un listener (no es un fetch en mount); no necesita guard `cancelled` adicional, pero el `setIsLoading(false)` en `finally` es obligatorio.
+- [ ] `setAvatarId` (handler async) ya tiene try/catch con revert optimista — verificar que tras el fix de `updateUserAvatar` (que ahora puede hacer `setDoc`) el revert siga siendo correcto.
+- [ ] Funciones exportadas: `fetchUserProfileDoc` y `updateUserAvatar` se usan fuera del archivo (AuthContext) — mantener export.
+- [ ] `logger.error` del catch NUNCA dentro de `if (import.meta.env.DEV)` (Sentry — #294).
+- [ ] Archivos no superan 300/400 lineas: `AuthContext.tsx` y `userProfile.ts` estan holgados; el cambio es minimo.
+
+### Checklist de observabilidad
+
+- [ ] El `catch` del callback de auth y el `.catch` de `fetchUserProfileDoc` loguean via `logger.error` (Sentry en prod). Esto da visibilidad de cuantas veces falla la lectura de perfil en el camino critico — dato que hoy se pierde silenciosamente al colgarse la app.
+- [ ] No se agregan `trackEvent` nuevos (no es necesario para un fix de correctness).
+- [ ] `fetchUserProfileDoc` ya usa `measuredGetDoc('userProfile_doc', ...)` — la instrumentacion de perf se mantiene.
+
+### Checklist offline
+
+- [ ] El primer arranque offline es uno de los escenarios que dispara el bug (el `getDoc` rechaza por falta de red). El fix S1 lo cubre: la app entra igual.
+- [ ] `updateUserAvatar` (write): coordinar con #344 para el offline guard. Este PRD no agrega el guard pero no lo bloquea.
+- [ ] El `catch` muestra error solo via `logger.error` (no toast) — es correcto: la falla de lectura de perfil en el arranque no debe interrumpir al usuario con un toast; la app degrada con gracia.
+
+### Checklist de documentacion
+
+- [ ] No hay secciones nuevas de HomeScreen, analytics events, ni tipos nuevos.
+- [ ] `docs/reference/patterns.md`: considerar agregar nota al patron "No silent .catch" / auth, explicitando que el camino critico de auth debe tener `finally` para `setIsLoading`.
+- [ ] `docs/reference/tests.md`: marcar checkbox `users` allow+deny en el inventario de rules tests tras agregar el test del create solo-avatar.
+- [ ] `docs/reference/firestore.md`: actualizar si el create solo-avatar implica documentar un nuevo path valido de create de `users`.
+
+---
+
+## Offline
+
+### Data flows
+
+| Operacion | Tipo (read/write) | Estrategia offline | Fallback UI |
+|-----------|-------------------|-------------------|-------------|
+| `fetchUserProfileDoc` en arranque | read | Firestore offline persistence (prod). Si falla igual → `.catch` devuelve `null`, app entra sin perfil | Ninguna (degrada silenciosamente, sin loading infinito) |
+| `updateUserAvatar` | write | Hoy sin offline queue. Coordinar con #344 para `withOfflineSupport`. Este PRD: optimistic update local + revert si falla | Avatar se revierte si el write falla (comportamiento actual, mantenido) |
+
+### Checklist offline
+
+- [ ] Reads de Firestore: usan persistencia offline (prod, ya configurada). El fix garantiza que un fallo de lectura no cuelga la app.
+- [ ] Writes: `updateUserAvatar` tiene optimistic UI + revert. Offline queue queda para #344.
+- [ ] APIs externas: N/A (solo Firestore + Firebase Auth).
+- [ ] UI: no se agrega indicador offline nuevo. El arranque offline ahora funciona en vez de colgarse.
+- [ ] Datos criticos: la app no depende del user doc para arrancar — el fix lo confirma como best-effort.
+
+### Esfuerzo offline adicional: S
+
+---
+
+## Modularizacion y % monolitico
+
+### Checklist modularizacion
+
+- [ ] Logica en service/context: el manejo de error vive en `userProfile.ts` (service) y `AuthContext.tsx` (context, capa permitida para usar servicios). No se agrega logica a componentes de layout.
+- [ ] No se agregan componentes nuevos.
+- [ ] No se agregan `useState` de logica de negocio a AppShell ni SideMenu.
+- [ ] Sin props noop nuevas.
+- [ ] AuthContext usa el service `userProfile.ts` para writes/reads — no importa `firebase/firestore` directamente para esta operacion (respeta la boundary; el SDK vive en el service).
+- [ ] `firestore.rules` no es codigo de componente.
+- [ ] Ningun archivo nuevo (solo modificaciones acotadas a 3 archivos existentes).
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | = | No se tocan componentes; solo context + service + rules |
+| Estado global | = | Mismo estado de AuthContext (`isLoading`), sin nuevos campos |
+| Firebase coupling | = | El SDK ya vive en `userProfile.ts`; el fix no mueve imports de Firebase |
+| Organizacion por dominio | = | Cambios en archivos de su dominio correcto (context/, services/, rules) |
+
+---
+
+## Accesibilidad y UI mobile
+
+No se agregan componentes interactivos ni copy nuevo. El fix es de correctness en la capa de datos/auth.
+
+### Checklist de accesibilidad
+
+- [ ] N/A — sin nuevos elementos interactivos.
+- [ ] El splash de loading existente sigue igual; el unico cambio es que ahora siempre termina (deja de mostrarse) en vez de colgarse.
+
+### Checklist de copy
+
+- [ ] N/A — sin copy user-facing nuevo. Los mensajes de `logger.error` son internos (no user-facing), pero deben quedar claros para debugging (ej: `'[AuthContext] fetchUserProfileDoc failed on auth state change:'`).
+
+---
+
+## Success Criteria
+
+1. Cuando `fetchUserProfileDoc` rechaza (rules deny, red, offline en arranque), `isLoading` pasa a `false` y la app renderiza normalmente — nunca queda en loading infinito.
+2. El fallo de lectura de perfil queda registrado via `logger.error` (visible en Sentry en prod), en vez de perderse silenciosamente.
+3. `updateUserAvatar` ya no lanza `not-found` sin manejar cuando el user doc no existe: segun el camino elegido (a o b), o crea el doc via `setDoc`, o deja el estado optimista sin throw no manejado. El avatar nunca queda en un estado donde el throw revierte la UI sin explicacion.
+4. (Si camino a) La regla de `users` para el create solo-avatar mantiene la whitelist `hasOnly` estricta, ownership por doc ID, `createdAt` server-side, y la invariante `displayNameLower` (#322 R12) sin abrir nuevos huecos — verificado con test allow+deny.
+5. Cobertura >= 80% del codigo modificado: tests de AuthContext (loading-false-on-error), userProfile (create/update + catch defensivo) y, si camino a, rules (allow+deny create solo-avatar).
+
+---
+
+## Decisiones pendientes (Gonzalo)
+
+| # | Decision | Impacto si no se resuelve antes de specs |
+|---|----------|------------------------------------------|
+| D1 | ¿Es valido un user doc con `avatarId` sin `displayName`? (camino a vs b en S2) | El implementador inventaria el modelo de datos. Camino (a) requiere tocar `firestore.rules` + test rules; camino (b) no toca rules pero deja `updateUserAvatar` sin paridad total. Confirmado que la regla actual DENIEGA un create solo-avatar (firestore.rules:30-43). |
+
+D1 es la unica decision de producto abierta. S1 (el fix del loading infinito, que es el core del issue) NO depende de D1 y puede implementarse de forma independiente. S2 depende de D1.
+
+---
+
+## Validacion Funcional
+
+**Analista**: Sofia (checklist funcional aplicado por prd-writer; agente Sofia no spawneable en este contexto de ejecucion)
+**Fecha**: 2026-06-09
+**Estado**: VALIDADO CON OBSERVACIONES
+
+### Hallazgos cerrados en esta iteracion
+
+- BLOQUEANTE: "S2 asume que el create solo-avatar es posible bajo las rules actuales" → resuelto: se verifico `firestore.rules:30-43` y se confirmo que el create DENIEGA payloads sin `displayName`. S2 reescrito con caminos (a)/(b) explicitos y se levanto D1 como decision de producto.
+- IMPORTANTE: "Estado transicional de auth no especificado (que ve el usuario mientras displayName/avatarId estan null)" → resuelto en S4: comportamiento identico a anonimo nuevo, rehidratacion en proximo auth state change, sin retry (out of scope explicito).
+- IMPORTANTE: "Multi-tab / multi-device y billing no evaluados" → resuelto en S4: el fix no introduce writes competitivos nuevos, ni reads/listeners/triggers nuevos. `updateUserAvatar` ya existia.
+- OBSERVACION: "Sin metrica de exito post-deploy observable" → resuelto: Success Criteria #2 define el `logger.error`→Sentry como senal observable de cuantas veces falla la lectura de perfil en el camino critico (antes se perdia con la app colgada).
+
+### Observaciones abiertas para el implementador
+
+- D1 (modelo de datos avatar-sin-displayName) debe resolverse con Gonzalo antes de implementar S2. S1 no esta bloqueado por D1 — puede ir primero.
+- Coordinar el path de `updateUserAvatar` con #344 (offline guard de profile mutations) para no pisar el mismo callsite.
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** D1 (avatar sin displayName) abierta — S1 (loading) es independiente y puede ir primero. Aplicar avatarId .size()<=50 tambien al update. Coordinar con #344 (mismo callsite).

--- a/docs/feat/fix/loading-infinito-authcontext-perfil/specs.md
+++ b/docs/feat/fix/loading-infinito-authcontext-perfil/specs.md
@@ -1,0 +1,538 @@
+# Specs: Loading infinito en AuthContext ante fallo de lectura de perfil
+
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-10
+**Issue:** #341
+
+---
+
+## Resumen ejecutivo
+
+Fix de correctness en el camino critico de autenticacion. Tres archivos:
+`src/context/AuthContext.tsx`, `src/services/userProfile.ts`, `firestore.rules`.
+Sin UI nueva, sin tipos nuevos, sin colecciones nuevas.
+
+El trabajo se separa en dos tracks **independientes** (alineado con la
+observacion de Sofia):
+
+- **S1 (loading infinito)** — core del issue. NO depende de la decision D1.
+  Se implementa y mergea **solo y primero**.
+- **S2 (`updateUserAvatar` fallback + rule)** — depende de la decision de
+  producto D1 (¿user doc con `avatarId` sin `displayName` valido?). Se
+  implementa en una fase posterior, gateada por D1. NO bloquea a S1.
+
+> **Decision D1 (Gonzalo) — RESUELTA 2026-06-12: Camino (a) = SI.** Es valido
+> un user doc con `avatarId` sin `displayName`. S2 relaja la regla de create
+> para permitir create solo-avatar (displayName/displayNameLower ausentes XOR
+> ambos presentes-y-sincronizados; preserva hasOnly, ownership, createdAt
+> server-side e invariante #322 R12). El limite `avatarId .size() <= 50` se
+> aplica en create + update. Camino (b) descartado. S1 ya estaba desbloqueado
+> (no depende de D1); con D1 resuelta, S2 queda habilitado para implementacion.
+
+---
+
+## Modelo de datos
+
+No se agregan colecciones ni campos. La coleccion `users` y el campo
+`avatarId` ya existen (ver `src/config/converters/userConverters.ts` y
+`firestore.rules:22-77`).
+
+Tipos involucrados (existentes, no se modifican):
+
+- `UserProfile` (`src/types/user.ts`) — devuelto por `fetchUserProfileDoc`.
+- `UserProfileData` (`src/services/userProfile.ts`) — agregacion del perfil
+  publico, NO se toca.
+
+El contrato semantico que cambia (no el shape): `fetchUserProfileDoc` pasa a
+ser **best-effort** — puede devolver `null` ante fallo de lectura, igual que
+`fetchUserProfile` ya lo es (`userProfile.ts:80-81`). No es un cambio de tipo:
+la firma `Promise<UserProfile | null>` ya admite `null`; lo que cambia es que
+ahora `null` tambien cubre el caso "la lectura fallo" (antes solo cubria
+"el doc no existe").
+
+### Estado de auth tras fallo de lectura (S4, observable)
+
+Cuando `fetchUserProfileDoc` falla, `displayName`/`avatarId` quedan `null`
+momentaneamente — estado identico al de un anonimo nuevo, ya soportado por la
+app. No hay re-fetch automatico (retry fuera de scope). Rehidratacion en el
+proximo `onAuthStateChanged` (token refresh) o cuando el usuario setee nombre/
+avatar. La app renderiza normalmente; `isLoading` siempre llega a `false`.
+
+> **Read-back de doc solo-avatar (SOLO si D1 = camino (a)).** Tras un
+> `setDoc({ avatarId, createdAt })` solo-avatar, cuando AuthContext re-lee el doc
+> via `fetchUserProfileDoc` (que usa `userProfileConverter`), el `fromFirestore`
+> devuelve `displayName: undefined` (el campo no esta en el doc). El caller lo
+> normaliza con `setDisplayNameState(profile.displayName || null)` → queda
+> `null`. **Estado ya soportado, no crashea** (`toDate(createdAt)` tambien esta
+> cubierto). Constancia para el implementador: NO es necesario "arreglar" el
+> converter ni agregar defaults; `displayName=null` es el resultado esperado y
+> correcto del read-back de un doc solo-avatar.
+
+## Firestore Rules
+
+> **Solo aplica si D1 = camino (a).** Si D1 = camino (b), NO se tocan las rules
+> y esta seccion se omite en implementacion (excepto el limite `.size() <= 50`
+> de `avatarId`, ver mas abajo, que se aplica **independientemente de D1**).
+
+### Limite `avatarId .size() <= 50` (independiente de D1)
+
+El checklist de seguridad del PRD (L125) exige validar longitud de `avatarId`.
+Hoy la regla solo valida `is string` en create (L44) y update (L61). Se agrega
+`.size() <= 50` en **ambos** paths (create + update), conforme la observacion
+de Sofia: el limite NO debe quedar solo en el create nuevo.
+
+Create (`firestore.rules:44`), reemplazar:
+
+```
+&& (!('avatarId' in request.resource.data) || request.resource.data.avatarId is string)
+```
+
+por:
+
+```
+&& (!('avatarId' in request.resource.data)
+    || (request.resource.data.avatarId is string
+        && request.resource.data.avatarId.size() <= 50))
+```
+
+Update (`firestore.rules:61`), reemplazar:
+
+```
+&& (!('avatarId' in request.resource.data) || request.resource.data.avatarId is string)
+```
+
+por:
+
+```
+&& (!('avatarId' in request.resource.data)
+    || (request.resource.data.avatarId is string
+        && request.resource.data.avatarId.size() <= 50))
+```
+
+> Nota: el update usa `request.resource.data.avatarId` (no `affectedKeys`)
+> porque el doc resultante siempre contiene `avatarId` si el cliente lo escribe;
+> el guard `'avatarId' in request.resource.data` es suficiente. Este patron
+> matchea el existente en L61.
+
+### Create solo-avatar (SOLO si D1 = camino (a))
+
+Hoy el create (`firestore.rules:28-45`) exige `displayName` presente, `> 0`,
+`<= 30`, charset, y `displayNameLower == displayName.lower()`. Un create con
+solo `avatarId` + `createdAt` es **DENEGADO** (confirmado, test #2 en
+`users.rules.test.ts:88` cubre el deny actual).
+
+Camino (a) relaja la **obligatoriedad** de `displayName`/`displayNameLower`
+manteniendo: `hasOnly` estricto, ownership por doc ID, `createdAt` server-side,
+y la invariante #322 R12 (`displayNameLower == displayName.lower()`). La regla
+debe permitir **ambos ausentes XOR ambos presentes-y-sincronizados** — nunca
+`displayNameLower` solo (cierra el hueco de desincronizacion B5).
+
+Nueva regla de create propuesta (reemplaza L28-45):
+
+```
+allow create: if request.auth != null && request.auth.uid == userId
+  && request.resource.data.keys().hasOnly(['displayName', 'displayNameLower', 'avatarId', 'createdAt'])
+  // displayName y displayNameLower: ambos ausentes (create solo-avatar) XOR
+  // ambos presentes-y-sincronizados. Nunca uno sin el otro.
+  && (
+    (!('displayName' in request.resource.data) && !('displayNameLower' in request.resource.data))
+    || (
+      request.resource.data.displayName is string
+      && request.resource.data.displayName.size() > 0
+      && request.resource.data.displayName.size() <= 30
+      && request.resource.data.displayName.matches('^[A-Za-z0-9À-ÿ_-]([A-Za-z0-9À-ÿ ._-]*[A-Za-z0-9À-ÿ_-])?$')
+      && request.resource.data.displayNameLower is string
+      && request.resource.data.displayNameLower == request.resource.data.displayName.lower()
+    )
+  )
+  // create solo-avatar requiere al menos avatarId (no permitir doc vacio
+  // solo-createdAt sin proposito)
+  && ('avatarId' in request.resource.data || 'displayName' in request.resource.data)
+  && (!('avatarId' in request.resource.data)
+      || (request.resource.data.avatarId is string
+          && request.resource.data.avatarId.size() <= 50))
+  && request.resource.data.createdAt == request.time;
+```
+
+> Invariante preservada: si `displayName` esta ausente, `displayNameLower`
+> tambien debe estarlo (rama 1). No existe forma de enviar `displayNameLower`
+> sin `displayName` valido y sincronizado. El `hasOnly` sigue siendo la misma
+> whitelist de 4 campos — no se agrega ningun campo.
+
+### Rules impact analysis
+
+| Query (service file) | Collection | Auth context | Rule que la permite | Cambio? |
+|---------------------|------------|-------------|---------------------|---------|
+| `fetchUserProfileDoc(uid)` (`userProfile.ts`) | users | owner leyendo su doc | `allow read: request.auth.uid == userId` | No |
+| `updateUserAvatar` updateDoc (`userProfile.ts`) | users | owner editando su doc | `allow update` (L46-76) | No (avatarId ya en `affectedKeys` whitelist) |
+| `updateUserAvatar` setDoc create solo-avatar (S2, camino a) | users | owner creando su doc | `allow create` modificado (arriba) | **SI — solo si D1=(a)** |
+
+> El fix de S1 NO agrega ninguna query nueva: `fetchUserProfileDoc` ya existia.
+> Solo cambia el manejo de su fallo. No hay riesgo de permission error nuevo.
+
+### Field whitelist check
+
+| Collection | Campo nuevo/modificado | En create `hasOnly()`? | En update `affectedKeys().hasOnly()`? | Cambio? |
+|-----------|------------------------|------------------------|---------------------------------------|---------|
+| users | avatarId (limite `.size()<=50`) | SI (ya en whitelist) | SI (ya en whitelist) | NO whitelist; SI validacion de tamaño en ambos paths |
+| users | displayName/displayNameLower opcionales en create (camino a) | SI (ya en whitelist) | N/A | NO whitelist; SI obligatoriedad relajada |
+
+> No se agrega ningun campo nuevo al `hasOnly`. El cambio es de **validacion**
+> (tamaño de avatarId, obligatoriedad de displayName), no de whitelist.
+
+## Cloud Functions
+
+Ninguna. El fix no agrega triggers, scheduled ni callables. `users` no requiere
+trigger de rate limit (1 doc por usuario, campos idempotentes — confirmado en
+PRD L120/L127).
+
+## Seed Data
+
+No aplica. No se crean colecciones nuevas ni campos requeridos nuevos. La
+coleccion `users` y `avatarId` ya existen en los seeds actuales.
+
+## Componentes
+
+Ninguno nuevo ni modificado. El fix vive en context + service + rules. Sin UI.
+
+### Mutable prop audit
+
+No aplica. No hay componentes que reciban data como prop y la muten.
+
+## Textos de usuario
+
+No hay copy user-facing nuevo. Los unicos strings nuevos son mensajes de
+`logger.error` (internos, no visibles al usuario, van a Sentry en prod):
+
+| Texto | Donde se usa | Notas |
+|-------|-------------|-------|
+| `[AuthContext] fetchUserProfileDoc failed on auth state change:` | catch en callback de `onAuthStateChanged` | interno, Sentry — no user-facing |
+| `[userProfile] fetchUserProfileDoc getDoc failed:` | `.catch` defensivo en `fetchUserProfileDoc` | interno, Sentry — no user-facing |
+
+## Hooks
+
+Ninguno nuevo. No se modifica ningun hook.
+
+## Servicios
+
+### `src/services/userProfile.ts`
+
+#### `fetchUserProfileDoc(uid: string): Promise<UserProfile | null>` (S1 — modificado)
+
+Agregar `.catch` defensivo al `measuredGetDoc`, alineando el contrato con
+`fetchUserProfile` (L80-81). Devuelve `null` ante fallo en vez de re-throw.
+
+```ts
+export async function fetchUserProfileDoc(uid: string): Promise<UserProfile | null> {
+  const ref = doc(db, COLLECTIONS.USERS, uid).withConverter(userProfileConverter);
+  const snap = await measuredGetDoc('userProfile_doc', ref)
+    .catch((err) => {
+      logger.error('[userProfile] fetchUserProfileDoc getDoc failed:', err);
+      return null;
+    });
+  return snap?.exists() ? snap.data() : null;
+}
+```
+
+> `logger.error` NUNCA dentro de `if (import.meta.env.DEV)` (patron #294 — rompe
+> Sentry). `measuredGetDoc` se mantiene (instrumentacion de perf intacta).
+
+#### `updateUserAvatar(uid: string, avatarId: string): Promise<void>` (S2 — depende de D1)
+
+**Camino (a) — D1 = SI (user doc puede tener avatar sin nombre):** paridad con
+`updateUserDisplayName`. Chequea existencia y crea con `setDoc` (incluyendo
+`createdAt: serverTimestamp()`) si no existe, o `updateDoc` si si.
+
+```ts
+export async function updateUserAvatar(uid: string, avatarId: string): Promise<void> {
+  const ref = doc(db, COLLECTIONS.USERS, uid);
+  const snap = await measuredGetDoc('userProfile_existsCheck', ref);
+  if (snap.exists()) {
+    await updateDoc(ref, { avatarId });
+  } else {
+    await setDoc(ref, { avatarId, createdAt: serverTimestamp() });
+  }
+}
+```
+
+**Camino (b) — D1 = NO (displayName es campo primario):** NO crea el doc. El
+catch debe **discriminar** el error: SOLO el `not-found` (doc aun no creado
+porque el usuario no seteo displayName) se traga con `logger.warn` y sin
+re-throw, dejando el estado optimista en memoria. **Cualquier otro error
+(`permission-denied`, red transitoria, etc.) se RE-LANZA** para que el caller
+`setAvatarId` (`AuthContext.tsx:141-144`) ejecute su revert legitimo del
+optimistic update.
+
+> **Por que la discriminacion es obligatoria:** `setAvatarId` revierte el avatar
+> ante cualquier throw de `updateUserAvatar`. Un catch que se traga TODO romperia
+> ese revert: el usuario online con doc existente cuyo `updateDoc` falla por
+> `permission-denied` o error de red veria el avatar nuevo en la UI sin que se
+> haya persistido, **sin enterarse** (hoy, sin el fix, ese caso SI revierte).
+> Tragar solo `not-found` preserva el comportamiento actual para todos los demas
+> errores y honra el Criterio de aceptacion ("optimistic revert de avatar solo
+> en error real").
+
+Mecanismo de discriminacion: inspeccionar el `code` del `FirestoreError`
+(`err.code === 'not-found'`). Solo ese codigo se traga; el resto se re-lanza.
+
+```ts
+export async function updateUserAvatar(uid: string, avatarId: string): Promise<void> {
+  const ref = doc(db, COLLECTIONS.USERS, uid);
+  try {
+    await updateDoc(ref, { avatarId });
+  } catch (err) {
+    // SOLO not-found se traga: el doc aun no existe (usuario sin displayName).
+    // Se persiste en la proxima oportunidad (cuando setee displayName). El caller
+    // mantiene el optimistic update en memoria.
+    if ((err as { code?: string }).code === 'not-found') {
+      logger.warn('[userProfile] updateUserAvatar skipped (doc not found yet):', err);
+      return;
+    }
+    // Cualquier otro error (permission-denied, red, etc.) se RE-LANZA para que
+    // el caller (setAvatarId) revierta el optimistic update. No swallow.
+    throw err;
+  }
+}
+```
+
+> **CRUCE CON #344 — no pisar el fallback.** #344 agrega offline guard
+> (`withOfflineSupport`) sobre el MISMO callsite (`setAvatarId` en
+> `AuthContext.tsx:134-145`, que llama a `updateUserAvatar`). Coordinacion:
+> este PRD toca el cuerpo de `updateUserAvatar` (service); #344 wrappea la
+> llamada desde el context. Son capas distintas (service vs callsite del
+> context) y NO deben colisionar. **Quien mergee segundo NO debe revertir el
+> fallback setDoc/catch de este PRD.** Dejar nota en el PR. En camino (b), el
+> `logger.warn` interno NO interfiere con el offline enqueue de #344: el offline
+> guard intercepta ANTES de llamar al service cuando esta offline; el
+> `try/catch` del service solo actua online cuando el doc no existe.
+
+## Integracion
+
+### S1 — `src/context/AuthContext.tsx` (callback de `onAuthStateChanged`)
+
+Envolver el cuerpo del callback en try/finally para garantizar
+`setIsLoading(false)` siempre. El `finally` cubre **ambas ramas** (firebaseUser
+presente y ausente/anonimo).
+
+```ts
+const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+  try {
+    if (firebaseUser) {
+      setUser(firebaseUser);
+      const method = getAuthMethod(firebaseUser);
+      setAuthMethod(method);
+      setEmailVerified(firebaseUser.emailVerified);
+      setUserProperty('auth_type', method);
+      const profile = await fetchUserProfileDoc(firebaseUser.uid);
+      if (profile) {
+        setDisplayNameState(profile.displayName || null);
+        setAvatarIdState(profile.avatarId ?? null);
+      }
+    } else {
+      const isAdminRoute = pathnameRef.current.startsWith('/admin');
+      if (isAdminRoute) {
+        setUser(null);
+      } else {
+        try {
+          await signInAnonymously(auth);
+        } catch (error) {
+          logger.error('Error signing in anonymously:', error);
+        }
+      }
+    }
+  } catch (error) {
+    // Defensa del camino critico: cualquier fallo (lectura de perfil, etc.)
+    // no debe dejar la app en loading infinito. La app entra igual.
+    logger.error('[AuthContext] fetchUserProfileDoc failed on auth state change:', error);
+  } finally {
+    setIsLoading(false);
+  }
+});
+```
+
+> Doble defensa (defense-in-depth): el `.catch` en el service (S1) hace que
+> `fetchUserProfileDoc` ya no lance, y el try/finally del callback garantiza
+> `setIsLoading(false)` aun si otra linea del callback fallara (ej: un
+> `setUserProperty` que tire). Ambas capas son intencionales — no es redundancia
+> a eliminar.
+
+### Preventive checklist
+
+- [x] **Service layer**: AuthContext usa `userProfile.ts` (service) para reads/
+  writes. No importa `firebase/firestore` directamente. Se mantiene.
+- [x] **Duplicated constants**: no se agregan constantes.
+- [x] **Context-first data**: `avatarId`/`displayName` siguen viniendo de
+  AuthContext. No se agrega `getDoc` extra en componentes.
+- [x] **Silent .catch**: el `.catch` de `fetchUserProfileDoc` usa `logger.error`
+  (no `() => {}`). El `try/catch` de camino (b) de `updateUserAvatar` usa
+  `logger.warn`. Cumple la regla "No silent .catch".
+- [x] **Stale props**: no aplica (sin componentes nuevos).
+
+## Tests
+
+| Archivo test | Que testear | Tipo |
+|-------------|-------------|------|
+| `src/context/AuthContext.test.tsx` (existe, 35 casos) | **S1.** Nuevo: `fetchUserProfileDoc` rechaza (mock `getDoc` reject) → `isLoading` queda `false` (no infinito). Nuevo: rechaza → `displayName`/`avatarId` quedan `null` y no crashea. Nuevo: verificar `logger.error` invocado (senal Sentry, Success Criteria #2). Nuevo: rama anonima sigue llamando `setIsLoading(false)` en `finally`. | Context |
+| `src/services/__tests__/userProfile.test.ts` (existe, 8 casos) | **S1.** Reemplazar test "propagates errors" de `fetchUserProfileDoc` (L80-85): ahora `getDoc` rechaza → devuelve `null` (no lanza) + `logger.error` llamado. **S2 (camino a):** `updateUserAvatar` doc existe → `updateDoc`; doc no existe → `setDoc` con `avatarId` + `createdAt`. **S2 (camino b):** `updateUserAvatar` `updateDoc` rechaza `{code:'not-found'}` → NO lanza + `logger.warn` llamado (swallow). **Nuevo (camino b):** `updateDoc` rechaza `{code:'permission-denied'}` (u otro code) → SI re-lanza (para que el caller revierta) + `logger.warn` NO llamado. | Service |
+| `tests/rules/users.rules.test.ts` (existe, 16 casos) | **S2 (solo camino a).** ALLOW: owner crea user doc solo con `avatarId` + `createdAt` (sin displayName). DENY: create con `displayNameLower` sin `displayName` (hueco de desincronizacion). DENY: create con `avatarId` > 50 chars. ALLOW/DENY: update avatarId <= 50 / > 50. Marcar checkbox `users` en inventario de tests.md (ya esta `[x] [x]`; agregar nota del nuevo invariante). | Rules |
+
+### Mock strategy
+
+- Firestore: mock SDK (`getDoc`, `setDoc`, `updateDoc`, `serverTimestamp`) —
+  patron existente en ambos tests (ver `userProfile.test.ts:35-46` y
+  `AuthContext.test.tsx:37-45`).
+- `logger`: mock `{ error: vi.fn(), warn: vi.fn() }` — verificar invocacion para
+  Success Criteria #2. Ya mockeado en `userProfile.test.ts:53`.
+- `measuredGetDoc`/`measuredGetDocs`: mock que delega a `getDoc`/`getDocs` (ya
+  existe en `userProfile.test.ts:30-33`).
+- Rules: harness `@firebase/rules-unit-testing` (`tests/rules/setup.ts`),
+  `authedContext` + `expectAllow`/`expectDeny`.
+
+### Criterio de aceptacion
+
+- Cobertura >= 80% del codigo modificado.
+- Paths condicionales cubiertos: profile null, profile rechaza, doc existe/no
+  existe, rama anonima, `logger.error`/`logger.warn` invocados.
+- Side effects verificados: `setIsLoading(false)` siempre corre (incluso en
+  error), optimistic revert de avatar solo en error real (camino b).
+
+## Analytics
+
+Sin `trackEvent` nuevos. El fix es de correctness. La unica senal observable es
+`logger.error` → Sentry (Success Criteria #2), que da visibilidad de cuantas
+veces falla la lectura de perfil en el camino critico — dato que hoy se pierde
+con la app colgada.
+
+---
+
+## Offline
+
+### Cache strategy
+
+| Dato | Estrategia | TTL | Storage |
+|------|-----------|-----|---------|
+| `fetchUserProfileDoc` en arranque | Firestore persistent cache (prod, ya configurada). Si falla igual → `.catch` devuelve `null`, app entra sin perfil | n/a | IndexedDB (Firestore SDK) |
+
+### Writes offline
+
+| Operacion | Mecanismo | Conflict resolution |
+|-----------|-----------|---------------------|
+| `updateUserAvatar` | Optimistic update local + revert si falla (actual, mantenido). Offline queue queda para #344 — este PRD no agrega el guard pero no lo bloquea | last-write-wins (1 campo idempotente) |
+
+### Fallback UI
+
+Ninguna. El arranque offline (uno de los disparadores del bug) ahora funciona
+en vez de colgarse: la app entra sin perfil, degrada con gracia, sin toast
+(la falla de lectura en arranque no debe interrumpir al usuario).
+
+---
+
+## Accesibilidad y UI mobile
+
+No aplica — sin elementos interactivos ni componentes nuevos. El splash de
+loading existente sigue igual; el unico cambio observable es que ahora siempre
+termina (deja de mostrarse) en vez de colgarse.
+
+## Textos y copy
+
+No hay copy user-facing nuevo. Mensajes de `logger.error`/`logger.warn` son
+internos (no se aplican reglas de voseo/tildes user-facing, pero deben ser
+claros para debugging).
+
+---
+
+## Decisiones tecnicas
+
+| Decision | Rationale | Alternativa rechazada |
+|----------|-----------|-----------------------|
+| Doble defensa S1 (`.catch` en service + try/finally en callback) | El `.catch` alinea el contrato del service; el try/finally protege contra cualquier otro throw del callback (no solo el fetch). Defense-in-depth en el camino mas critico de la app | Solo try/finally en el callback: dejaria `fetchUserProfileDoc` con contrato inconsistente respecto a `fetchUserProfile`. Solo `.catch` en service: no protegeria si otra linea del callback tira |
+| S1 independiente de S2 (fases separadas) | S1 es el core del issue (bloqueo total). No depende de D1. Separar permite mergear el fix critico sin esperar la decision de producto | Bundle S1+S2 en un solo merge: ataria el fix critico a una decision abierta |
+| `avatarId .size() <= 50` en create **Y** update | Sofia: el limite no debe quedar solo en el create nuevo. El update existente tambien acepta avatarId arbitrario hoy | Solo en create: dejaria el update sin validacion de tamaño |
+| Camino (a) vs (b) diferido a D1 | Es decision de producto (¿doc avatar-sin-nombre es valido?). El implementador no la decide | Asumir (a): el PRD lo recomienda pero requiere confirmacion explicita |
+
+---
+
+## Hardening de seguridad
+
+### Firestore rules requeridas
+
+Ver seccion "Firestore Rules". Resumen:
+
+1. **Independiente de D1:** `avatarId .size() <= 50` en create (L44) y update
+   (L61).
+2. **Solo camino (a):** create solo-avatar con `displayName`/`displayNameLower`
+   opcionales (ambos ausentes XOR ambos sincronizados), manteniendo `hasOnly`,
+   ownership, `createdAt` server-side, e invariante #322 R12.
+
+### Rate limiting
+
+| Coleccion | Limite | Implementacion |
+|-----------|--------|----------------|
+| users | n/a | No requiere rate limit nuevo (1 doc por usuario, campos idempotentes — PRD L120/L127). El create solo-avatar no introduce coleccion de items |
+
+### Vectores de ataque mitigados
+
+| Ataque | Mitigacion | Archivo |
+|--------|-----------|---------|
+| Crear `users/{otroUid}` con avatarId arbitrario | `request.auth.uid == userId` (doc ID) se mantiene en el create solo-avatar — no se relaja | firestore.rules |
+| Field injection en create solo-avatar | `hasOnly(['displayName','displayNameLower','avatarId','createdAt'])` intacto | firestore.rules |
+| `displayNameLower` desincronizado (hijack B5 #322) | create solo-avatar exige ambos ausentes XOR ambos sincronizados; nunca lower sin name | firestore.rules |
+| `avatarId` gigante (storage/cost abuse) | `.size() <= 50` en create + update | firestore.rules |
+| Lectura de perfil de otros via el fix | El fix solo cambia el manejo del fallo del read; el read sigue restringido a owner/admin/public | firestore.rules |
+
+---
+
+## Deuda tecnica: mitigacion incorporada
+
+Issues consultados (PRD L135): no hay labels `security`/`tech debt` poblados;
+deuda usa `enhancement` con prefijo "Tech debt:". Relevantes: #342, #343-#349,
+#168.
+
+| Issue | Que se resuelve | Paso del plan |
+|-------|-----------------|---------------|
+| #344 (profile mutations sin offline guard) | NO se resuelve aca; se coordina el callsite para no pisar el fallback setDoc/catch | Fase 2, nota de coordinacion |
+| #322 R12 (displayNameLower sync) | El create solo-avatar (camino a) preserva la invariante sin abrir hueco | Fase 2 (camino a) |
+| #332 (rules tests harness) | Se aprovecha `users.rules.test.ts` para agregar tests del create solo-avatar y limite avatarId | Fase 2 |
+
+Mitigaciones de inconsistencia (no son issues, pero se cierran):
+
+- `fetchUserProfileDoc` alcanza el mismo contrato best-effort que
+  `fetchUserProfile` (ambas con `.catch`) — elimina la divergencia que origino
+  el bug.
+- `updateUserAvatar` (camino a) alcanza paridad con `updateUserDisplayName` —
+  elimina la divergencia entre dos mutadores del mismo doc.
+
+---
+
+## Estimacion de tamaño de archivos
+
+| Archivo | Lineas actuales | Delta estimado | Resultante | Supera 400? |
+|---------|-----------------|----------------|------------|-------------|
+| `src/context/AuthContext.tsx` | 266 | +6 (try/finally + catch) | ~272 | No |
+| `src/services/userProfile.ts` | 161 | +8 (catch en fetch + branch en avatar) | ~169 | No |
+| `firestore.rules` | 778 | +12 (avatarId size + create solo-avatar) | ~790 | No (no es TS) |
+| `src/context/AuthContext.test.tsx` | 684 | +40 (4 casos nuevos) | ~724 | Test file (sin limite) |
+| `src/services/__tests__/userProfile.test.ts` | 279 | +30 (catch + avatar paths) | ~309 | No |
+| `tests/rules/users.rules.test.ts` | 271 | +50 (camino a) | ~321 | No |
+
+Ningun archivo de produccion supera 400 lineas. No requiere decomposicion.
+
+---
+
+## Validacion Tecnica
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Revisor:** Diego (solution architect)
+
+**Observaciones:** S1 (loading infinito: try/finally en el callback de onAuthStateChanged + `.catch` defensivo en `fetchUserProfileDoc`) queda **VALIDADO y es implementable YA** — NO depende de D1, no toca rules, mergea solo y primero. Cobertura técnica vs PRD completa, claims de código verificados (AuthContext.tsx:104/121, userProfile.ts:80-81/131-135, firestore.rules:28-45), contrato best-effort de `fetchUserProfileDoc` correcto y alineado con `fetchUserProfile`, edge cases cubiertos (estado null = anónimo nuevo, rehidratación en próximo onAuthStateChanged, doble defensa intencional).
+
+El límite `avatarId .size() <= 50` (independiente de D1) queda validado en create y update; los avatarIds son slugs cortos predefinidos (`cat`, `dog`...) y el caller ya valida `getAvatarById` — el límite server-side es backstop correcto.
+
+S2 (`updateUserAvatar` fallback + create solo-avatar) queda **GATEADO por D1** — NO implementable hasta que Gonzalo resuelva D1 (¿user doc con avatarId sin displayName válido?). El modelo de ambos caminos es técnicamente sólido: camino (a) relaja la obligatoriedad de displayName manteniendo hasOnly, ownership, createdAt server-side e invariante #322 R12 (ambos ausentes XOR ambos sincronizados — cierra el hueco B5); camino (b) deja el optimistic en memoria.
+
+Cerrado en el ciclo con specs-plan-writer:
+- IMPORTANTE (S2 camino b): el catch ahora discrimina — solo `not-found` se traga, el resto se re-lanza para preservar el revert legítimo de `setAvatarId`. Resuelto.
+- OBSERVACION (S2 camino a): documentado en S4 que el read-back de un doc solo-avatar produce `displayName=null` (estado soportado, no tocar el converter). Resuelto.
+
+Para Pablo (plan): S1 y S2 deben ir en fases separadas — S1 sin esperar a D1, S2 detrás del gate D1. La coordinación con #344 (mismo callsite `setAvatarId`) ya está notada en specs; el plan debe garantizar que quien mergee segundo no revierta el fallback de S2.

--- a/docs/feat/infra/343-fetchuserlikes-fanout-businessid/plan.md
+++ b/docs/feat/infra/343-fetchuserlikes-fanout-businessid/plan.md
@@ -1,0 +1,302 @@
+# Plan: fetchUserLikes fan-out → query-by-businessId (cerrar guard #302 R3)
+
+**Specs:** [specs.md](specs.md)
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-12
+**Issue:** #343
+
+> Basado en `specs.md` (VALIDADO CON OBSERVACIONES por Diego, 2026-06-12) y `prd.md` (VALIDADO CON OBSERVACIONES por Sofia, 2026-06-10).
+
+---
+
+## Orden de rollout obligatorio (gate de Diego)
+
+El feature toca schema + rules + query + datos historicos. El orden de despliegue **no es opcional** — invertirlo deja la query nueva devolviendo vacio o las rules rechazando writes. Cada paso es reversible.
+
+```
+(1) Indice compuesto   → deploy firestore.indexes.json
+(2) Rules              → deploy firestore.rules (businessId en hasOnly + isValidBusinessId)
+(3) Codigo             → merge + deploy de la firma nueva + query directa + offline handler
+(4) Backfill           → scripts/backfill-commentlikes-businessid.mjs --audit, validar conteo, luego --apply
+```
+
+**Por que ese orden:**
+
+| Si se despliega antes... | Consecuencia |
+|--------------------------|--------------|
+| Codigo (3) antes de Rules (2) | El `setDoc` con `businessId` es rechazado por `hasOnly()` viejo → todo like nuevo falla |
+| Codigo (3) antes de Indice (1) | La query `where(userId)+where(businessId)` lanza `failed-precondition` (indice faltante) |
+| Backfill (4) antes de Rules (2)/Codigo (3) | Backfill corre con Admin SDK (bypasea rules) — tecnicamente posible, pero deja docs con `businessId` que el codigo viejo ignora; sin valor hasta que (3) este live |
+
+**Window de degradacion suave (documentado en specs S3):** entre el deploy del codigo (3) y el fin del `--apply` (4), los likes legacy (sin `businessId`) **no aparecen** en la query nueva → el usuario ve un like propio antiguo como "no le di me gusta". Es un estado **transitorio y no destructivo**: el dato del like sigue existiendo, solo no se resuelve hasta el backfill. Mitigacion operativa: correr `--apply` **inmediatamente** despues del deploy del codigo para minimizar el window (orden de minutos). Re-like en ese intervalo auto-backfillea via `setDoc` idempotente (con re-dispatch de trigger aceptado, ver specs Cloud Functions).
+
+### Gap critico F2→F3: la rule nueva ROMPE el codigo viejo (BLOQUEANTE)
+
+El `hasOnly(['userId','commentId','businessId','createdAt'])` de F2 **exige** `businessId` (ademas, `isValidBusinessId(request.resource.data.businessId)` falla si el campo esta ausente). Pero el codigo de F3 (el que escribe `businessId`) todavia no esta live. Resultado: **entre el deploy de Rules (2) y el deploy de Codigo (3), todo like nuevo del codigo viejo —que escribe solo 4 campos sin `businessId`— es rechazado por la rule.** Esto NO es el "window de degradacion suave" (ese es de lectura/visual y empieza en F3); este es un window de **escritura rota** que empieza en F2.
+
+**Por que no se puede cerrar haciendo la rule opcional:** una rule transitoria que acepte `businessId` ausente (`!('businessId' in request.resource.data) || isValidBusinessId(...)`) re-abre la puerta a escribir likes sin `businessId` mientras este live → contamina datos durante el window y obliga a un segundo backfill. Se descarta.
+
+**Mitigacion adoptada — minimizar y secuenciar el window F2→F3:**
+
+1. **F2 y F3 se despliegan en la misma ventana operativa, consecutivos, F2 primero.** No se deja correr produccion con la rule de F2 y el codigo de F3 sin desplegar mas alla del tiempo de un deploy (orden de minutos). El indice de F2 SI debe estar `Enabled` antes (puede tardar) — por eso se deploya el indice primero (puede adelantarse dias, es aditivo), y recien cuando el indice esta `Enabled` se hace el par consecutivo **rules → codigo**.
+2. **Secuencia operativa exacta:**
+   - (a) `firebase deploy --only firestore:indexes` → esperar `Enabled` (puede ser dias antes; aditivo, no rompe nada).
+   - (b) Con el indice ya `Enabled`: `firebase deploy --only firestore:rules` **e inmediatamente despues** deploy del codigo de F3. Ventana de escritura rota = duracion entre ambos deploys (minutos).
+   - (c) `--audit`/`--apply` del backfill (F4).
+3. **Consecuencia aceptada del window (minutos):** un usuario que likee un comentario en la ventana exacta entre (b)-rules y (b)-codigo recibe un error de permisos en ese `setDoc`. El offline handler reintenta; al reintentar con el codigo ya live (3-arg), el `setDoc` incluye `businessId` y pasa. Sin perdida de dato, sin corrupcion. Window de minutos, no de backfill.
+
+> **Implicancia para F2 (paso de deploy) y F3 (deploy inmediato):** el "deploy inmediato" de F3 ya NO es solo para minimizar el window de lectura — es **obligatorio** para cerrar el window de escritura rota abierto por F2. El indice se adelanta; rules+codigo van juntos y consecutivos.
+
+---
+
+## Staging de riesgo
+
+| Fase | Riesgo | Esfuerzo | Notas |
+|------|--------|----------|-------|
+| F1 — Type + converter + seeds (S1 parcial) | Bajo | S (~0.5d) | Cambio de tipos/datos local; sin efecto runtime hasta F2-F4 |
+| F2 — Rules + indice (S1/S2 parcial, deploy) | Medio | M (~1d) | Indice nuevo es aditivo; la rule NO es aditiva (el `hasOnly` nuevo exige `businessId`, ver gap F2→F3 abajo). Reversible. **Se despliega antes que el codigo**. Esfuerzo incluye el suite de rules tests nuevo |
+| F3 — Codigo: write con businessId + query directa + offline handler (S1/S2) | Medio | L (~1.5d) | Elimina `fetchUserLikes` + reescribe 4 tests; toca 3 services + hook + offline handler; abre el window de degradacion suave hasta el backfill |
+| F4 — Backfill (S3) | Alto | M (~1d) | Script nuevo + test; toca toda la coleccion `commentLikes` una vez. `--audit` obligatorio antes de `--apply`; ventanear si excede cap (el ventaneo puede extender el calendario, no el esfuerzo) |
+| F5 — Docs (obligatoria) | Bajo | S (~0.5d) | Cierre de guard #302 R3 + reference docs |
+
+> **Leyenda esfuerzo:** S = chico (<= 0.5 dia), M = medio (~1 dia), L = grande (~1.5 dias). Estimacion de ingenieria para un owner (nico); excluye tiempos de espera de deploy (indice `Enabled`) y de ventaneo de backfill, que son calendario operativo, no esfuerzo. Total ingenieria ~4.5 dias.
+
+---
+
+## File ownership por agente
+
+| Agente | Archivos | Fase |
+|--------|----------|------|
+| **nico** (data/services/backend) | `src/types/business.ts`, `src/config/converters/businessConverters.ts`, `src/services/comments.ts`, `src/services/businessData.ts`, `src/services/registerOfflineHandlers.ts`, `src/hooks/useCommentListBase.ts`, `firestore.rules`, `firestore.indexes.json`, `scripts/backfill-commentlikes-businessid.mjs`, `scripts/seed-admin-data.mjs`, `scripts/seed-staging.ts`, `src/components/admin/perf/perfHelpers.ts`, todos los tests asociados | F1-F4 |
+| **luna** (UI) | — (sin cambios de UI; el toggle ya existe) | — |
+| **deploy/operativo** (humano con `gcloud`/`firebase`) | deploy de indice, rules, ejecucion de backfill `--audit`/`--apply` | F2, F4 |
+
+> Todo el codigo es service-layer / scripts / rules → ownership de **nico**. No hay trabajo de **luna** (sin cambios de markup ni a11y, confirmado en specs "Componentes" y "Accesibilidad"). Es un feature de un solo owner; las fases se ordenan por dependencia, no por handoff entre agentes.
+
+---
+
+## Fases de implementacion
+
+### Fase 1 — Schema local: type + converter + seeds (sin runtime aun)
+
+**Branch:** `feat/343-commentlikes-businessid`
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/types/business.ts` | Agregar `businessId: string` a la interface `CommentLike` |
+| 2 | `src/config/converters/businessConverters.ts` | `commentLikeConverter`: agregar `businessId` en `toFirestore` y leerlo en `fromFirestore` (ver specs) |
+| 3 | `src/config/converters/businessConverters.test.ts` | Ampliar el round-trip de `commentLikeConverter` para cubrir `businessId` (toFirestore incluye, fromFirestore lee) |
+| 4 | `scripts/seed-admin-data.mjs` | Capturar `businessId` del comment en `commentIds.push({ id, userId, businessId })` (linea ~232) y propagarlo al `setDoc` del like (linea ~281). Idem bloque replies si se likean |
+| 5 | `scripts/seed-staging.ts` | Like: agregar `businessId: BUSINESS_IDS[i % BUSINESS_IDS.length]` (commentId sintetico → solo necesita `biz_NNN` valido) |
+
+- **Test:** `businessConverters.test.ts` verde. Los seeds actualizados se EDITAN en F1 pero se EJECUTAN recien tras F2 (la rule vieja rechaza el campo `businessId` extra via `hasOnly`).
+- **Commit:** `feat(#343): CommentLike.businessId — type, converter y seeds`
+- **Rollback:** revert del commit; tipos/converter/seeds vuelven a 4 campos.
+
+### Fase 2 — Rules + indice (deploy, ANTES del codigo)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `firestore.rules` | Reemplazar `match /commentLikes/{docId}` (lineas ~172-185): `hasOnly(['userId','commentId','businessId','createdAt'])`, `isValidBusinessId(request.resource.data.businessId)`, conservar `userId == auth.uid` / `commentId.size() > 0` / `createdAt == request.time`. Eliminar el comentario obsoleto (lineas ~173-175) sobre la imposibilidad de `resource.data` checks |
+| 2 | `firestore.indexes.json` | Agregar indice `commentLikes(userId ASC, businessId ASC)`, scope `COLLECTION`. Conservar el indice `(userId, createdAt)` existente (aditivo) |
+| 3 | `tests/rules/commentLikes.rules.test.ts` (nuevo) | ALLOW create owner + `businessId` valido + `commentId` no vacio + `createdAt==request.time`; DENY `businessId` invalido / ausente / campo extra / `userId != auth.uid` / `createdAt != request.time`; ALLOW delete owner; DENY delete no-owner; ALLOW read autenticado |
+| 4 | (deploy) | `firebase deploy --only firestore:indexes` y esperar a que el indice quede `Enabled`. Luego `firebase deploy --only firestore:rules`. Validar seeds actualizados (F1) contra emulador con rules nuevas |
+
+- **Test:** `commentLikes.rules.test.ts` verde contra emulador (`@firebase/rules-unit-testing` v5, helpers de `tests/rules/setup.ts`).
+- **Commit:** `feat(#343): rules + indice compuesto commentLikes(userId, businessId)`
+- **Rollback:** revert de rules (vuelve a `hasOnly` sin `businessId`); el indice nuevo es aditivo y puede dejarse (no molesta) o borrarse. Reglas reversibles sin perdida de datos.
+- **Riesgo de orden:** este deploy NO debe mergear/desplegarse junto al codigo de F3 — debe estar live primero. Si CI despliega rules+codigo en el mismo pipeline, separar en dos PRs o gatear el deploy de F3.
+
+### Fase 3 — Codigo: write con businessId + query directa + offline handler
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/services/comments.ts` | `likeComment(userId, commentId, businessId)`: agregar 3er arg y escribir `businessId` en el `setDoc`. `unlikeComment` sin cambio |
+| 2 | `src/hooks/useCommentListBase.ts` | call site (~linea 116-122): `onlineAction` pasa `businessId` a `likeComment(user.uid, commentId, businessId)` (`businessId` ya esta en el closure scope, dependencia listada) |
+| 3 | `src/services/registerOfflineHandlers.ts` | Handler `comment_like` (~linea 83-87): destructurar `{ userId, businessId, payload }` de `OfflineAction` y pasar `action.businessId` como 3er arg a `likeComment`. `comment_unlike` sin cambio. `CommentLikePayload` NO cambia |
+| 4 | `src/services/businessData.ts` | En `fetchBusinessData`: agregar la query directa de likes como octavo elemento del `Promise.all` (`measuredGetDocs('businessData_userLikes', query(...where(userId)...where(businessId)...))`); mapear a `Set` desde `d.data().commentId`. Eliminar la llamada post-`Promise.all` a `fetchUserLikes` (linea 148) |
+| 5 | `src/services/businessData.ts` | En `fetchSingleCollection` case `'comments'` (linea ~72): reemplazar `fetchUserLikes(...)` por la misma query directa filtrada por `(userId, businessId)`. Shape de retorno `{ comments, userCommentLikes }` sin cambio |
+| 6 | `src/services/businessData.ts` | Eliminar la funcion `fetchUserLikes` (lineas 21-50) e importar `commentLikeConverter` desde `../config/converters` |
+| 7 | `src/components/admin/perf/perfHelpers.ts` | Agregar `businessData_userLikes: 'Detalle: likes del usuario'` a `QUERY_LABELS` (cierra parte de #347) |
+| 8 | `src/services/comments.test.ts` | Actualizar cases que llaman `likeComment` con 2 args → 3 args; assertion de que el `setDoc` payload incluye `businessId` |
+| 9 | `src/services/businessData.test.ts` | **Actualizar/eliminar los 4 tests de `fetchUserLikes`** (gate Diego, ver detalle abajo) |
+| 10 | `src/services/businessData.test.ts` | Agregar `commentLikeConverter: {}` al `vi.mock('../config/converters')` (hoy falta — linea 27-34); la query nueva lo importa. Nuevos cases de query directa |
+| 11 | tests de `registerOfflineHandlers` | Assertion explicita: `comment_like` replay pasa `action.businessId` como 3er arg a `likeComment` |
+
+**Detalle de los 4 tests de `fetchUserLikes` a actualizar (gate Diego, businessData.test.ts):**
+
+| # | Test actual | Accion |
+|---|-------------|--------|
+| 1 | `describe('fetchUserLikes — measureAsync instrumentation')` → `wraps Promise.all of batches...` (l.138) | **Eliminar** (funcion ya no existe) |
+| 2 | idem → `short-circuits ... when commentIds is empty` (l.145) | **Eliminar** → reemplazar por: "lista de comentarios vacia → query directa devuelve Set vacio sin romper" |
+| 3 | idem → `returns a Set of comment ids that have likes` (l.152) | **Reescribir** como test de la query directa: `Set` derivado de `d.data().commentId` (no del doc id `split`) |
+| 4 | idem → `splits 35 ids into 2 batches (30 + 5)` (l.168) | **Eliminar** (ya no hay batching; 1 sola query) |
+| (+) | `comments case ... fires fetchUserLikes if ids present` (l.116) y su assertion `measureAsync ... businessData_userLikes` (l.129) | **Actualizar**: ahora `fetchSingleCollection('comments')` resuelve likes via `measuredGetDocs('businessData_userLikes', ...)` — cambiar la assertion de `mockMeasureAsync` a `mockMeasuredGetDocs` |
+
+> El case de `fetchBusinessData` (l.60) debe pasar a esperar `businessData_userLikes` en `mockMeasuredGetDocs` (octava query del `Promise.all`).
+
+- **Test:** suite completa de `businessData.test.ts`, `comments.test.ts`, `businessConverters.test.ts`, `registerOfflineHandlers` verde; cobertura >= 80% del codigo nuevo; verificar que no quedan referencias a `fetchUserLikes` (`grep -rn fetchUserLikes src/`).
+- **Commit:** `feat(#343): query directa commentLikes(userId, businessId) + elimina fetchUserLikes (cierra guard #302 R3)`
+- **Rollback:** revert del commit. Restaura `fetchUserLikes` y el fan-out. Las rules/indice de F2 quedan (aditivos, no rompen el codigo viejo). El `businessId` en docs nuevos escritos durante el window queda inerte para el codigo viejo (lo ignora) — sin corrupcion.
+- **Deploy:** correr **inmediatamente** despues del merge para minimizar el window de degradacion suave antes de F4.
+
+### Fase 4 — Backfill de docs legacy
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `scripts/backfill-commentlikes-businessid.mjs` (nuevo) | Patron de `migrate-displayname-lower-sync.mjs`: modos `--audit`/`--apply`, Admin SDK via ADC, CLI gateado por `import.meta.url`, primitivas exportadas (`parseMode`, `getDb`, `audit`, `applyBackfill`, `printAuditReport`, `run`), `BATCH_SIZE=500`, reads de comments via `db.getAll()` en chunks de 30 |
+| 2 | `scripts/backfill-commentlikes-businessid.mjs` | `audit(db)`: clasificar `withBusinessId` (skip) / `toBackfill` (comment existe → `{likeId, businessId}`) / `orphan` (comment borrado → `{likeId}`). Reportar `total`, `withBusinessId`, `toBackfill`, `orphan` y la linea explicita del cap: `"Legacy docs a escribir: <N>. Cap free tier writes/dia: 20000. Ventanear si N supera el cap."` |
+| 3 | `scripts/backfill-commentlikes-businessid.mjs` | `applyBackfill(db, plan)`: `toBackfill` → `batch.update(ref, {businessId})`; `orphan` → `batch.delete(ref)`; commit cada 500 ops; idempotente (re-run = 0 ops) |
+| 4 | `scripts/__tests__/backfill-commentlikes-businessid.test.mjs` (nuevo) | `--audit` no escribe; clasificacion correcta; chunking `getAll` en grupos de 30; `applyBackfill` setea `businessId`; orphan se elimina; idempotencia (re-run = 0 ops); reporte imprime conteo de legacy docs |
+| 5 | (operativo) | **Correr `--audit` PRIMERO** (gate Diego). Leer el reporte: si `toBackfill + orphan` supera el cap de writes/dia (20000), **ventanear** el `--apply` (multiples dias o pausas entre lotes). Solo entonces correr `--apply` |
+
+- **Test:** `backfill-commentlikes-businessid.test.mjs` verde (db fake inyectado, sin emulador, patron del test de `migrate-displayname-lower-sync`).
+- **Commit:** `feat(#343): script backfill commentlikes businessId (--audit/--apply, orphan cleanup)`
+- **Rollback:** el `--apply` setea un campo y borra orphans — el set de `businessId` es idempotente y no destructivo. Los orphans borrados eran likes sin comentario (no leibles por ninguna query) → su borrado es seguro y no necesita rollback. Si el `--apply` se interrumpe, re-correrlo lo completa (idempotente).
+- **Gate operativo:** NO correr `--apply` sin haber leido el reporte de `--audit` y validado el conteo contra el cap.
+
+### Fase 5 — Documentacion (OBLIGATORIA)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `docs/reference/firestore.md` | Campo `businessId` en `commentLikes` + indice nuevo `(userId, businessId)` |
+| 2 | `docs/reference/security.md` | Fila `commentLikes` en tabla de rules: `businessId` en `hasOnly()` + `isValidBusinessId()` |
+| 3 | `docs/reference/patterns.md` | Reemplazar entry "Batched likes" por "query directa por (userId, businessId)" |
+| 4 | `docs/reference/guards/302-performance.md` | Marcar R3 como **cumplido** (fan-out eliminado, query directa) |
+| 5 | `docs/reference/tests.md` | Marcar checkbox allow+deny de `commentLikes` en inventario de rules tests |
+| 6 | `docs/_sidebar.md` | Agregar entradas Specs/Plan bajo la seccion `infra` (#343) |
+
+- **Commit:** `docs(#343): firestore/security/patterns + cierre guard #302 R3`
+- **Rollback:** revert del commit de docs.
+
+---
+
+## Orden de implementacion (cadena de dependencias)
+
+1. **F1** — type + converter + seeds (editar, no ejecutar seeds aun).
+2. **F2** — rules + indice → **deploy** (indice `Enabled`, luego rules). Validar seeds contra emulador.
+3. **F3** — codigo (write 3-arg, offline handler, query directa, borrar `fetchUserLikes`, perf label) + tests → merge + **deploy inmediato**.
+4. **F4** — `--audit` → validar conteo → `--apply` (ventanear si excede cap).
+5. **F5** — docs + sidebar + cierre guard.
+
+> F1 puede solaparse con F2 en el mismo PR (ambos son "preparacion" sin runtime), pero el **deploy** de F2 debe preceder al **deploy** de F3. F4 depende del deploy de F3 (codigo live). F5 al final.
+
+---
+
+## Merge / PR strategy
+
+El gap F2→F3 (ver "Gap critico F2→F3" arriba) impone que rules y codigo **no compartan un deploy automatico que los publique juntos sin orden**. Para que el orden de deploy sea explicito y auditable, se separa en PRs:
+
+| PR | Fases | Contenido | Gate de merge | Deploy disparado |
+|----|-------|-----------|---------------|------------------|
+| **PR-1** | F1 + F2 | Type + converter + seeds + rules + indice + rules tests | CI verde (lint, build, rules tests, converter test) | `firestore:indexes` primero (esperar `Enabled`), luego `firestore:rules`. **NO** mergear PR-2 hasta que el indice este `Enabled` |
+| **PR-2** | F3 | Codigo (3-arg, query directa, offline handler, borrar `fetchUserLikes`, perf label) + tests | CI verde + indice de PR-1 `Enabled` + rules de PR-1 ya live | Deploy de codigo **inmediatamente** tras merge (cierra el window de escritura rota abierto por las rules de PR-1) |
+| **PR-3** | F4 + F5 | Script backfill + test + docs + sidebar + cierre guard | CI verde; el script NO corre en CI | `--audit`/`--apply` operativo (humano) tras confirmar PR-2 live |
+
+**Reglas de la estrategia:**
+
+- **PR-1 y PR-2 NO se mergean juntos ni en cadena automatica.** Entre el merge/deploy de PR-1 (rules) y el merge/deploy de PR-2 (codigo) hay un window de escritura rota (minutos) que se cierra desplegando PR-2 inmediatamente. El indice de PR-1 se adelanta (puede tardar dias en `Enabled`); rules + codigo van consecutivos una vez el indice esta listo.
+- **Si el pipeline de CI despliega rules automaticamente al mergear:** PR-1 debe mergearse en una ventana coordinada con la persona que despliega PR-2, o gatear el deploy de rules para que sea manual. Confirmar el comportamiento del pipeline antes de mergear PR-1.
+- **PR-3 (backfill) NO bloquea la disponibilidad del feature**, pero el feature queda en "window de degradacion suave de lectura" hasta que `--apply` termine. Mergear y correr PR-3 lo antes posible tras PR-2 live.
+- Cada PR es revertible de forma independiente (ver "Rollback" de cada fase).
+
+### Base branch
+
+- **Base branch de los 3 PRs: `new-home`** (NO `main`). El repo esta trabajando sobre `new-home` como integracion activa; `main` es el branch por defecto pero el trabajo en curso vive en `new-home`. Las feature branches (`feat/343-commentlikes-businessid` y derivadas por PR) parten de `new-home` y apuntan su PR a `new-home`.
+- Confirmar con el delivery lead que `new-home` sigue siendo el target de integracion al momento de abrir los PRs (si `new-home` ya se mergeo a `main`, rebasear sobre `main`).
+
+---
+
+## Test plan global
+
+| Archivo | Que valida | Fase |
+|---------|-----------|------|
+| `businessConverters.test.ts` | round-trip `businessId` en `commentLikeConverter` | F1 |
+| `commentLikes.rules.test.ts` (nuevo) | allow+deny create/delete/read con `businessId` | F2 |
+| `comments.test.ts` (16 cases) | `likeComment` 3-arg escribe `businessId` | F3 |
+| `businessData.test.ts` | query directa → `Set` desde `d.data().commentId`; lista vacia; `fetchSingleCollection('comments')`; **4 tests de `fetchUserLikes` actualizados/eliminados**; mock `commentLikeConverter` agregado | F3 |
+| `registerOfflineHandlers` test | replay `comment_like` pasa `action.businessId` (3er arg) | F3 |
+| `backfill-commentlikes-businessid.test.mjs` (nuevo) | audit no escribe; clasificacion; chunking 30; apply setea businessId; orphan delete; idempotencia; reporte de conteo | F4 |
+
+- Verificacion de eliminacion: `grep -rn "fetchUserLikes" src/` debe devolver 0 matches tras F3.
+- Cobertura >= 80% del codigo nuevo (CI gate).
+- `npm run lint` + `npm run build` verde.
+
+---
+
+## Riesgos
+
+1. **Despliegue fuera de orden (indice/rules/codigo).** Si el pipeline despliega F3 antes que F2, todo like nuevo falla (rule) o la query lanza `failed-precondition` (indice). **Mitigacion:** separar F2 y F3 en deploys distintos; F2 debe estar live y el indice `Enabled` antes de mergear F3.
+2. **Window de degradacion suave visible al usuario.** Entre deploy de F3 y fin de `--apply`, likes legacy aparecen como "no likeado". **Mitigacion:** correr `--apply` inmediatamente post-deploy; el dato no se pierde (transitorio); re-like auto-backfillea.
+3. **Volumen del backfill excede cap de writes/dia.** **Mitigacion:** `--audit` obligatorio antes de `--apply` (gate Diego); ventanear si `toBackfill + orphan` > 20000.
+4. **Test `businessData.test.ts` con mock incompleto.** El `vi.mock('../config/converters')` actual NO incluye `commentLikeConverter` — la query nueva lo importa. **Mitigacion:** agregarlo al mock (F3 paso 10) o el import rompe el test.
+
+---
+
+## Guardrails de modularidad
+
+- [x] Ningun componente nuevo importa `firebase/firestore` directamente — todo en `services/` y `scripts/` (Admin SDK).
+- [x] Archivos en carpeta de dominio correcta (`services/`, `config/converters/`, `types/business.ts`, `scripts/`).
+- [x] Logica en services/scripts, no en componentes.
+- [x] Se ELIMINA `fetchUserLikes` (reduce superficie) — no agrava deuda.
+- [x] Script de backfill < 400 lineas (patron `migrate-displayname-lower-sync.mjs`).
+- [x] No se agregan barrels ni god-context.
+
+## Guardrails de seguridad
+
+- [x] Create rule tiene `hasOnly(['userId','commentId','businessId','createdAt'])`.
+- [x] Cada campo validado: `userId == auth.uid`, `commentId is string` + `.size() > 0`, `businessId` via `isValidBusinessId()`, `createdAt == request.time`.
+- [x] `businessId` string con patron (`isValidBusinessId` regex `biz_NNN`).
+- [x] No hay update rule (solo create/delete) → `businessId` inmutable por construccion.
+- [x] Rate limit 50/dia en `onCommentLikeCreated` (`snap.ref.delete()` al exceder) — intacto.
+- [x] Coleccion ya tiene trigger con rate limit (sin cambios).
+- [x] Backfill corre con ADC, sin Service Account keys en disco.
+- [x] Query siempre filtra `userId == auth.uid` → sin scraping de likes ajenos.
+
+## Guardrails de observabilidad
+
+- [x] Query nueva usa `measuredGetDocs('businessData_userLikes', ...)`.
+- [x] `businessData_userLikes` agregada a `QUERY_LABELS` (cierra parte de #347).
+- [x] Sin `trackEvent` nuevo (`comment_like` ya en GA4 definitions).
+- [x] Trigger conserva `trackFunctionTiming` (no se toca).
+- [x] `logger.error` del script no envuelto en `if (DEV)`.
+
+## Guardrails de copy
+
+- [x] Sin copy user-facing nuevo (toasts de like ya en `MSG_COMMENT`).
+- [x] Logs/comentarios del script en espanol; label de perf en espanol ("Detalle: likes del usuario").
+- [x] Terminologia: "comercios", "comentarios", "me gusta".
+
+## Criterios de done
+
+- [ ] Schema: `CommentLike.businessId` en type + converter + seeds (F1).
+- [ ] Rules + indice desplegados, allow+deny verde (F2).
+- [ ] `likeComment` 3-arg, query directa, `fetchUserLikes` eliminada, offline handler propaga `businessId` (F3).
+- [ ] 4 tests de `fetchUserLikes` actualizados/eliminados; suite verde >= 80% cobertura nuevo (F3).
+- [ ] Backfill `--audit` corrido y conteo validado contra cap; `--apply` completado e idempotente (F4).
+- [ ] Guard #302 R3 marcado como cumplido.
+- [ ] Reference docs actualizados (firestore, security, patterns, tests) + sidebar (F5).
+- [ ] No lint errors; build succeeds; `grep fetchUserLikes src/` = 0.
+
+---
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Ciclo:** 1
+
+**Cerrado en esta iteracion:**
+- BLOQUEANTE #1 "Gap F2→F3 rules-nuevas/codigo-viejo no contemplado" → resuelto: nueva subseccion "Gap critico F2→F3" nombra el window de escritura rota (distinto del window de lectura), descarta la rule opcional transitoria, y fija la secuencia operativa indice-Enabled → rules+codigo consecutivos (minutos). Corregida la etiqueta "Aditivo" de F2 en Staging de riesgo.
+- IMPORTANTE #2 "Merge/PR strategy fase→PR no explicita" → resuelto: nueva seccion "Merge / PR strategy" con 3 PRs (PR-1=F1+F2, PR-2=F3, PR-3=F4+F5), gates de merge y regla explicita de no-cadena PR-1/PR-2.
+- IMPORTANTE #3 "Estimacion de esfuerzo por fase ausente" → resuelto: columna Esfuerzo (S/M/L con dias) en Staging de riesgo; total ~4.5d ingenieria, coherente con "M" del PRD (F3 es el L dominante).
+- OBSERVACION #4 "Base branch no especificado" → resuelto: subseccion "Base branch" fija `new-home` como base de los 3 PRs.
+
+**Observaciones para el implementador:**
+- El window de escritura rota F2→F3 es operativo, no de codigo: depende de que quien despliega coordine rules+codigo en la misma ventana (minutos) DESPUES de que el indice este `Enabled`. Confirmar ANTES de mergear PR-1 si el pipeline de CI despliega rules automaticamente al mergear — si lo hace, gatear ese deploy o coordinar la ventana con quien mergea PR-2.
+- Correr `backfill --audit` y validar el conteo de legacy docs contra el cap de writes/dia (20000) ANTES de `--apply`; ventanear si excede. Gate operativo, no automatizable en CI.
+- F3 es la fase pesada (L, ~11 pasos: 3 services + hook + offline handler + 4 tests reescritos + perf label). Verificar `grep -rn fetchUserLikes src/` = 0 tras F3 antes de cerrar la fase.
+- Ownership de un solo agente (nico); sin paralelismo ni overlap de archivos → sin riesgo de conflicto de merge entre agentes.
+
+**Listo para pasar a implementacion:** Si, con observaciones (el orden de deploy F2→F3 es el unico punto que requiere disciplina operativa; el resto es mergeable de forma independiente por PR).

--- a/docs/feat/infra/343-fetchuserlikes-fanout-businessid/prd.md
+++ b/docs/feat/infra/343-fetchuserlikes-fanout-businessid/prd.md
@@ -1,0 +1,297 @@
+# PRD: fetchUserLikes fan-out → query-by-businessId (cerrar guard #302 R3)
+
+**Feature:** 343-fetchuserlikes-fanout-businessid
+**Categoria:** infra
+**Fecha:** 2026-06-09
+**Issue:** #343
+**Prioridad:** Alta (HIGH segun /health-check)
+
+---
+
+## Contexto
+
+`fetchBusinessData` (`src/services/businessData.ts`) carga las 7 queries del business view en un `Promise.all`, pero los likes del usuario sobre los comentarios se resuelven **despues** del `Promise.all` via `fetchUserLikes(uid, commentIds)`, que mapea cada `commentId` a `${uid}__${cId}` y hace batches de `where(documentId(), 'in', batch)` (30/batch). El guard `#302 R3` (`docs/reference/guards/302-performance.md`) exige exactamente lo contrario: una sola query directa filtrada por `(userId, businessId)` dentro del `Promise.all`. El patron actual viola el guard porque el schema no lo permite: `likeComment` escribe solo `{userId, commentId, createdAt}` (sin `businessId`) y el unico indice de `commentLikes` es `(userId, createdAt)`.
+
+## Problema
+
+- **Waterfall de RTT:** `fetchUserLikes` corre serialmente despues del `Promise.all` principal, sumando 150-300ms en 3G por cada apertura de comercio (el costo crece con la cantidad de comentarios: `ceil(N/30)` reads extra).
+- **Viola guard #302 R3:** el guard esta `Active desde v2.36.0` y documenta el fix exacto requerido (campo `businessId` en el doc + indice compuesto + firma `likeComment(userId, commentId, businessId)` + query directa en el `Promise.all`). Hoy el codigo esta en estado prohibido y solo no rompe CI porque el fix nunca se aplico.
+- **Imposible de optimizar sin cambio de schema:** los docs `commentLikes` existentes no tienen `businessId`, asi que una query `where('businessId','==',bId)` devolveria vacio para todo el historial. Requiere agregar el campo al write, crear el indice compuesto, y backfillear los docs existentes — los tres en conjunto, o la query nueva devuelve datos incompletos.
+
+## Solucion
+
+### S1 — Schema: agregar `businessId` al write de `commentLikes`
+
+- Extender `likeComment(userId, commentId)` → `likeComment(userId, commentId, businessId)` en `src/services/comments.ts`. El doc pasa a escribir `{userId, commentId, businessId, createdAt}`.
+- `businessId` ya esta disponible en todos los call sites: `useCommentListBase.ts` ya pasa `businessId`/`businessName` a `withOfflineSupport` (lineas 116-120). El handler offline `comment_like` en `registerOfflineHandlers.ts` recibe `businessId` en el `OfflineAction` (campo top-level requerido), por lo que el payload no necesita cambiar — el handler debe pasar `action.businessId` a `likeComment`.
+- Actualizar `firestore.rules` `match /commentLikes/{docId}`: agregar `businessId` al `keys().hasOnly([...])` y validar con `isValidBusinessId(request.resource.data.businessId)` (helper ya usado en `userTags`/`favorites`). El comentario obsoleto en las rules (lineas 172-175) que justifica la imposibilidad de `resource.data` checks debe reemplazarse, ya que la nueva query SI filtra por field.
+- Actualizar `CommentLike` type (`src/types/business.ts`) con `businessId: string` y el `commentLikeConverter` (`src/config/converters/businessConverters.ts`) `toFirestore`/`fromFirestore`.
+
+Patrones aplicables: `Doc ID compuesto` (patterns.md — `commentLikes` sigue usando `{userId}__{commentId}`), `Firestore rules field whitelist` (patterns.md — todo campo nuevo en el write debe estar en `hasOnly()`), `withConverter<T>()`.
+
+### S2 — Indice compuesto + query directa (cerrar el waterfall)
+
+- Agregar a `firestore.indexes.json`: `commentLikes(userId ASC, businessId ASC)`.
+- En `fetchBusinessData`, agregar la query de likes como octavo elemento del `Promise.all`: `where('userId','==',uid)` + `where('businessId','==',bId)`, envuelta en `measuredGetDocs('businessData_userLikes', ...)`. El resultado se mapea a `Set<commentId>` directamente desde `d.data().commentId` (ya no se parsea el doc id). Esto colapsa `ceil(N/30)+1` operaciones en 1.
+- Eliminar `fetchUserLikes` y su llamada post-`Promise.all` en `fetchBusinessData` y en `fetchSingleCollection` (case `comments`). El `fetchSingleCollection('comments')` debe tambien resolver los likes via la misma query directa.
+- Conservar la clave de perf `businessData_userLikes`. Nota: hoy la clave existe en `businessData.ts` pero NO esta en `QUERY_LABELS` de `perfHelpers.ts` (aparece sin label en el dashboard). Aprovechar este feature para agregarla a `QUERY_LABELS` (alineado con #347, que detecta queries sin instrumentar/labelear).
+
+**Edge — cache de `userCommentLikes`:** `readCache.ts` serializa `userCommentLikes` como `string[]` (set de commentIds) y `useBusinessData` lo mergea en refetches parciales (`merged.userCommentLikes = prev.userCommentLikes` cuando `patched.has('comments')`). La forma de este dato **no cambia** con este feature (sigue siendo un `Set<commentId>` derivado de la query) — el cambio es solo *como se obtiene* (query directa vs fan-out). No requiere invalidar cache ni migrar entries cacheadas. Verificar en specs que el shape del `Set` resultante es identico al actual para no romper el merge de `patchedRef`.
+
+### S3 — Backfill de docs `commentLikes` existentes
+
+- Script one-off `scripts/backfill-commentlikes-businessid.mjs`, siguiendo el patron canonico de `scripts/migrate-displayname-lower-sync.mjs`: modos `--audit` (default, read-only) y `--apply`, idempotente, Admin SDK via Application Default Credentials (ADC), primitivas exportadas para testeo, bloque CLI gateado por `import.meta.url === file://${process.argv[1]}`, batches de 500.
+- Logica: por cada doc de `commentLikes` sin `businessId`, leer `comments/{commentId}.businessId` y escribir el campo. Si el comentario fue borrado (no existe), el like es huerfano — el script lo cuenta en una categoria `orphan` y en `--apply` lo **elimina** (un like sin comentario no aporta y nunca volveria a leerse por la query nueva). Agrupar los reads de `comments` con `getAll()` en chunks de 30 para evitar N+1 (mismo patron que `fanOutToFollowers` #312).
+- **Orden de rollout (critico):** (1) deploy del indice compuesto, (2) deploy de rules con `businessId` en `hasOnly()` permitiendo el campo nuevo, (3) deploy del codigo con la firma nueva de `likeComment` y la query directa, (4) correr el backfill `--apply`. Hasta que el backfill termine, los likes legacy (sin `businessId`) no apareceran en la query nueva — degradacion suave: el usuario veria un like propio antiguo como "no likeado" hasta el backfill. Documentar este window en el plan.
+
+### UX
+
+Sin cambios visibles de UI. El toggle de like sigue siendo optimista (logica inline en `BusinessComments`/`BusinessQuestions` via `useCommentListBase`). La unica diferencia perceptible es la **mejora**: el estado "ya le diste like" aparece junto con los comentarios en vez de tras un segundo round-trip.
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| S1 — `businessId` en write + rules + type + converter | Alta | S |
+| S2 — indice compuesto + query directa en `Promise.all` + borrar `fetchUserLikes` | Alta | S |
+| S3 — script backfill (`--audit`/`--apply`, idempotente, orphan cleanup) | Alta | M |
+| Tests: businessData (query directa), comments (firma), rules allow+deny, backfill primitivas | Alta | M |
+| Rollout secuenciado (indice → rules → codigo → backfill) | Alta | S |
+
+**Esfuerzo total estimado:** M
+
+---
+
+## Out of Scope
+
+- Los hallazgos menores del mismo /health-check (M1 `MenuPhotoViewer` lazy, L1 `OnboardingContext` useMemo, L2 `useUserSearch` debounce cleanup, L3 `BusinessComments` virtualizacion) — son issues/tareas separadas.
+- Cambiar el doc ID compuesto de `commentLikes` (sigue siendo `{userId}__{commentId}`).
+- Migrar `RankingsView.tsx` y `MapView.tsx` a `getBusinessMap()` (followup pendiente de #302/#324, no relacionado a likes).
+- Agregar likes a entidades distintas de comentarios (preguntas ya usan la misma coleccion `comments`, cubiertas).
+
+---
+
+## Tests
+
+Politica `docs/reference/tests.md`: cobertura >= 80% del codigo nuevo, validacion de inputs, paths condicionales, side effects.
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `src/services/businessData.ts` | Service | Query directa de likes dentro del `Promise.all` mapea a `Set<commentId>`; lista vacia de comentarios no dispara query innecesaria; `fetchSingleCollection('comments')` resuelve likes via query directa |
+| `src/services/comments.ts` | Service | `likeComment` escribe `businessId` en el doc; firma de 3 args; `comments.test.ts` (16 cases) actualizado |
+| `src/config/converters/businessConverters.ts` | Converter | `commentLikeConverter` round-trip con `businessId` (`businessConverters.test.ts` ya cubre commentLike) |
+| `src/services/registerOfflineHandlers.ts` | Handler | `comment_like` replay pasa `action.businessId` a `likeComment` |
+| `scripts/backfill-commentlikes-businessid.mjs` | Script | `--audit` no escribe; `--apply` setea `businessId` desde el comment; idempotencia (re-run = no-op); orphan (comment borrado) se elimina en `--apply`; chunking de reads |
+| `tests/rules/commentLikes.rules.test.ts` | Firestore rules | allow create con `businessId` valido + owner + timestamp; deny si `businessId` invalido / falta / campo extra / userId != auth.uid; allow/deny delete por owner |
+
+### Criterios de testing
+
+- Cobertura >= 80% del codigo nuevo
+- Tests de validacion para todos los inputs del usuario
+- Todos los paths condicionales cubiertos (lista vacia, orphan, idempotencia)
+- Side effects verificados (cache, analytics `comment_like`, perf `businessData_userLikes`)
+- `commentLikes` marca su checkbox allow+deny en el inventario de rules tests de `tests.md`
+
+---
+
+## Seguridad
+
+- [ ] `commentLikes` create rule agrega `businessId` a `keys().hasOnly(['userId','commentId','businessId','createdAt'])`
+- [ ] `businessId` validado con `isValidBusinessId()` (mismo helper que `userTags`/`favorites`/`listItems`)
+- [ ] `userId == request.auth.uid` y `createdAt == request.time` se conservan
+- [ ] La query nueva `where('userId','==',uid)` mantiene el aislamiento: un usuario solo lee sus propios likes (no se exponen likes ajenos)
+- [ ] Comentario obsoleto en `firestore.rules` (lineas 172-175) reemplazado — ya no aplica la justificacion de "no resource.data checks"
+- [ ] Rate limit server-side de `commentLikes` (50/dia) en `onCommentLikeCreated` se conserva intacto — `businessId` no altera el path del trigger
+- [ ] Backfill corre con ADC (`gcloud auth application-default login`), sin Service Account keys en disco (security.md env vars #5)
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| Write de `commentLike` con `businessId` arbitrario | Inyectar businessId falso para envenenar la query / inflar conteos cross-business | `isValidBusinessId()` en rules (regex `biz_NNN`), rate limit 50/dia en trigger (ya existe) |
+| Write con campo extra adjunto | Inyeccion de datos | `hasOnly()` whitelist estricta |
+| Query masiva de likes ajenos | Scraping | Query siempre filtra `userId == auth.uid`; read rule `auth != null` ya restringe a autenticados |
+
+(El feature escribe a Firestore — checklist):
+
+- [ ] Create rule tiene `hasOnly()` con whitelist de campos (`userId`, `commentId`, `businessId`, `createdAt`)
+- [ ] CADA campo en `hasOnly()` tiene validacion de tipo (`userId == auth.uid`, `commentId is string` + size>0, `businessId` via `isValidBusinessId`, `createdAt == request.time`)
+- [ ] Campos string con limite/patron (`commentId.size() > 0`, `businessId` regex)
+- [ ] No hay update rule (commentLikes solo create/delete) — no aplica `affectedKeys()`
+- [ ] Campos immutables (userId, commentId, businessId) no se pueden modificar (no hay update path)
+- [ ] Rate limit server-side ya existe en `onCommentLikeCreated` con `snap.ref.delete()` al exceder (no se toca)
+- [ ] La coleccion ya tiene trigger con rate limit (sin cambios)
+- [ ] Sin campos `is list` ni texto libre — no aplica moderacion
+
+(No agrega campos a `userSettings`. Lee solo datos propios del usuario — no habilita scraping nuevo.)
+
+---
+
+## Deuda tecnica y seguridad
+
+Consultado: `gh issue list --label security/tech debt --state open` (no hay issues con esos labels; todos los tech-debt actuales estan bajo `enhancement`). Issues abiertos relacionados al area: #347 (perf-instrumentation), #344 (offline guard en custom tags / profile), #342 (deps + secrets).
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| Guard #302 R3 (`docs/reference/guards/302-performance.md`) | mitiga (este feature lo cierra) | Implementar el fix exacto documentado en el guard; marcar como cumplido |
+| #347 (count queries sin `measureAsync`) | empeora si se ignora | La query nueva DEBE usar `measuredGetDocs` (`businessData_userLikes`) — no introducir otra query sin instrumentar |
+| #344 (offline guard) | afecta | El path `comment_like` offline ya esta cubierto; verificar que el replay con `businessId` no rompa la cola existente |
+
+### Mitigacion incorporada
+
+- Cerrar guard #302 R3 (fan-out prohibido → query directa). Paso en el plan: S2.
+- Instrumentar la query nueva con `measuredGetDocs` (alineado con #347). Paso en el plan: S2.
+- Limpiar el comentario obsoleto en `firestore.rules`. Paso en el plan: S1.
+
+---
+
+## Robustez del codigo
+
+### Checklist de hooks async
+
+- [ ] No se agregan hooks nuevos — `useCommentListBase` ya existe y maneja toggle/error con `try/catch` + `toast.error`
+- [ ] Handlers async existentes conservan su `try/catch` (no se tocan)
+- [ ] `fetchUserLikes` se elimina (funcion no exportada fuera del modulo + tests) — verificar que no quede referenciada
+- [ ] No hay `setState` post-async sin guard nuevo
+- [ ] El script de backfill vive en `scripts/` (no en `src/hooks/`)
+- [ ] Sin nuevas keys de localStorage
+- [ ] Archivos nuevos (script) no superan 400 lineas
+- [ ] `logger.error` no envuelto en `if (DEV)`
+
+### Checklist de observabilidad
+
+- [ ] Trigger no cambia — `trackFunctionTiming` ya presente en `onCommentLikeCreated/Deleted`
+- [ ] Query nueva usa `measuredGetDocs('businessData_userLikes', ...)` y la clave `businessData_userLikes` se agrega a `perfHelpers.ts:QUERY_LABELS` con label en espanol (hoy falta — ver #347)
+- [ ] No hay `trackEvent` nuevo (`comment_like` ya existe en GA4 definitions)
+
+### Checklist offline
+
+- [ ] El toggle de like ya deshabilita/encola correctamente offline (`withOfflineSupport`) — verificar que el replay pase `businessId`
+- [ ] Error handlers muestran `toast.error` en todos los environments (ya implementado en `useCommentListBase`)
+
+### Checklist de documentacion
+
+- [ ] No hay secciones nuevas de HomeScreen
+- [ ] No hay eventos analytics nuevos
+- [ ] `CommentLike` type modificado en `src/types/business.ts` (dominio correcto, no barrel)
+- [ ] `docs/reference/firestore.md` actualizado: campo `businessId` en `commentLikes` + indice nuevo
+- [ ] `docs/reference/patterns.md` actualizado: `Batched likes` entry (linea ~91 de project-reference) reemplazado por "query directa por (userId, businessId)"
+- [ ] `docs/reference/guards/302-performance.md` R3 marcado como cumplido
+- [ ] `docs/reference/security.md` tabla de rules: fila `commentLikes` actualizada con `businessId`
+- [ ] `docs/reference/tests.md`: marcar checkbox allow+deny de `commentLikes` en inventario de rules
+
+---
+
+## Offline
+
+### Data flows
+
+| Operacion | Tipo (read/write) | Estrategia offline | Fallback UI |
+|-----------|-------------------|-------------------|-------------|
+| `likeComment` (con businessId) | write | Encolar en IndexedDB via `withOfflineSupport('comment_like', {businessId}, ...)` (ya existe) | Toggle optimista local; revert on error |
+| `unlikeComment` | write | Idem `comment_unlike` (ya existe) | Idem |
+| Query de likes en `fetchBusinessData` | read | Persistencia offline de Firestore (prod) + readCache 3-tier de `useBusinessData` | StaleBanner si datos stale |
+| Backfill | write (server, one-off) | N/A (corre con Admin SDK online) | N/A |
+
+### Checklist offline
+
+- [ ] Reads de Firestore: la query nueva entra al `Promise.all` que ya pasa por readCache 3-tier de `useBusinessData`
+- [ ] Writes: el like ya tiene queue offline; el replay debe propagar `businessId`
+- [ ] APIs externas: N/A
+- [ ] UI: el indicador offline existente del toggle se conserva
+- [ ] Datos criticos: los likes se cachean junto al resto del business data
+
+### Esfuerzo offline adicional: S
+
+---
+
+## Modularizacion y % monolitico
+
+### Checklist modularizacion
+
+- [ ] Logica en services (`businessData.ts`, `comments.ts`) — no en componentes de layout
+- [ ] No se agregan componentes nuevos
+- [ ] No se agregan useState a AppShell/SideMenu
+- [ ] Firebase SDK solo en services/ y scripts/ (Admin SDK) — no en components/
+- [ ] El script de backfill no es un hook (vive en `scripts/`)
+- [ ] No se crean barrels ni se appendea a barrels compartidos
+- [ ] El converter modificado vive en `businessConverters.ts` (dominio correcto)
+- [ ] Ningun archivo nuevo supera 400 lineas
+- [ ] No se necesita estado global nuevo
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | = | Cambio confinado a service layer; ningun componente se modifica salvo propagacion de `businessId` ya presente |
+| Estado global | = | Sin contextos nuevos |
+| Firebase coupling | = | Query sigue en service, no en componente; elimina una funcion (`fetchUserLikes`), reduce superficie |
+| Organizacion por dominio | = | Cambios en dominio business correcto |
+
+---
+
+## Accesibilidad y UI mobile
+
+### Checklist de accesibilidad
+
+- [ ] No se agregan elementos interactivos nuevos (sin cambios de UI)
+- [ ] El boton de like existente conserva su `aria-label` y `aria-live` en el contador
+- [ ] No hay imagenes nuevas
+- [ ] No hay formularios nuevos
+
+### Checklist de copy
+
+- [ ] Sin copy nuevo user-facing (los toasts de error de like ya existen en `MSG_COMMENT`)
+- [ ] Logs y comentarios de codigo del script en espanol consistente
+- [ ] Terminologia: "comercios", "comentarios", "me gusta"
+
+---
+
+## Success Criteria
+
+1. Abrir un comercio con N comentarios ejecuta **1** read de `commentLikes` (no `ceil(N/30)`), medible como caida en operaciones via la clave `businessData_userLikes` del dashboard de performance.
+2. El estado "ya le diste me gusta" se resuelve dentro del `Promise.all` principal (sin round-trip extra post-load).
+3. Todo doc `commentLikes` nuevo incluye `businessId` valido; las rules rechazan writes sin `businessId` o con `businessId` invalido (test allow+deny verde).
+4. El backfill `--apply` setea `businessId` en el 100% de los docs legacy con comentario existente, elimina los huerfanos, y es idempotente (re-run = 0 writes).
+5. Guard #302 R3 cumplido: `fetchUserLikes` eliminado y la query directa es la unica via de lectura de likes; CI de cobertura >= 80% verde.
+
+---
+
+## Validacion Funcional
+
+**Analista**: Sofia (checklist aplicado por prd-writer — el agente subagente no es spawneable en este contexto; se ejecutaron las verificaciones `grep`/`ls` de Ciclo 1 contra el codebase)
+**Fecha**: 2026-06-09
+**Estado**: VALIDADO CON OBSERVACIONES
+
+### Hallazgos cerrados en esta iteracion
+
+- IMPORTANTE: "clave de perf afirmada como registrada sin verificar" → corregido en S2 y checklist de observabilidad: `businessData_userLikes` NO esta en `QUERY_LABELS`; se agrega como parte del feature (verificado con `grep` en `perfHelpers.ts`).
+- IMPORTANTE: "interaccion con readCache y merge de refetch parcial no documentada" → agregado edge en S2 explicando que el shape del `Set<commentId>` no cambia, no requiere invalidar cache (verificado en `readCache.ts:22/115` y `useBusinessData.ts:126`).
+- BLOQUEANTE potencial: "que ven los usuarios con likes legacy durante el rollout (backwards compat de docs sin `businessId`)" → resuelto en S3: window de degradacion suave documentado (like antiguo aparece como "no likeado" hasta el backfill), con orden de rollout secuenciado y reversible.
+
+### Verificaciones de Ciclo 1 ejecutadas
+
+- `isValidBusinessId()` existe en `firestore.rules` (linea 12, usado en 8 colecciones) — confirmado.
+- `businessId` ya disponible en todos los call sites de like (`useCommentListBase.ts:116-120`, `OfflineAction` top-level) — confirmado, sin cambio de payload.
+- No quedan otros consumidores de `fetchUserLikes` fuera de `businessData.ts` — confirmado.
+
+### Observaciones abiertas para el implementador
+
+- Free tier billing: el feature **reduce** reads (de `ceil(N/30)+1` a 1 por apertura de comercio). Riesgo de billing nulo. El write de like suma un campo, no un doc — sin impacto en write count.
+- El backfill toca toda la coleccion `commentLikes` una vez. En `--apply`, contar el volumen en `--audit` antes para estimar si supera el cap de writes/dia del tier (batches de 500, eventualmente correr en ventanas si el volumen es alto). Decision operativa para el plan.
+- Race entre dos tabs/devices likeando el mismo comentario: el doc ID compuesto `{userId}__{commentId}` ya garantiza idempotencia (setDoc); sin cambio de comportamiento.
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** El handler offline comment_like destructura {userId,payload} y NO extrae businessId — debe pasar action.businessId. Re-like durante el window de backfill re-dispara onCommentLikeCreated (notif duplicada + rate limit). El --audit debe reportar el conteo de docs legacy.

--- a/docs/feat/infra/343-fetchuserlikes-fanout-businessid/specs.md
+++ b/docs/feat/infra/343-fetchuserlikes-fanout-businessid/specs.md
@@ -1,0 +1,398 @@
+# Specs: fetchUserLikes fan-out → query-by-businessId (cerrar guard #302 R3)
+
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-10
+**Issue:** #343
+
+---
+
+## Modelo de datos
+
+### Coleccion `commentLikes` (modificada)
+
+- **Doc ID compuesto:** `{userId}__{commentId}` (sin cambio — Out of Scope mantenerlo).
+- **Campo nuevo:** `businessId: string` (formato `biz_NNN`). Permite la query directa `where('userId','==',uid) && where('businessId','==',bId)`, eliminando el fan-out por `documentId() in`.
+
+Documento resultante:
+
+```text
+commentLikes/{userId}__{commentId}
+  userId: string        // == auth.uid
+  commentId: string      // 1+ chars
+  businessId: string     // NUEVO — formato biz_NNN
+  createdAt: Timestamp   // == request.time
+```
+
+### Tipo `CommentLike` (`src/types/business.ts`)
+
+```typescript
+export interface CommentLike {
+  userId: string;
+  commentId: string;
+  businessId: string;   // NUEVO
+  createdAt: Date;
+}
+```
+
+### Indice compuesto (`firestore.indexes.json`)
+
+Nuevo indice `COLLECTION` scope sobre `commentLikes`:
+
+```json
+{
+  "collectionGroup": "commentLikes",
+  "queryScope": "COLLECTION",
+  "fields": [
+    { "fieldPath": "userId", "order": "ASCENDING" },
+    { "fieldPath": "businessId", "order": "ASCENDING" }
+  ]
+}
+```
+
+> El indice existente `commentLikes(userId ASC, createdAt ASC)` se **conserva**. No tiene consumidor verificado hoy (ninguna query lo usa: `fetchRecentCommentLikes` ordena por `createdAt` sin `where('userId')`, `fetchUsersPanelData` usa solo `limit()`, `deleteUserData` filtra por `userId` sin `orderBy`). Se conserva por conservadurismo — borrar indices fuera del scope del feature es out-of-scope y de bajo riesgo, no porque una query especifica lo requiera. El nuevo es aditivo.
+
+### Edge — cache `userCommentLikes` (no cambia de shape)
+
+`useBusinessData` deriva `userCommentLikes` como `Set<commentId>` (string), lo serializa en `readCache` como `string[]` y lo preserva en el merge de `patchedRef` (`useBusinessData.ts:93,117-118`). Este feature **no cambia el shape del Set**: sigue siendo `Set<string>` de `commentId`s. El cambio es solo *como se obtiene* (query directa por field en vez de fan-out por doc ID). No requiere invalidar ni migrar entries cacheadas — el merge `merged.userCommentLikes = prev.userCommentLikes` sigue siendo correcto.
+
+## Firestore Rules
+
+Reemplazo de `match /commentLikes/{docId}` (firestore.rules lineas 172-185). Se elimina el comentario obsoleto (lineas 173-175) que justificaba la imposibilidad de `resource.data` checks — ya no aplica porque la query nueva filtra por field.
+
+```
+    // Likes en comentarios — cualquier usuario autenticado puede leer.
+    // La query de likes filtra por (userId == auth.uid, businessId), por lo que
+    // un usuario solo ve sus propios likes. Owner crea/elimina su like.
+    match /commentLikes/{docId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null
+        && request.resource.data.keys().hasOnly(['userId', 'commentId', 'businessId', 'createdAt'])
+        && request.resource.data.userId == request.auth.uid
+        && request.resource.data.commentId is string
+        && request.resource.data.commentId.size() > 0
+        && isValidBusinessId(request.resource.data.businessId)
+        && request.resource.data.createdAt == request.time;
+      allow delete: if request.auth != null
+        && resource.data.userId == request.auth.uid;
+    }
+```
+
+> `commentLikes` no tiene `update` rule (solo create/delete) — `businessId` es inmutable por construccion (no hay path de modificacion).
+
+### Rules impact analysis
+
+| Query (service file) | Collection | Auth context | Rule que la permite | Cambio? |
+|---------------------|------------|-------------|-------------------|---------|
+| query directa likes en `fetchBusinessData` (`businessData.ts`) `where(userId==uid)+where(businessId==bId)` | commentLikes | Owner leyendo sus propios likes | `allow read: if auth != null` (read no filtra por field; el filtro `userId==uid` lo aplica la query) | No (rule de read sin cambio) |
+| query directa likes en `fetchSingleCollection('comments')` | commentLikes | idem | idem | No |
+| `likeComment(uid, commentId, businessId)` create (`comments.ts`) | commentLikes | Owner creando su like con businessId | `allow create … hasOnly([…,'businessId'])` | **SI** — agregar `businessId` al `hasOnly()` + `isValidBusinessId()` |
+| replay offline `comment_like` (`registerOfflineHandlers.ts`) | commentLikes | idem (mismo `likeComment`) | idem create rule | cubierto por el mismo cambio |
+
+> El backfill (`scripts/backfill-commentlikes-businessid.mjs`) corre con Admin SDK (ADC) — bypasea rules. No requiere analisis de rules.
+
+### Field whitelist check
+
+| Collection | Campo nuevo | En create `hasOnly()`? | En update `affectedKeys().hasOnly()`? | Cambio? |
+|-----------|-------------|----------------------|--------------------------------------|---------|
+| commentLikes | businessId | NO (hoy `['userId','commentId','createdAt']`) | N/A (no hay update rule) | **SI** — agregar `'businessId'` al create `hasOnly()` |
+
+## Cloud Functions
+
+Sin cambios. `onCommentLikeCreated` / `onCommentLikeDeleted` (`functions/src/triggers/commentLikes.ts`) se gatillan por el path `commentLikes/{docId}` — agregar `businessId` al doc no altera el path ni el rate limit (50/dia via `checkRateLimit`). El trigger ya tiene `trackFunctionTiming`.
+
+> **Caso conocido (re-like durante el window de backfill):** un like legacy (sin `businessId`) se ve "no likeado" en la query nueva hasta que el backfill corre. El usuario puede re-likear; el `setDoc` con doc ID compuesto es idempotente y **auto-backfillea** el `businessId` faltante — pero re-escribir el doc **re-dispara `onCommentLikeCreated`**, lo que (a) genera una notificacion duplicada al autor del comentario y (b) consume una unidad del rate limit 50/dia del usuario. **Decision: aceptable.** El window es corto (orden de minutos tras el deploy del codigo, hasta correr `--apply`), el doble-disparo solo afecta a usuarios que re-likean en ese intervalo un comentario que ya habian likeado antes, y el rate limit 50/dia tiene margen suficiente. La mitigacion operativa es minimizar el window: correr `--apply` inmediatamente despues del deploy del codigo (ver orden de rollout en plan).
+
+## Seed Data
+
+El campo `businessId` se agrega a `commentLikes`. **Ambos seeds crean docs `commentLikes` hoy** (verificado: `seed-admin-data.mjs:281`, `seed-staging.ts:241`), por lo que actualizarlos es **obligatorio** — sin el campo, las rules nuevas rechazan los writes del seed y la query directa no encuentra esos likes.
+
+### Emulator seed (`scripts/seed-admin-data.mjs`)
+
+- Coleccion: `commentLikes` (bloque "5c. Comment likes", lineas 270-286).
+- El `setDoc` (linea 281-285) debe incluir `businessId`. El `businessId` correcto es el del comentario likeado. Hoy el tracking `commentIds.push({ id: ref.id, userId })` (linea 232) **no captura** `businessId` — el comment write (linea 225) genera `businessId: randomFrom(BUSINESS_IDS)` en una variable local. Cambio: capturar ese `businessId` en una const y pushearlo: `commentIds.push({ id: ref.id, userId, businessId })`. Luego en el like: `{ userId, commentId: comment.id, businessId: comment.businessId, createdAt: daysAgo(...) }`. Hacer lo mismo en el bloque de replies (lineas 249-258) si esos comments tambien se likean.
+- Ejemplo resultante: `{ userId: 'seed_user_1', commentId: '<ref.id>', businessId: 'biz_001', createdAt: daysAgo(5) }`.
+
+### Staging seed (`scripts/seed-staging.ts`)
+
+- Coleccion: `commentLikes` (bloque "11. Comment likes", lineas 238-246).
+- El like usa `commentId: \`seed_comment_${randomInt(0, 59)}\`` (string sin ref real). Derivar un `businessId` valido del pool: `businessId: BUSINESS_IDS[i % BUSINESS_IDS.length]` (mismo patron que el resto del archivo). Como el `commentId` es sintetico y no apunta a un doc real, el `businessId` no necesita coincidir con un comment existente — solo debe ser un `biz_NNN` valido para pasar las rules y aparecer en la query.
+- Ejemplo resultante: `{ userId: USER_IDS[i % USER_IDS.length], commentId: 'seed_comment_3', businessId: BUSINESS_IDS[i % BUSINESS_IDS.length], createdAt: daysAgo(...) }`.
+
+## Componentes
+
+Sin componentes nuevos ni modificados visualmente. La UI de like (`BusinessComments`, `BusinessQuestions` via `useCommentListBase`/`useCommentListBase.ts`) no cambia su markup ni a11y. La unica diferencia es que el estado "ya le diste me gusta" llega junto con los comentarios (dentro del `Promise.all`).
+
+### Mutable prop audit
+
+No aplica — no hay screens de detalle/form editables nuevos. El toggle de like ya usa estado local optimista (`optimisticLikes` Map) en `useCommentListBase`; no cambia.
+
+## Textos de usuario
+
+Sin copy nuevo. Los toasts de error de like ya existen en `MSG_COMMENT.likeError`. Los logs/comentarios del script de backfill van en espanol consistente.
+
+| Texto | Donde se usa | Notas |
+|-------|-------------|-------|
+| (ninguno nuevo) | — | — |
+
+## Hooks
+
+Sin hooks nuevos. `useCommentListBase` (hook que centraliza el toggle de like de comments y questions) se modifica en un solo punto: la closure que invoca `likeComment` pasa a propagar `businessId` (ver Integracion).
+
+## Servicios
+
+### `likeComment` (`src/services/comments.ts`) — firma modificada
+
+```typescript
+export async function likeComment(userId: string, commentId: string, businessId: string): Promise<void> {
+  const docId = `${userId}__${commentId}`;
+  await setDoc(doc(db, COLLECTIONS.COMMENT_LIKES, docId), {
+    userId,
+    commentId,
+    businessId,             // NUEVO
+    createdAt: serverTimestamp(),
+  });
+  trackEvent('comment_like', { comment_id: commentId });
+}
+```
+
+- `unlikeComment` no cambia (borra por doc ID).
+
+### `fetchBusinessData` (`src/services/businessData.ts`) — query directa
+
+- Agregar la query de likes como **octavo elemento** del `Promise.all`:
+
+```typescript
+measuredGetDocs('businessData_userLikes', query(
+  collection(db, COLLECTIONS.COMMENT_LIKES).withConverter(commentLikeConverter),
+  where('userId', '==', uid),
+  where('businessId', '==', bId),
+)),
+```
+
+- Mapear el resultado a `Set<string>` directamente desde `d.data().commentId` (ya no se parsea el doc id):
+  `const userCommentLikes = new Set(likesSnap.docs.map((d) => d.data().commentId));`
+- Eliminar la llamada post-`Promise.all` a `fetchUserLikes` (lineas 148) y la funcion `fetchUserLikes` (lineas 21-50).
+- Importar `commentLikeConverter` desde `../config/converters`.
+
+### `fetchSingleCollection('comments')` (`src/services/businessData.ts`)
+
+- En el `case 'comments'`, reemplazar `const userCommentLikes = await fetchUserLikes(uid, ...)` por la misma query directa filtrada por `(userId, businessId)`. Se resuelve junto al snap de comments (puede ser un `Promise.all` interno de 2 queries o secuencial — el shape de retorno `{ comments, userCommentLikes }` no cambia).
+
+### Instrumentacion
+
+- La clave `businessData_userLikes` se conserva (ahora envuelve `measuredGetDocs` de una sola query dentro del `Promise.all`).
+- Agregar `businessData_userLikes: 'Detalle: likes del usuario'` a `QUERY_LABELS` en `src/components/admin/perf/perfHelpers.ts` (hoy falta — alineado con #347).
+
+### `commentLikeConverter` (`src/config/converters/businessConverters.ts`)
+
+```typescript
+export const commentLikeConverter: FirestoreDataConverter<CommentLike> = {
+  toFirestore(like: CommentLike) {
+    return { userId: like.userId, commentId: like.commentId, businessId: like.businessId, createdAt: like.createdAt };
+  },
+  fromFirestore(snapshot, options?) {
+    const d = snapshot.data(options);
+    return { userId: d.userId, commentId: d.commentId, businessId: d.businessId, createdAt: toDate(d.createdAt) };
+  },
+};
+```
+
+### Script backfill (`scripts/backfill-commentlikes-businessid.mjs`)
+
+Sigue el patron canonico de `scripts/migrate-displayname-lower-sync.mjs`:
+
+- Modos `--audit` (default, read-only) y `--apply`.
+- Admin SDK via ADC (`applicationDefault()`), precondicion `checkCredentials()`.
+- Bloque CLI gateado por `import.meta.url === file://${process.argv[1]}`.
+- Primitivas exportadas para test: `parseMode`, `getDb`, `audit(db)`, `applyBackfill(db, plan)`, `printAuditReport`, `run`.
+- Batches de 500 (`BATCH_SIZE`).
+- Reads de `comments/{commentId}` agrupados con `db.getAll(...refs)` en chunks de 30 (mismo patron que `fanOutToFollowers` #312, `FANOUT_GETALL_CHUNK_SIZE`), resueltos en paralelo.
+
+Logica de `audit(db)`:
+
+1. `db.collection('commentLikes').get()` → recorrer docs.
+2. Clasificar cada doc:
+   - `hasBusinessId`: ya tiene `businessId` string valido → skip (idempotencia).
+   - candidato: sin `businessId`. Extraer `commentId` (del campo o del doc id `split('__')[1]`).
+3. Para los candidatos: chunk de `commentId`s en grupos de 30, `db.getAll(...commentRefs)`. Por cada like:
+   - comment existe → categoria `toBackfill` con `{ likeId, businessId: comment.businessId }`.
+   - comment NO existe → categoria `orphan` con `{ likeId }`.
+4. **Reportar el conteo total de docs legacy** (`total`, `withBusinessId`, `toBackfill`, `orphan`) en el reporte de `--audit`. Este conteo decide si el `--apply` supera el cap de writes/dia del free tier (un backfill = `toBackfill` writes + `orphan` deletes). Si el volumen excede el cap diario, ventanear el `--apply` (correr en multiples dias o con pausa entre lotes). El reporte de `--audit` imprime explicitamente: `"Legacy docs a escribir: <N>. Cap free tier writes/dia: 20000. Ventanear si N supera el cap."`.
+
+Logica de `applyBackfill(db, plan)` (idempotente):
+
+- `plan.toBackfill`: `batch.update(ref, { businessId })`.
+- `plan.orphan`: `batch.delete(ref)` (un like sin comentario nunca volveria a leerse por la query nueva).
+- Commit cada 500 ops. Re-run tras exito = 0 ops (los docs ya tienen `businessId` o ya fueron borrados).
+
+## Integracion
+
+### Punto 1 — call site del toggle de like (`src/hooks/useCommentListBase.ts:116-122`)
+
+El meta del `withOfflineSupport('comment_like', { userId, businessId, businessName }, ...)` **ya pasa `businessId`** (linea 118). El cambio es que el `onlineAction` propague `businessId` a `likeComment`:
+
+```typescript
+() => likeComment(user.uid, commentId, businessId),
+```
+
+(`businessId` ya esta en el closure scope del `useCallback`, dependencia listada en linea 131).
+
+### Punto 2 — handler offline `comment_like` (`src/services/registerOfflineHandlers.ts:83-87`)
+
+Hoy el handler destructura `{ userId, payload }` y **NO extrae `businessId`** — llama `likeComment(userId, commentId)` (2 args). El call site SI lo pasa al `OfflineAction` (`businessId` es campo top-level requerido de `OfflineAction`, propagado por `withOfflineSupport` desde el meta). El cambio es la firma de destructuring del handler:
+
+```typescript
+comment_like: async ({ userId, businessId, payload }: OfflineAction) => {
+  const { commentId } = payload as CommentLikePayload;
+  const { likeComment } = await import('./comments');
+  await likeComment(userId, commentId, businessId);
+},
+```
+
+- `CommentLikePayload` (`src/types/offline.ts:110-112`) **no cambia** (`{ commentId }`) — `businessId` viaja en el top-level del `OfflineAction`, no en el payload.
+- `comment_unlike` no cambia.
+
+### Preventive checklist
+
+- [x] **Service layer**: la query y el write viven en `src/services/` (`businessData.ts`, `comments.ts`). Ningun componente importa `firebase/firestore` para esto.
+- [x] **Duplicated constants**: ninguna constante nueva duplicada. `BATCH_SIZE`/chunk size son locales al script (consistentes con el patron migrate).
+- [x] **Context-first data**: no aplica — la query reemplaza otra query, no lee de un context.
+- [x] **Silent .catch**: el script usa `logger.error?.(...)` en los catch de batch commit; el toggle conserva `logger.error` + `toast.error` (`useCommentListBase.ts:126-127`).
+- [x] **Stale props**: no aplica — sin componentes nuevos con props mutables.
+
+## Tests
+
+| Archivo test | Que testear | Tipo |
+|-------------|-------------|------|
+| `src/services/businessData.test.ts` (nuevo o ampliado) | Query directa de likes dentro del `Promise.all` mapea a `Set<commentId>` desde `d.data().commentId`; lista de comentarios vacia no rompe (Set vacio); `fetchSingleCollection('comments')` resuelve likes via query directa; `fetchUserLikes` eliminada (no exportada / sin referencias) | Service |
+| `src/services/comments.test.ts` (16 cases existentes) | `likeComment` escribe `businessId` en el doc (3er arg en el `setDoc` payload); firma de 3 args; `unlikeComment` sin cambio; actualizar cases que llaman `likeComment` con 2 args | Service |
+| `src/config/converters/businessConverters.test.ts` (23 cases existentes) | `commentLikeConverter` round-trip con `businessId` (`toFirestore` incluye `businessId`, `fromFirestore` lo lee) | Converter |
+| `src/services/__tests__/registerOfflineHandlers.test.ts` (o el existente del replay) | `comment_like` replay extrae `action.businessId` y lo pasa a `likeComment(userId, commentId, businessId)` — **assertion explicita del 3er arg**; `comment_unlike` sin cambio | Handler |
+| `scripts/__tests__/backfill-commentlikes-businessid.test.mjs` | `--audit` no escribe; `audit` clasifica `withBusinessId`/`toBackfill`/`orphan` y reporta `total`; chunking de `getAll` en grupos de 30; `applyBackfill` setea `businessId` desde el comment; orphan (comment borrado) se elimina en `--apply`; idempotencia (re-run = 0 ops); reporte imprime conteo de legacy docs | Script |
+| `tests/rules/commentLikes.rules.test.ts` (nuevo) | ALLOW create con `businessId` valido + owner + `commentId` no vacio + `createdAt==request.time`; DENY: `businessId` invalido (no `biz_NNN`), `businessId` ausente, campo extra (`hasOnly`), `userId != auth.uid`, `createdAt != request.time`; ALLOW delete owner; DENY delete no-owner; ALLOW read autenticado | Rules |
+
+### Mock strategy
+
+- Firestore (service tests): mock SDK (`getDocs`, `setDoc`, `collection`, `query`, `where`, `withConverter`). Verificar el payload del `setDoc` incluye `businessId`.
+- Analytics: mock `trackEvent`.
+- Script: inyectar `db` fake con `collection().get()` y `getAll()` mockeados (sin emulador). Patron del test de `migrate-displayname-lower-sync`.
+- Rules: `@firebase/rules-unit-testing` v5 contra emulador, helpers de `tests/rules/setup.ts`.
+
+### Criterio de aceptacion
+
+- Cobertura >= 80% del codigo nuevo.
+- Paths condicionales cubiertos: lista vacia, orphan, idempotencia, chunking.
+- Side effects: cache shape (Set), analytics `comment_like`, perf `businessData_userLikes`.
+- `commentLikes` marca su checkbox allow+deny en el inventario de rules de `tests.md`.
+
+## Analytics
+
+Sin eventos nuevos. `comment_like` ya existe en GA4 definitions y se conserva intacto en `likeComment`.
+
+---
+
+## Offline
+
+### Cache strategy
+
+| Dato | Estrategia | TTL | Storage |
+|------|-----------|-----|---------|
+| `userCommentLikes` (Set<commentId>) | Entra al `Promise.all` de `useBusinessData` → readCache 3-tier (memory → IndexedDB → Firestore). Shape **identico** al actual | 5 min (memory) / LRU 20 entries (IndexedDB) | `modo-mapa-read-cache` (IndexedDB) + Firestore persistent cache (prod) |
+
+### Writes offline
+
+| Operacion | Mecanismo | Conflict resolution |
+|-----------|-----------|-------------------|
+| `likeComment` (con businessId) | `withOfflineSupport('comment_like', { userId, businessId, businessName }, { commentId }, ...)` — ya existe. Replay pasa `action.businessId` a `likeComment` | Doc ID compuesto `{userId}__{commentId}` → `setDoc` idempotente (re-like no duplica) |
+| `unlikeComment` | `withOfflineSupport('comment_unlike', ...)` — sin cambio | `deleteDoc` idempotente |
+
+### Fallback UI
+
+Sin cambios. El toggle optimista local + `StaleBanner` (cuando datos stale) ya cubren el offline. El boton de like conserva su comportamiento offline.
+
+---
+
+## Accesibilidad y UI mobile
+
+| Componente | Elemento | aria-label | Min touch target | Error state |
+|-----------|----------|------------|-----------------|-------------|
+| (ninguno nuevo) | — | — | — | — |
+
+Sin elementos interactivos nuevos. El boton de like existente conserva su `aria-label` y el `aria-live="polite"` del contador.
+
+### Reglas
+
+- Sin cambios de UI — no aplican las reglas de IconButton/touch target/img onError.
+
+## Textos y copy
+
+| Texto | Donde | Regla aplicada |
+|-------|-------|----------------|
+| (ninguno nuevo) | — | — |
+
+### Reglas de copy
+
+- Logs/comentarios del script en espanol consistente.
+- Terminologia: "comercios", "comentarios", "me gusta".
+
+---
+
+## Decisiones tecnicas
+
+1. **`businessId` en el top-level del `OfflineAction`, no en el payload.** `OfflineAction.businessId` ya es un campo requerido (`types/offline.ts:41`) y el call site ya lo pasa via el meta de `withOfflineSupport`. No se toca `CommentLikePayload`. Esto minimiza el cambio y mantiene el contrato del replay consistente con los otros handlers (favorite/tag/rating ya leen `businessId` del top-level).
+
+2. **Indice aditivo, no reemplazo.** Se agrega `(userId, businessId)`. El indice `(userId, createdAt)` se conserva por conservadurismo: no tiene consumidor verificado hoy (ninguna query lo usa), pero borrar indices ajenos al scope del feature es out-of-scope y de bajo riesgo.
+
+3. **Orphan cleanup en el backfill.** Un like cuyo comentario fue borrado nunca volveria a leerse por la query nueva (filtra por `businessId`, que el orphan no puede resolver), por lo que no aporta. Hoy **no existe cascade de likes al borrar un comentario** (`onCommentDeleted` solo cascadea las replies huerfanas, no los `commentLikes`), por eso los orphans se acumulan. El backfill es la unica via de limpieza; borrarlos (vs dejarlos con `businessId` vacio) evita basura permanente.
+
+4. **Re-dispatch del trigger en re-like durante el window: aceptado.** Ver seccion Cloud Functions. Window minimizado corriendo `--apply` inmediatamente post-deploy.
+
+5. **Reportar conteo de legacy docs en `--audit`.** Decide si `--apply` supera el cap de writes/dia del free tier; si lo supera, ventanear. El `--audit` lo imprime explicito.
+
+6. **No invalidar cache.** El shape del `Set<commentId>` no cambia; el merge `patchedRef` sigue siendo correcto sin migrar entries cacheadas.
+
+---
+
+## Hardening de seguridad
+
+### Firestore rules requeridas
+
+Ver seccion "Firestore Rules" arriba — el bloque `match /commentLikes/{docId}` con `hasOnly(['userId','commentId','businessId','createdAt'])`, `isValidBusinessId(businessId)`, `userId == auth.uid`, `commentId.size() > 0`, `createdAt == request.time`. Comentario obsoleto (lineas 173-175) eliminado.
+
+### Rate limiting
+
+| Coleccion | Limite | Implementacion |
+|-----------|--------|---------------|
+| commentLikes | 50/dia | `checkRateLimit` en `onCommentLikeCreated` (ya existe, `snap.ref.delete()` al exceder) — **no se toca** |
+
+### Vectores de ataque mitigados
+
+| Ataque | Mitigacion | Archivo |
+|--------|-----------|---------|
+| Inyectar `businessId` falso para envenenar query / inflar conteos cross-business | `isValidBusinessId()` (regex `biz_NNN`) en create rule | `firestore.rules` |
+| Inyeccion de campo extra | `hasOnly()` whitelist estricta | `firestore.rules` |
+| Scraping de likes ajenos | Query siempre filtra `userId == auth.uid`; read rule `auth != null` | `firestore.rules` + `businessData.ts` |
+| Spam de likes | Rate limit 50/dia server-side (intacto) | `functions/src/triggers/commentLikes.ts` |
+| Backfill con credenciales en disco | ADC (`gcloud auth application-default login`), sin Service Account keys commiteadas | `scripts/backfill-commentlikes-businessid.mjs` |
+
+---
+
+## Deuda tecnica: mitigacion incorporada
+
+Consultado en PRD: no hay issues con labels `security`/`tech debt` abiertos; tech-debt actuales bajo `enhancement`. Issues relacionados: #347 (perf-instrumentation), #344 (offline guard), #342 (deps+secrets).
+
+| Issue | Que se resuelve | Paso del plan |
+|-------|----------------|---------------|
+| Guard #302 R3 (`docs/reference/guards/302-performance.md`) | Fan-out prohibido → query directa por `(userId, businessId)`; `fetchUserLikes` eliminada | Fase 3 |
+| #347 (queries sin label en `QUERY_LABELS`) | `businessData_userLikes` agregada a `QUERY_LABELS` con label en espanol | Fase 3 |
+| #344 (offline guard) | Verificar que el replay con `businessId` no rompe la cola existente | Fase 2 + test |
+
+---
+
+## Revisión Técnica (Gate Diego)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Revisor:** Diego (solution architect)
+
+**Observaciones:** Cobertura PRD→specs completa, data model/security/rollout/offline verificados contra el código y correctos. Dos justificaciones fácticas se corrigieron por contradecir el código: (1) el índice `(userId, createdAt)` no tiene consumidor verificado — `fetchCommentLikeStats` no existe; ninguna query usa el compuesto. Se conserva por conservadurismo, no por uso. (2) `onCommentDeleted` NO cascadea likes (solo replies huérfanas), así que el orphan cleanup del backfill es la única vía de limpieza, no una redundancia con un cascade inexistente. El plan debe respetar: (a) el orden de rollout secuenciado índice→rules→código→backfill con el window de degradación suave documentado; (b) correr `--audit` y validar el conteo de legacy docs contra el cap de writes/día ANTES de `--apply`, ventaneando si excede; (c) actualizar los 4 tests de `fetchUserLikes` en businessData.test.ts (se eliminan junto con la función); (d) el replay offline debe pasar `action.businessId` (3er arg) — handler hoy no lo extrae.

--- a/docs/feat/infra/347-perf-instrumentation-count-queries/plan.md
+++ b/docs/feat/infra/347-perf-instrumentation-count-queries/plan.md
@@ -1,0 +1,197 @@
+# Plan de implementación: perf-instrumentation de count queries en follows/favorites (#347)
+
+**Specs:** [specs.md](specs.md) — VALIDADO CON OBSERVACIONES por Diego (2026-06-12)
+**PRD:** [prd.md](prd.md) — VALIDADO CON OBSERVACIONES por Sofia (2026-06-10)
+**Fecha:** 2026-06-12
+
+---
+
+## Estrategia y staging de riesgo
+
+| Fase | Riesgo | Notas |
+|------|--------|-------|
+| F1 — Wrap 3 call sites en `measureAsync` (S1) | Bajo | Decorador de medición; sin cambio de firma ni semántica offline. **Cierra R7.** |
+| F2 — Paridad labels + seed (S2) | Bajo | Solo agrega 2 entradas a un registro de constantes y al doc agregado del seed `.mjs` |
+| F3 — Tests (con la feature, no al final) | Bajo | F3a setup de mocks `favorites.test.ts` (gap real), F3b asserts en ambos services |
+| F4 — Verificación de guard + done (S3) | Bajo | `npm run guards` → R7 con 0 hits; `npm run guards:check` no sube baseline |
+
+> **Orden deliberado:** F1 (instrumentación) y F3 (tests) van en la misma entrega lógica — los tests acompañan al código que instrumentan. F4 (verificación del guard) es el último paso porque depende de que F1 esté completo y bien formateado (línea-por-línea). No hay fase de docs obligatoria: el PRD/specs confirman que `patterns.md` ya documenta `measureAsync` y no hay colecciones/campos/rules nuevos.
+
+### Invariantes que el plan DEBE respetar (observaciones de Diego)
+
+1. **Guard R7 es línea-por-línea.** El grep subyacente (`scripts/guards/checks.mjs:271`) es `grep -rn "getCountOfflineSafe(" ... | grep -v measureAsync`. En los 3 sites `measureAsync(` y `getCountOfflineSafe(` deben quedar en la **misma línea física**. Si el wrap parte ambos en líneas distintas, el guard sigue reportando el hit. Atención a `followUser:41`, que es una **asignación** (`const followingCount = await getCountOfflineSafe(...)`) — el specs solo muestra el ejemplo inline para `favorites_count`.
+2. **Sufijo camelCase de las claves es intencional, NO normalizar a snake puro.** `follows_followingCount` / `follows_followersCount` / `favorites_count` replican el precedente en producción (`follows_followersCount` en `perfHelpers.ts:72` + seed `:917`). Normalizar rompería la paridad con la fila existente que ya recibe muestras.
+3. **`favorites.test.ts` parte sin infra de mock.** No mockea `getCountOfflineSafe` ni `measureAsync` ni importa `fetchUserFavoritesCount` (verificado: `favorites.test.ts:1-22` solo mockea firestore/queryCache/analytics e importa `addFavorite, removeFavorite`). F3a es **setup de mocks completo**, no solo un assert. `follows.test.ts` ya mockea `getCountOfflineSafe` (`:11-14`) pero **no** `measureAsync` ni testea `fetchFollowersCount` — ambos a agregar en F3b.
+
+---
+
+## File ownership
+
+| Archivo | Fase | Tipo de cambio |
+|---------|------|----------------|
+| `src/services/follows.ts` | F1 | wrap 2 sites + import `measureAsync` |
+| `src/services/favorites.ts` | F1 | wrap 1 site + import `measureAsync` |
+| `src/components/admin/perf/perfHelpers.ts` | F2 | +2 entradas en `QUERY_LABELS` |
+| `scripts/seed-admin-data.mjs` | F2 | +2 entradas en doc agregado `perfMetrics.queries` |
+| `src/services/follows.test.ts` | F3b | mock `measureAsync` + tests de `followUser` y `fetchFollowersCount` + smoke label |
+| `src/services/favorites.test.ts` | F3a + F3b | setup mocks (`getCountOfflineSafe`, `measureAsync`) + import `fetchUserFavoritesCount` + test + smoke label |
+
+Sin solapamiento entre fases. F1 y F2 tocan archivos disjuntos → podrían ir en paralelo, pero se commitean separados por trazabilidad.
+
+---
+
+## Fase 1 — Envolver los 3 call sites en `measureAsync` (S1)
+
+**Branch:** `feat/347-perf-instrument-count-queries`
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/services/follows.ts:20` | Extender el import existente de `../utils/perfMetrics`: `import { measuredGetDoc, measuredGetDocs, measureAsync } from '../utils/perfMetrics';` |
+| 2 | `src/services/follows.ts:41-43` | Envolver el count del límite. **`measureAsync(` y `getCountOfflineSafe(` en la MISMA línea** (es asignación): `const followingCount = await measureAsync('follows_followingCount', () => getCountOfflineSafe(` ... `));`. La key NO cambia de camelCase. |
+| 3 | `src/services/follows.ts:98-100` | Envolver el return: `return measureAsync('follows_followersCount', () => getCountOfflineSafe(` ... `));`. `follows_followersCount` ya existe en labels/seed — solo se emite desde este nuevo origen. |
+| 4 | `src/services/favorites.ts:13` | Agregar import: `import { measureAsync } from '../utils/perfMetrics';` (hoy no importa perfMetrics). |
+| 5 | `src/services/favorites.ts:52-54` | Envolver el return: `return measureAsync('favorites_count', () => getCountOfflineSafe(` ... `));`. Patrón canónico de `ratings.ts:141`. |
+
+**Forma esperada de `followUser:41` (asignación — el caso de riesgo del guard):**
+
+```ts
+const followingCount = await measureAsync('follows_followingCount', () => getCountOfflineSafe(
+  query(collection(db, COLLECTIONS.FOLLOWS), where('followerId', '==', followerId)),
+));
+```
+
+> `measureAsync(` y `getCountOfflineSafe(` quedan en la línea de apertura → el `grep -v measureAsync` neutraliza ese hit. El cierre `));` puede ir en líneas siguientes sin afectar el grep (que matchea la línea con `getCountOfflineSafe(`).
+
+- **Verificación rápida local:** `grep -rn "getCountOfflineSafe(" src/services/follows.ts src/services/favorites.ts | grep -v measureAsync` debe devolver vacío (salvo, fuera de scope, los `// guard:exempt` de `rankings.ts`).
+- **Test:** `npx vitest run src/services/follows.test.ts src/services/favorites.test.ts` debe seguir verde **antes** de F3 (los mocks existentes de `follows` toleran el wrap solo si `measureAsync` está mockeado o si `sessionId` no está seteado; ver nota en F3b). `npx tsc --noEmit` sin errores (firmas `Promise<void>`/`Promise<number>` intactas).
+- **Commit:** `fix(#347): envolver 3 count queries de follows/favorites en measureAsync`
+- **Rollback:** revert del commit; ambos services vuelven a `getCountOfflineSafe` directo (el guard R7 volvería a reportar, estado previo conocido).
+
+---
+
+## Fase 2 — Paridad de labels + seed para las 2 claves nuevas (S2)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/components/admin/perf/perfHelpers.ts` (junto a `:72`) | Agregar al objeto `QUERY_LABELS`: `follows_followingCount: 'Seguidos: count',` y `favorites_count: 'Favoritos: count',`. Mantener estilo `<Sustantivo>: count` y orden alfabético/agrupado del bloque. NO tocar `follows_followersCount` (ya existe). |
+| 2 | `scripts/seed-admin-data.mjs` (bloque `perfMetrics.queries`, `:902-953`, junto a `:917`) | Agregar 2 entradas con valores plausibles: `follows_followingCount: { p50: 70, p95: 180, count: 35 },` y `favorites_count: { p50: 65, p95: 160, count: 90 },`. NO tocar `follows_followersCount: { p50: 60, p95: 150, count: 40 }` (`:917`). El staging recibe las claves por el mismo `.mjs` vía `--target staging`. |
+
+- **Verificación:** `npx tsc --noEmit` (labels); `node --check scripts/seed-admin-data.mjs` para validar sintaxis del seed.
+- **Verificación de paridad (Regla 7 del guard #303):** opcionalmente `node scripts/seed-admin-data.mjs` contra el emulador y confirmar que `QueryLatencyTable` renderiza `Seguidos: count` y `Favoritos: count`. No bloqueante para el merge si el guard pasa.
+- **Commit:** `chore(#347): registrar follows_followingCount + favorites_count en QUERY_LABELS y seed`
+- **Rollback:** revert del commit; las filas caen al fallback `?? name` de `QueryLatencyTable` (sin label en español, pero sin romper).
+
+---
+
+## Fase 3 — Tests (acompañan a la instrumentación)
+
+### F3a — Setup de mocks en `favorites.test.ts` (gap de infraestructura, observación 3 de Diego)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/services/favorites.test.ts` (junto a `:6-7`) | Agregar mock de `getCountOfflineSafe` siguiendo el patrón de `follows.test.ts:11-14`: `const mockGetCountOfflineSafe = vi.fn();` + `vi.mock('./getCountOfflineSafe', () => ({ getCountOfflineSafe: (...a) => mockGetCountOfflineSafe(...a) }));`. |
+| 2 | `src/services/favorites.test.ts` | Agregar mock de `perfMetrics` que delega: `vi.mock('../utils/perfMetrics', () => ({ measureAsync: vi.fn((_name, fn) => fn()) }));`. Importar el mock para spy de `name`. |
+| 3 | `src/services/favorites.test.ts` | Agregar mock de `./offlineInterceptor` si la importación de `fetchUserFavoritesCount` arrastra el módulo (verificar: `favorites.ts:14` importa `gateServiceWrite`; hoy los tests de add/remove ya lo ejercen — confirmar si está mockeado o si funciona por el mock de firestore). |
+| 4 | `src/services/favorites.test.ts:20` | Extender el import: `import { addFavorite, removeFavorite, fetchUserFavoritesCount } from './favorites';`. |
+
+### F3b — Asserts de instrumentación en ambos services
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/services/follows.test.ts` (junto a `:11-14`) | Agregar mock de `perfMetrics`: `vi.mock('../utils/perfMetrics', () => ({ measuredGetDoc: vi.fn(), measuredGetDocs: vi.fn(), measureAsync: vi.fn((_name, fn) => fn()) }));`. Importar `measureAsync` (el mock) para el spy. **Sin este mock, el wrap de F1 ejecuta el `measureAsync` real, que en test (sin `sessionId`) hace `return fn()` — funciona, pero no permite assertar el `name`.** |
+| 2 | `src/services/follows.test.ts` | Test `followUser` invoca `measureAsync` con `'follows_followingCount'` y delega en `getCountOfflineSafe` (mock resuelve un número < 200 → no lanza; verificar que `setDoc` + `invalidateQueryCache` + `trackEvent(EVT_FOLLOW)` siguen llamándose). Test del límite: `mockGetCountOfflineSafe` resuelve `200` → `followUser` rechaza con `'Has alcanzado el limite de 200 usuarios seguidos'`. |
+| 3 | `src/services/follows.test.ts` | Test `fetchFollowersCount` (hoy no testeado): importar de `./follows`, mock resuelve `7` → retorna `7`; `measureAsync` invocado con `'follows_followersCount'`. Path offline: mock resuelve `0` → retorna `0`. |
+| 4 | `src/services/follows.test.ts` | Smoke: `import { QUERY_LABELS } from '../components/admin/perf/perfHelpers';` + `expect(QUERY_LABELS['follows_followingCount']).toBeTruthy()`. (Decisión specs: NO crear `perfHelpers.test.ts`; cubrir vía smoke.) |
+| 5 | `src/services/favorites.test.ts` | Test `fetchUserFavoritesCount`: mock resuelve `12` → retorna `12`; `measureAsync` invocado con `'favorites_count'`. Path offline: mock resuelve `0` → retorna `0`. Smoke: `expect(QUERY_LABELS['favorites_count']).toBeTruthy()`. |
+
+- **Test:** `npx vitest run src/services/follows.test.ts src/services/favorites.test.ts` verde; cobertura del código nuevo >= 80% (el wrap es trivial); no baja la cobertura existente (`favorites.test.ts` 7 casos, `follows.test.ts`).
+- **Commit:** `test(#347): cubrir measureAsync en counts de follows/favorites + smoke de labels`
+- **Rollback:** revert del commit de tests (el código de F1/F2 sigue funcional, solo sin los asserts nuevos).
+
+---
+
+## Fase 4 — Verificación del guard #303 y criterio de done (S3)
+
+| Paso | Comando | Criterio |
+|------|---------|----------|
+| 1 | `npm run guards` (= `node scripts/guards/run.mjs --pretty`) | La regla `R7-getCount-without-measure` del guard `303` reporta **0 hits**. |
+| 2 | `npm run guards:check` (= `node scripts/guards/check-baseline.mjs`, gate de CI `guards.yml:43`) | Pasa — NO sube el `.guards-baseline.json` (el baseline de R7 ya esperaba 0; los 3 sites dejan de contar). |
+| 3 | `npm run build` | Build OK. |
+| 4 | `npx vitest run` (suite completa o al menos services tocados) | Verde. |
+
+- **Sin commit propio** (es verificación). Si el guard expone un baseline desactualizado, ajustar baseline en el commit de F1 con justificación. No agregar reglas nuevas al guard (fuera de scope, R7 y R3 ya existen).
+- **Rollback:** N/A (fase de verificación).
+
+---
+
+## Orden de implementación
+
+1. **F1** — wrap de los 3 sites (`follows.ts`, `favorites.ts`) respetando el invariante línea-por-línea. Es la raíz: cierra R7 y habilita el resto.
+2. **F2** — labels + seed (independiente de F1, pero se commitea después por trazabilidad de la clave emitida).
+3. **F3a → F3b** — setup de mocks de `favorites.test.ts` primero (sin él los tests nuevos no compilan), luego los asserts en ambos services.
+4. **F4** — correr `npm run guards` y `npm run guards:check`; build + suite completa.
+
+Dependencia dura: F3b paso 4/5 (smoke de labels) requiere F2 paso 1 mergeado (las claves deben existir en `QUERY_LABELS`). F1 debe preceder a F4.
+
+---
+
+## Test plan global
+
+| Archivo / comando | Qué cubre | Fase |
+|-------------------|-----------|------|
+| `src/services/follows.test.ts` | `measureAsync('follows_followingCount')` en `followUser`; límite 200 sigue lanzando; `fetchFollowersCount` retorna número + key + offline 0; smoke label | F3b |
+| `src/services/favorites.test.ts` | setup mocks + `fetchUserFavoritesCount` retorna número + key `favorites_count` + offline 0; add/remove existentes intactos; smoke label | F3a + F3b |
+| `npm run guards` | R7 con 0 hits | F4 |
+| `npm run guards:check` | baseline no sube | F4 |
+| `npm run build` / `npx tsc --noEmit` | firmas y tipos intactos | F1/F4 |
+
+Mock strategy: `measureAsync` mockeado como `(_name, fn) => fn()` (delega y permite spy del `name`); `getCountOfflineSafe` mockeado para controlar retorno (incluido `0` offline). Sin regresión en asserts de `invalidateQueryCache` / `trackEvent`.
+
+---
+
+## Riesgos
+
+1. **Wrap parte `measureAsync`/`getCountOfflineSafe` en líneas distintas → R7 sigue rojo.** Mitigación: invariante explícito en F1 + verificación con grep local antes de F4; el caso de `followUser:41` (asignación) está documentado con su forma exacta.
+2. **Normalización accidental de la key a snake puro** (`follows_following_count`) rompería la paridad con la fila prod `follows_followersCount`. Mitigación: invariante #2 + las keys están escritas literalmente en cada paso del plan.
+3. **`favorites.test.ts` sin mock de `perfMetrics`/`getCountOfflineSafe` → el test de `fetchUserFavoritesCount` falla o ejecuta el `measureAsync` real.** Mitigación: F3a es setup de mocks completo (no un assert), siguiendo `follows.test.ts:11-14`.
+
+---
+
+## Guardrails (verificación final)
+
+- [ ] Ningún componente importa `firebase/firestore` directamente (solo services, capa permitida).
+- [ ] Sin colecciones/campos/rules/Cloud Functions nuevos → sin cambios en `firestore.rules` ni functions.
+- [ ] Las 2 claves nuevas registradas en `QUERY_LABELS` (`perfHelpers.ts`) y en el doc agregado del seed `.mjs` (paridad Regla 7 del guard #303).
+- [ ] Keys con sufijo camelCase preservado (no normalizar).
+- [ ] `measureAsync` y `getCountOfflineSafe` en la misma línea física en los 3 sites.
+- [ ] Ningún archivo supera 400 líneas (`follows.ts` ~106, `favorites.ts` ~71, `perfHelpers.ts` ~127).
+- [ ] Sin `logger.error` envuelto en `if (DEV)`; sin `.catch(() => {})`.
+- [ ] Labels en español con terminología consistente (`Seguidos: count`, `Favoritos: count`).
+
+## Criterios de done
+
+- [ ] Los 3 call sites ejecutan `getCountOfflineSafe` dentro de `measureAsync` con keys `follows_followingCount` / `follows_followersCount` / `favorites_count`.
+- [ ] `npm run guards` → `R7-getCount-without-measure` con 0 hits; `npm run guards:check` pasa.
+- [ ] `QUERY_LABELS` y seed `perfMetrics.queries` contienen las 2 claves nuevas con label no vacío.
+- [ ] `follows.test.ts` y `favorites.test.ts` verdes con asserts nuevos de `measureAsync` + smoke de labels; cobertura del código nuevo >= 80%, sin bajar la existente.
+- [ ] `npm run build` OK; `npx tsc --noEmit` sin errores.
+
+---
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Ciclo:** 1
+
+**Observaciones para el implementador:**
+
+1. Es un issue de esfuerzo S sobre un solo branch / un solo owner — NO hay agentes paralelos, asi que no aplica riesgo de overlap de ownership. La tabla de file ownership es informativa, no una asignacion luna/nico. Si se delega, va a UN solo implementador (perfil backend/services).
+2. La forma exacta de `followUser:41` (asignacion `const followingCount = await measureAsync('follows_followingCount', () => getCountOfflineSafe(`) DEBE quedar con `measureAsync(` y `getCountOfflineSafe(` en la misma linea fisica. Verificado contra `checks.mjs:271`: el grep R7 matchea la linea de `getCountOfflineSafe(` y la neutraliza solo si `measureAsync` esta en esa misma linea. El cierre `));` en lineas siguientes no afecta. Confirmar con el grep local de F1 ANTES de F4.
+3. Claves camelCase (`follows_followingCount`, `favorites_count`) NO se normalizan a snake puro — replican el precedente prod `follows_followersCount` (verificado en `perfHelpers.ts:72` y seed `:917`). Escritas literalmente en cada paso, mantenerlas asi.
+4. F3a (setup de mocks en `favorites.test.ts`) es trabajo de infraestructura, no un assert: el archivo hoy NO mockea `getCountOfflineSafe`/`measureAsync` ni importa `fetchUserFavoritesCount` (verificado `:1-22`). El paso F3a-3 (verificar si `offlineInterceptor`/`gateServiceWrite` necesita mock) queda como verificacion durante implementacion — los tests de add/remove ya ejercen `gateServiceWrite` (`favorites.ts:32,59`) pero `fetchUserFavoritesCount` no lo toca, asi que probablemente no haga falta mockearlo para el test nuevo. No es bloqueante.
+5. El branch sugerido en F1 (`feat/347-perf-instrument-count-queries`) asume base `main`; el repo trabaja sobre `new-home`. Confirmar la base correcta al crear el branch (decision de quien delega, no del plan).
+6. El plan asume que `.guards-baseline.json` para R7 ya espera 0 hits (F4 paso 2). Si el baseline actual cuenta los 3 sites como hits esperados, F4 va a requerir bajar el baseline en el commit de F1 — el plan ya lo contempla ("ajustar baseline en el commit de F1 con justificacion"). Verificar el valor del baseline antes de cerrar F4.
+
+Cobertura specs->plan completa (3 call sites, 2 claves nuevas en labels+seed, smoke de labels, no-crear perfHelpers.test.ts, out-of-scope respetados). Orden de fases correcto (F1 raiz, F3a antes de F3b, dependencia F3b->F2 documentada). Test plan integrado con la feature, no al final. Rollback por fase definido. Sin BLOQUEANTES ni IMPORTANTES.

--- a/docs/feat/infra/347-perf-instrumentation-count-queries/prd.md
+++ b/docs/feat/infra/347-perf-instrumentation-count-queries/prd.md
@@ -1,0 +1,258 @@
+# PRD: Tech debt — perf-instrumentation de count queries en follows/favorites
+
+**Feature:** 347-perf-instrumentation-count-queries
+**Categoria:** infra
+**Fecha:** 2026-06-09
+**Issue:** #347
+**Prioridad:** Media
+
+---
+
+## Contexto
+
+El sistema de observabilidad client-side (#303, #325) mide la latencia de las queries Firestore via `measureAsync` / `measuredGetDoc` / `measuredGetDocs` (`src/utils/perfMetrics.ts`) y la expone en el panel admin de Performance (`QueryLatencyTable`). Tres llamadas a `getCountOfflineSafe(...)` en los services `follows.ts` y `favorites.ts` quedaron sin envolver, dejando ciegos al dashboard dos hot paths sociales (cada follow y cada vista de perfil).
+
+## Problema
+
+- `src/services/follows.ts:41` (`followUser`, following-limit count, corre en CADA follow), `src/services/follows.ts:98` (`fetchFollowersCount`, corre en CADA vista de perfil) y `src/services/favorites.ts:52` (`fetchUserFavoritesCount`) llaman a `getCountOfflineSafe` sin `measureAsync`. Sus hermanos en `ratings.ts:141`, `notifications.ts:62` y `recommendations.ts:84,109` SI estan envueltos — la inconsistencia significa latencia invisible al panel admin para estos counts.
+- El guard de regresion `303-perf-instrumentation` ya tiene la regla `R7-getCount-without-measure` codificada en `scripts/guards/checks.mjs:266-272` (referencia explicita a #347), pero hoy esta **fallando**: los 3 call sites son detectados. El guard no puede pasar hasta que se envuelvan.
+- El seed `scripts/seed-admin-data.mjs` y el registro `QUERY_LABELS` (`perfHelpers.ts`) no contienen las dos claves nuevas que se introduciran (`follows_followingCount`, `favorites_count`). Sin esa paridad, el dashboard renderiza filas sin label en espanol y el seed sub-reporta tras `npm run seed-admin` (Regla 7 del guard #303).
+
+> **Nota sobre el cuerpo del issue:** la afirmacion de que el seed "omite `unreadCount` y `businessData_*`/`rankings_*`/`recommendations_*`" esta **desactualizada**. El doc grande de `perfMetrics` (`seed-admin-data.mjs:902-953`) ya incluye esas claves. El unico gap real de seed es para las DOS claves nuevas que crea este feature. El gap genuino de "seed completeness" es el bloque chico de 7 dias (`seed-admin-data.mjs:844-848`) que solo tiene 3 claves (`notifications`, `userSettings`, `paginatedQuery`) — pero ese bloque es deliberadamente minimal (vitals por dia) y NO alimenta `QueryLatencyTable`, que lee del doc agregado. No requiere cambios.
+
+## Solucion
+
+### S1 — Envolver los 3 call sites en `measureAsync`
+
+Aplicar el patron canonico ya usado en `ratings.ts:141` y `recommendations.ts:84,109`: `measureAsync('<feature>_<verb>', () => getCountOfflineSafe(...))`. Claves en snake_case segun la convencion documentada en `patterns.md` ("Naming convention de claves"):
+
+| Call site | Funcion | Clave nueva |
+|-----------|---------|-------------|
+| `follows.ts:41` | `followUser` (limite de seguidos) | `follows_followingCount` |
+| `follows.ts:98` | `fetchFollowersCount` | `follows_followersCount` (YA existe en QUERY_LABELS/seed) |
+| `favorites.ts:52` | `fetchUserFavoritesCount` | `favorites_count` |
+
+`follows_followersCount` ya esta registrado en `QUERY_LABELS:72` y en el seed `:917` (lo emitia otra ruta) — solo hay que emitirlo tambien desde `fetchFollowersCount`. Las dos claves genuinamente nuevas son `follows_followingCount` y `favorites_count`.
+
+`measureAsync` es `async` y devuelve `Promise<T>` — el wrap preserva el tipo de retorno `Promise<number>` de las tres funciones sin cambios de firma. No hay efectos sobre la semantica offline: `getCountOfflineSafe` sigue devolviendo `0` cuando `!navigator.onLine`.
+
+### S2 — Registrar las claves nuevas (paridad seed + labels)
+
+Para cada clave nueva (`follows_followingCount`, `favorites_count`):
+
+- Agregar entrada en `QUERY_LABELS` (`src/components/admin/perf/perfHelpers.ts`) con label en espanol (ej: "Seguidos: count", "Favoritos: count").
+- Agregar entrada en el doc agregado de `perfMetrics.queries` del seed (`scripts/seed-admin-data.mjs:902-953`) con valores p50/p95/count plausibles, para que la fila renderice tras `npm run seed-admin` (Regla 7 del guard #303).
+
+### S3 — Cerrar el guard #303 R7
+
+El guard `R7-getCount-without-measure` ya existe en `scripts/guards/checks.mjs`. Tras S1, su grep debe devolver vacio (los 3 sites pasan a tener `measureAsync` inline). No se requiere extender el guard — la "extension" pedida por el issue ya esta codificada (R7 para `getCountOfflineSafe`, R3 para `getCountFromServer`). El trabajo es **hacerlo pasar**, no agregar reglas. Verificar que la corrida del guard (`node scripts/guards/checks.mjs` o el runner equivalente) reporte R7 limpio.
+
+> Los call sites de `rankings.ts:118,193` corren dentro de un `measureAsync('rankings_userLiveScore')` de mayor nivel y llevan el marker `// guard:exempt` — no se tocan.
+
+### UX
+
+Cambio invisible al usuario final. El efecto observable es en el panel admin `/admin` → tab Performance → `QueryLatencyTable`: aparecen dos filas nuevas (`Seguidos: count`, `Favoritos: count`) con su latencia p50/p95 real en produccion, y la fila `Seguidores: count` empieza a recibir muestras desde el nuevo origen.
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| S1 — Wrap `follows.ts:41` en `measureAsync('follows_followingCount', ...)` | Alta | S |
+| S1 — Wrap `follows.ts:98` en `measureAsync('follows_followersCount', ...)` | Alta | S |
+| S1 — Wrap `favorites.ts:52` en `measureAsync('favorites_count', ...)` | Alta | S |
+| S2 — Agregar `follows_followingCount` + `favorites_count` a `QUERY_LABELS` | Media | S |
+| S2 — Agregar las 2 claves nuevas al seed `perfMetrics.queries` | Media | S |
+| S3 — Verificar guard #303 R7 pasa en verde | Alta | S |
+
+**Esfuerzo total estimado:** S
+
+---
+
+## Out of Scope
+
+- Modificar el bloque chico de 7 dias del seed (`:844-848`) — es minimal por diseño y no alimenta `QueryLatencyTable`.
+- Re-instrumentar otros services o agregar nuevos counts no listados.
+- Cambiar la firma o el comportamiento offline de `getCountOfflineSafe`.
+- Agregar nuevas reglas al guard #303 (ya existen R7 y R3); solo se hace que la corrida quede en verde.
+- Optimizar el costo Firestore de los counts (cache, agregados server-side) — es un followup de performance, no de instrumentacion.
+
+---
+
+## Tests
+
+Cambio de instrumentacion de bajo riesgo. La cobertura existente de los services debe seguir pasando; se agregan asserts puntuales de que `measureAsync` se invoca con la clave correcta.
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `src/services/follows.test.ts` | Service | `followUser` y `fetchFollowersCount` invocan `measureAsync` con `follows_followingCount` / `follows_followersCount`; retorno numerico preservado; limite de 200 sigue lanzando |
+| `src/services/favorites.test.ts` | Service | `fetchUserFavoritesCount` invoca `measureAsync` con `favorites_count`; retorno numerico preservado |
+| `src/components/admin/perf/perfHelpers.test.ts` (si existe; si no, cubierto via QUERY_LABELS smoke) | Util | Las 2 claves nuevas tienen label no vacio en `QUERY_LABELS` |
+
+### Criterios de testing
+
+- Cobertura >= 80% del codigo nuevo (el wrap es trivial; el foco es no romper la cobertura existente de `favorites.test.ts` —7 casos, 100%— ni `follows.test.ts`).
+- Mock strategy: mockear `measureAsync` (o `perfMetrics`) para verificar que se llama con la clave esperada y que delega en `getCountOfflineSafe`. Mock de `getCountOfflineSafe` para controlar el valor de retorno.
+- Verificar que el path offline (`getCountOfflineSafe` devuelve 0) sigue funcionando a traves del wrap.
+- Side effects verificados: `measureAsync` registrado, sin cambios en `invalidateQueryCache` / `trackEvent` de `followUser`.
+
+---
+
+## Seguridad
+
+Cambio puramente de observabilidad client-side. No agrega colecciones, campos, endpoints ni inputs de usuario. No toca Firestore rules ni Cloud Functions.
+
+- [ ] No se agregan campos a ninguna coleccion → sin cambios en `firestore.rules`.
+- [ ] No hay texto libre nuevo → sin moderacion.
+- [ ] `getCountOfflineSafe` ya requiere `request.auth != null` via rules de `follows`/`favorites` (read: auth) — el wrap no altera el control de acceso.
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| (ninguna nueva) | El feature no expone superficie nueva; solo envuelve reads ya existentes | N/A — los counts ya estaban en produccion sin instrumentar |
+
+No escribe a Firestore. No agrega campos a `userSettings`. No lee datos nuevos (los counts ya se ejecutaban). No habilita scraping adicional.
+
+---
+
+## Deuda tecnica y seguridad
+
+Este feature **resuelve** deuda tecnica de instrumentacion explicitamente trackeada por el guard #303 (R7 referencia #347 por numero). No introduce deuda nueva.
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| #303 (guard perf-instrumentation) | mitiga | Cerrar R7 en verde; mantener paridad seed (Regla 7) |
+| #325 (perf instrumentation hot paths / `measureAsync`) | mitiga | Extiende el mismo patron a los counts olvidados |
+
+### Mitigacion incorporada
+
+- Cerrar `R7-getCount-without-measure` del guard #303 (3 call sites) → pasos S1.
+- Mantener paridad seed/labels para las claves nuevas (Regla 7 del guard #303) → pasos S2.
+
+---
+
+## Robustez del codigo
+
+### Checklist de hooks async
+
+- [ ] N/A — no se agregan hooks ni `useEffect`. Solo se envuelven funciones de service ya existentes.
+- [ ] Funciones exportadas: `fetchFollowersCount`, `fetchUserFavoritesCount`, `followUser` ya son parte de la API publica del service — sin cambios de export.
+- [ ] Archivos en `src/services/` (no `hooks/`) — correcto, no usan React hooks.
+- [ ] Sin nuevas constantes de localStorage.
+- [ ] Archivos no superan 300/400 lineas (`follows.ts` ~104, `favorites.ts` ~70, `perfHelpers.ts` ~125).
+- [ ] Sin `logger.error` envuelto en `if (DEV)`.
+
+### Checklist de observabilidad
+
+- [ ] N/A — no se agregan Cloud Function triggers ni services nuevos con queries (se instrumentan reads existentes).
+- [ ] Las 2 claves nuevas se registran en `QUERY_LABELS` (`perfHelpers.ts`) y en el seed `perfMetrics.queries` — paridad Regla 7 del guard #303.
+- [ ] N/A — no son `trackEvent` (GA4); son claves de `measureAsync` (perf metrics, sistema distinto). No requieren `GA4_EVENT_NAMES` ni `ga4FeatureDefinitions.ts`.
+
+### Checklist offline
+
+- [ ] N/A — son reads. `getCountOfflineSafe` ya devuelve 0 offline; el wrap lo preserva.
+- [ ] N/A — sin formularios/dialogs nuevos.
+
+### Checklist de documentacion
+
+- [ ] N/A — sin nuevas secciones de HomeScreen.
+- [ ] N/A — no son analytics events GA4.
+- [ ] N/A — sin tipos nuevos.
+- [ ] `docs/reference/features.md` — sin cambio (no es feature de usuario).
+- [ ] `docs/reference/firestore.md` — sin cambio (sin colecciones/campos nuevos).
+- [ ] `docs/reference/patterns.md` — sin cambio (el patron `measureAsync` ya esta documentado en "Performance instrumentation").
+- [ ] `docs/reference/guards/303-perf-instrumentation.md` — opcional: nota de que R7 quedo en verde (no obligatorio).
+
+---
+
+## Offline
+
+### Data flows
+
+| Operacion | Tipo | Estrategia offline | Fallback UI |
+|-----------|------|-------------------|-------------|
+| `followUser` following-count check | read (count) | `getCountOfflineSafe` devuelve 0 offline → no bloquea el follow | Sin UI; offline el follow se encola via interceptor del service de escritura |
+| `fetchFollowersCount` | read (count) | `getCountOfflineSafe` devuelve 0 offline | El perfil muestra 0 seguidores cuando offline (comportamiento preexistente) |
+| `fetchUserFavoritesCount` | read (count) | `getCountOfflineSafe` devuelve 0 offline | Contador 0 offline (comportamiento preexistente) |
+
+### Checklist offline
+
+- [ ] Reads de Firestore: usan `getCountOfflineSafe` (guard offline ya implementado). El wrap `measureAsync` no lo altera.
+- [ ] Writes: N/A (no se cambian writes).
+- [ ] APIs externas: N/A.
+- [ ] UI: sin cambios (comportamiento offline preexistente).
+- [ ] Datos criticos: counts no son criticos para primera carga.
+
+### Esfuerzo offline adicional: S
+
+---
+
+## Modularizacion y % monolitico
+
+Cambio confinado a 3 services + 1 helper de labels + 1 script de seed. No toca componentes de layout, no agrega estado global, no cruza la boundary del service layer.
+
+### Checklist modularizacion
+
+- [ ] Logica en services (`follows.ts`, `favorites.ts`) — correcto.
+- [ ] N/A — no se agregan componentes.
+- [ ] No se agregan `useState` a AppShell/SideMenu.
+- [ ] N/A — sin props nuevas.
+- [ ] N/A — sin handlers de accion nuevos.
+- [ ] Firebase SDK: `getCountOfflineSafe` ya aisla `getCountFromServer`; los services pueden importar de Firebase SDK (capa permitida).
+- [ ] Archivos en `src/services/` contienen logica de service — correcto.
+- [ ] Ningun archivo supera 400 lineas.
+- [ ] N/A — sin converters nuevos.
+- [ ] Archivos en carpeta de dominio correcta (`services/`, `components/admin/perf/`).
+- [ ] N/A — sin estado global nuevo.
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | = | No toca componentes; solo services y un registro de labels |
+| Estado global | = | Sin estado nuevo |
+| Firebase coupling | = | `getCountFromServer` ya aislado en `getCountOfflineSafe`; el wrap es un decorador de medicion |
+| Organizacion por dominio | = | Archivos en sus dominios correctos |
+
+---
+
+## Accesibilidad y UI mobile
+
+No hay UI nueva. La unica superficie visual afectada es `QueryLatencyTable` en el panel admin, que ya renderiza filas via `QUERY_LABELS[name] ?? name`.
+
+### Checklist de accesibilidad
+
+- [ ] N/A — sin componentes interactivos nuevos.
+- [ ] N/A — sin IconButtons, Box clickeables, formularios nuevos.
+- [ ] `QueryLatencyTable` ya maneja el fallback `?? name` si falta el label (no quedaria sin texto), pero igual se agregan ambos labels.
+
+### Checklist de copy
+
+- [ ] Labels nuevos en `QUERY_LABELS` en espanol con tildes correctas (ej: "Seguidos: count", "Favoritos: count") — consistentes con el estilo existente del registro (`'Seguidores: count'`, `'Ratings: count por usuario'`).
+- [ ] Terminologia consistente con el resto de `QUERY_LABELS`.
+- [ ] N/A — sin mensajes de error nuevos.
+
+---
+
+## Success Criteria
+
+1. Los 3 call sites (`follows.ts:41`, `follows.ts:98`, `favorites.ts:52`) ejecutan `getCountOfflineSafe` dentro de `measureAsync` con claves snake_case (`follows_followingCount`, `follows_followersCount`, `favorites_count`).
+2. La corrida del guard #303 reporta `R7-getCount-without-measure` en verde (grep vacio).
+3. `QUERY_LABELS` contiene `follows_followingCount` y `favorites_count` con label en espanol no vacio; `QueryLatencyTable` renderiza esas filas tras `npm run seed-admin`.
+4. El doc agregado de `perfMetrics.queries` del seed incluye las 2 claves nuevas (paridad Regla 7 del guard #303).
+5. La suite de tests existente de `follows.test.ts` y `favorites.test.ts` sigue pasando, con asserts nuevos de que `measureAsync` se invoca con la clave correcta; cobertura del codigo nuevo >= 80%.
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** perfHelpers.test.ts no existe: elegir crear el archivo o smoke via QUERY_LABELS. Fijar el comando canonico del guard. follows_followingCount solo se emite desde followUser (no en vistas de perfil).

--- a/docs/feat/infra/347-perf-instrumentation-count-queries/specs.md
+++ b/docs/feat/infra/347-perf-instrumentation-count-queries/specs.md
@@ -1,0 +1,267 @@
+# Specs: Tech debt — perf-instrumentation de count queries en follows/favorites
+
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-10
+**Issue:** #347
+
+---
+
+## Resumen tecnico
+
+Feature de observabilidad client-side pura. Envuelve 3 call sites de `getCountOfflineSafe(...)` en `measureAsync(...)` para que su latencia llegue al panel admin (`QueryLatencyTable`), registra las 2 claves nuevas en `QUERY_LABELS` + seed para paridad de dashboard, y hace pasar en verde el guard `R7-getCount-without-measure` (#303) que hoy falla por estos 3 sites.
+
+**No** agrega colecciones, campos, endpoints, rules, Cloud Functions, hooks, componentes ni estado global. **No** cambia firmas ni semantica offline.
+
+### Scope real (cerrado, segun observaciones de Sofia)
+
+| Call site | Funcion | Clave | Estado de la clave |
+|-----------|---------|-------|--------------------|
+| `src/services/follows.ts:41` | `followUser` (limite de seguidos) | `follows_followingCount` | **NUEVA** — registrar en QUERY_LABELS + seed |
+| `src/services/follows.ts:98` | `fetchFollowersCount` | `follows_followersCount` | YA existe en `perfHelpers.ts:72` y seed `:917` — solo emitir desde este site |
+| `src/services/favorites.ts:52` | `fetchUserFavoritesCount` | `favorites_count` | **NUEVA** — registrar en QUERY_LABELS + seed |
+
+> **Nota sobre `follows_followingCount` (observacion Sofia):** esta clave se emite **unicamente** desde `followUser` (path de escritura: el check de limite previo al `setDoc`). En produccion recibe muestras **solo cuando un usuario crea un follow**, no en vistas de perfil. Esto es **esperado y correcto** — no es un bug de cobertura del dashboard. La fila `Seguidos: count` tendra `count` bajo comparado con `follows_followersCount` (que corre en cada vista de perfil). Documentar este comportamiento para que QA no lo interprete como instrumentacion rota.
+
+---
+
+## Modelo de datos
+
+Sin cambios. No se agregan ni modifican colecciones, documentos ni indexes. Las queries instrumentadas (`where('followerId','==',...)`, `where('followedId','==',...)`, `where('userId','==',...)`) ya existen y corren en produccion.
+
+## Firestore Rules
+
+Sin cambios. El wrap `measureAsync` es un decorador de medicion client-side; no altera el control de acceso. `getCountOfflineSafe` ya opera bajo las rules de read (`auth != null`) de `follows` y `favorites`.
+
+### Rules impact analysis
+
+| Query (service file) | Collection | Auth context | Rule que la permite | Cambio? |
+|---------------------|------------|--------------|---------------------|---------|
+| `followUser` count (`follows.ts:41`) | follows | Usuario autenticado leyendo sus propios follows | `allow read: if request.auth != null` (preexistente) | No |
+| `fetchFollowersCount` (`follows.ts:98`) | follows | Usuario autenticado | `allow read: if request.auth != null` (preexistente) | No |
+| `fetchUserFavoritesCount` (`favorites.ts:52`) | favorites | Usuario autenticado | `allow read: if request.auth != null` (preexistente) | No |
+
+Ninguna query es nueva — ya se ejecutaban sin instrumentar. El wrap no introduce lecturas adicionales ni cambia el documento/coleccion leido.
+
+### Field whitelist check
+
+N/A — no se agregan ni modifican campos en ninguna interfaz/servicio. Sin escrituras Firestore nuevas.
+
+## Cloud Functions
+
+N/A — sin triggers, scheduled ni callables nuevos o modificados.
+
+## Seed Data
+
+El feature **no crea colecciones Firestore nuevas** ni agrega campos requeridos. El unico cambio de seed es de **paridad de dashboard** (Regla 7 del guard #303): el doc agregado de `perfMetrics.queries` debe incluir las 2 claves nuevas para que `QueryLatencyTable` renderice esas filas tras el seed.
+
+### Emulator seed (`scripts/seed-admin-data.mjs`)
+
+- Documento: el doc agregado de `perfMetrics` (bloque `performance.queries`, lineas `:902-953`).
+- Cambio: agregar 2 entradas al objeto `queries` con valores p50/p95/count plausibles, consistentes con el estilo de sus hermanos (`ratings_countByUser`, `follows_followersCount`).
+- Ejemplo:
+
+```js
+follows_followingCount: { p50: 70, p95: 180, count: 35 },
+favorites_count: { p50: 65, p95: 160, count: 90 },
+```
+
+- `follows_followersCount` y los demas ya estan presentes (`:917` etc.) — no se tocan.
+
+### Staging seed (`scripts/seed-staging.ts`)
+
+N/A — no existe un seed de perf-metrics dedicado para staging. El doc agregado de `perfMetrics` se seedea via `scripts/seed-admin-data.mjs --target staging` (mismo archivo, flag de target). No hay un `seed-staging.ts` separado que toque `perfMetrics.queries`. El staging recibe las claves nuevas por la misma edicion del `.mjs`.
+
+> El bloque chico de 7 dias del seed (`:844-848`) NO se toca — es vitals-por-dia minimal por diseno y no alimenta `QueryLatencyTable` (que lee del doc agregado). Confirmado en PRD Out of Scope.
+
+## Componentes
+
+Sin componentes nuevos ni modificados. La unica superficie visual afectada es `src/components/admin/perf/QueryLatencyTable` (existente), que renderiza filas via `QUERY_LABELS[name] ?? name` — recibe 2 filas nuevas automaticamente al registrar los labels. No requiere edicion de codigo del componente.
+
+### Mutable prop audit
+
+N/A — sin componentes editables nuevos.
+
+## Textos de usuario
+
+Sin textos visibles al usuario final. Los unicos strings nuevos son labels del panel admin en `QUERY_LABELS`:
+
+| Texto | Donde se usa | Notas |
+|-------|--------------|-------|
+| `Seguidos: count` | label de `follows_followingCount` en `QueryLatencyTable` (admin) | Consistente con `Seguidores: count` (`:72`) |
+| `Favoritos: count` | label de `favorites_count` en `QueryLatencyTable` (admin) | Consistente con estilo `<Sustantivo>: count` |
+
+## Hooks
+
+Sin hooks nuevos ni modificados.
+
+## Servicios
+
+| Funcion | Archivo | Cambio | Firma |
+|---------|---------|--------|-------|
+| `followUser` | `src/services/follows.ts:36-55` | Envolver el count del limite (linea 41) en `measureAsync('follows_followingCount', () => getCountOfflineSafe(...))`. Agregar import de `measureAsync` desde `../utils/perfMetrics`. | Sin cambios — sigue `Promise<void>` |
+| `fetchFollowersCount` | `src/services/follows.ts:97-101` | Envolver el `return getCountOfflineSafe(...)` en `measureAsync('follows_followersCount', () => getCountOfflineSafe(...))`. | Sin cambios — sigue `Promise<number>` |
+| `fetchUserFavoritesCount` | `src/services/favorites.ts:51-55` | Envolver el `return getCountOfflineSafe(...)` en `measureAsync('favorites_count', () => getCountOfflineSafe(...))`. Agregar import de `measureAsync` desde `../utils/perfMetrics`. | Sin cambios — sigue `Promise<number>` |
+
+Patron canonico (ya usado en `ratings.ts:141`):
+
+```ts
+return measureAsync('favorites_count', () => getCountOfflineSafe(
+  query(collection(db, COLLECTIONS.FAVORITES), where('userId', '==', userId)),
+));
+```
+
+`measureAsync<T>(name, fn): Promise<T>` (`src/utils/perfMetrics.ts:37`) preserva el tipo de retorno. El path offline se preserva: `getCountOfflineSafe` sigue devolviendo `0` cuando `!navigator.onLine`.
+
+## Integracion
+
+El feature toca 3 services + 1 registro de labels + 1 seed. No cruza la boundary del service layer. `QueryLatencyTable` consume `QUERY_LABELS` sin cambios.
+
+### Preventive checklist
+
+- [x] **Service layer**: los services ya importan Firebase SDK (capa permitida). No se agregan imports de `firebase/firestore` en componentes.
+- [x] **Duplicated constants**: las claves nuevas se agregan al registro existente `QUERY_LABELS` — no se duplica.
+- [x] **Context-first data**: N/A — no se lee data de contextos.
+- [x] **Silent .catch**: N/A — `measureAsync` no introduce `.catch` silencioso; propaga el rechazo de la promise como antes.
+- [x] **Stale props**: N/A — sin props.
+
+## Tests
+
+| Archivo test | Que testear | Tipo |
+|--------------|-------------|------|
+| `src/services/follows.test.ts` (existe) | `followUser` invoca `measureAsync` con `follows_followingCount`; `fetchFollowersCount` (agregar a imports — hoy no se testea) invoca `measureAsync` con `follows_followersCount` y retorna el numero de `getCountOfflineSafe`; el limite de 200 sigue lanzando. | Service |
+| `src/services/favorites.test.ts` (existe) | `fetchUserFavoritesCount` (agregar a imports y mock de `getCountOfflineSafe` — hoy no presente) invoca `measureAsync` con `favorites_count`; retorno numerico preservado; mantiene los casos existentes de add/remove. | Service |
+| `src/components/admin/perf/perfHelpers.test.ts` | **DECISION (observacion Sofia):** ver "Decisiones tecnicas → Cobertura de QUERY_LABELS" mas abajo. | Util |
+
+### Decision explicita sobre perfHelpers.test.ts
+
+`perfHelpers.test.ts` **no existe** hoy. Se elige **NO crearlo**. La verificacion de que las 2 claves nuevas tienen label no vacio se cubre con un **smoke assert dentro de los tests de service ya existentes** (importando `QUERY_LABELS` de `perfHelpers.ts` y asegurando `QUERY_LABELS['follows_followingCount']` y `QUERY_LABELS['favorites_count']` son strings no vacios). Rationale en "Decisiones tecnicas". Esto evita crear un archivo de test nuevo para un registro de constantes (excepcion documentada en `tests.md`: "Constantes sin logica") manteniendo el assert de paridad.
+
+### Mock strategy
+
+- `follows.test.ts` ya mockea `getCountOfflineSafe` (linea 11-14) — reutilizar. **Mockear `measureAsync`** (`vi.mock('../utils/perfMetrics', () => ({ measureAsync: (name, fn) => fn() }))`) para: (a) que el wrap delegue en `getCountOfflineSafe` y preserve el retorno, (b) capturar el `name` con un spy y assertar la clave. Alternativa equivalente: spy que registre `name` y ejecute `fn()`.
+- `favorites.test.ts` hoy **no** mockea `getCountOfflineSafe` ni `measureAsync` (solo testea add/remove). Agregar ambos mocks siguiendo el patron de `follows.test.ts`, e importar `fetchUserFavoritesCount`.
+- El path offline (retorno `0`) se cubre haciendo que el mock de `getCountOfflineSafe` resuelva `0` y verificando que el wrap propaga `0`.
+- Sin cambios en asserts de `invalidateQueryCache` / `trackEvent` de `followUser` (verificar que siguen pasando — no debe haber regresion de side effects).
+
+### Criterio de aceptacion
+
+- Cobertura >= 80% del codigo nuevo (el wrap es trivial). No bajar la cobertura existente de `favorites.test.ts` ni `follows.test.ts`.
+- Asserts nuevos: `measureAsync` invocado con la clave correcta en los 3 sites; smoke de los 2 labels.
+
+## Analytics
+
+Sin cambios GA4. Las claves de `measureAsync` son perf-metrics (sistema distinto a `trackEvent`/GA4). No requieren `GA4_EVENT_NAMES` ni `ga4FeatureDefinitions.ts`. `followUser` mantiene su `trackEvent(EVT_FOLLOW, ...)` sin cambios.
+
+---
+
+## Offline
+
+### Cache strategy
+
+| Dato | Estrategia | TTL | Storage |
+|------|-----------|-----|---------|
+| count de following/followers/favorites | `getCountOfflineSafe` devuelve `0` cuando offline (preexistente); el wrap `measureAsync` no lo altera | N/A | Firestore SDK |
+
+### Writes offline
+
+N/A — los 3 call sites son reads. No se cambian writes. `followUser`'s `setDoc` y el `gateServiceWrite` de favorites permanecen intactos.
+
+### Fallback UI
+
+Sin cambios. Comportamiento offline preexistente: contadores muestran `0` offline.
+
+---
+
+## Accesibilidad y UI mobile
+
+Sin componentes interactivos nuevos. `QueryLatencyTable` (admin) ya maneja el fallback `?? name` si faltara un label; igual se agregan ambos labels.
+
+| Componente | Elemento | aria-label | Min touch target | Error state |
+|-----------|----------|------------|------------------|-------------|
+| (ninguno nuevo) | N/A | N/A | N/A | N/A |
+
+## Textos y copy
+
+| Texto | Donde | Regla aplicada |
+|-------|-------|----------------|
+| `Seguidos: count` | label admin `follows_followingCount` | terminologia consistente con `Seguidores: count` |
+| `Favoritos: count` | label admin `favorites_count` | terminologia consistente con estilo `<Sustantivo>: count` |
+
+Sin voseo aplicable (no son CTAs de usuario). Sin tildes pendientes en estos strings.
+
+---
+
+## Decisiones tecnicas
+
+### 1. No crear `perfHelpers.test.ts`; cubrir las 2 claves via smoke en tests de service (observacion Sofia)
+
+**Decision:** NO se crea `src/components/admin/perf/perfHelpers.test.ts`. La paridad de labels se asegura con un assert smoke (`QUERY_LABELS['follows_followingCount']` y `['favorites_count']` son strings no vacios) **dentro de** `follows.test.ts` y `favorites.test.ts` respectivamente.
+
+**Rationale:** `QUERY_LABELS` es un registro de constantes sin logica condicional — `tests.md` lo lista como excepcion que no requiere test unitario dedicado. Crear un archivo de test entero para un objeto de constantes agrega superficie de mantenimiento sin valor proporcional. El assert smoke en los tests que ya tocan el feature da la senal de paridad (label presente para la clave que el service emite) sin archivo nuevo. **Alternativa rechazada:** crear `perfHelpers.test.ts` — descartada por sobre-ingenieria para constantes.
+
+### 2. Comando canonico del guard (observacion Sofia)
+
+El gate que corre en CI es **`npm run guards:check`** (= `node scripts/guards/check-baseline.mjs`), invocado en `.github/workflows/guards.yml:43`. Es el unico comando cuyo exit code bloquea (compara contra `.guards-baseline.json`). El reporte legible es `npm run guards` (= `node scripts/guards/run.mjs --pretty`, `guards.yml:50`).
+
+**Criterio de done reproducible:** correr `npm run guards` y verificar que la regla `R7-getCount-without-measure` del guard `303` reporta **0 hits**; y que `npm run guards:check` pasa (no sube el baseline). El grep subyacente de R7 (`checks.mjs:271`) debe devolver vacio tras envolver los 3 sites.
+
+### 3. Wrap inline vs. helper dedicado
+
+Se usa `measureAsync(...)` inline en cada site (patron de `ratings.ts:141`, `recommendations.ts:84,109`) en vez de un helper `measuredGetCount`. **Rationale:** consistencia con el codebase existente y con la deteccion del guard R7 (que busca `measureAsync` en la misma cadena que `getCountOfflineSafe`). Un helper nuevo requeriria agregar una exencion al guard — fuera de scope.
+
+### 4. Seed: `.mjs` y no `.ts`
+
+El doc agregado de `perfMetrics.queries` vive en `scripts/seed-admin-data.mjs:902-953`. El `scripts/seed-admin-data.ts` (usado por `npm run seed`) **no** contiene bloque de perf-metrics. El seed que alimenta `QueryLatencyTable` es el `.mjs` (`node scripts/seed-admin-data.mjs`, tambien `--target staging`). Por eso la edicion de seed va exclusivamente al `.mjs`, alineado con PRD y `patterns.md:153`.
+
+---
+
+## Hardening de seguridad
+
+### Firestore rules requeridas
+
+Ninguna. No se agregan superficies escribibles ni legibles nuevas. Los 3 reads ya corrian en produccion bajo las rules existentes de `follows`/`favorites` (`read: if request.auth != null`).
+
+### Rate limiting
+
+N/A — no hay colecciones escribibles nuevas.
+
+### Vectores de ataque mitigados
+
+| Ataque | Mitigacion | Archivo |
+|--------|-----------|---------|
+| (ninguno nuevo) | El feature solo envuelve reads preexistentes en un decorador de medicion; no expone superficie nueva | N/A |
+
+---
+
+## Deuda tecnica: mitigacion incorporada
+
+Issues consultados: el feature ataca directamente deuda trackeada por el guard #303 (R7 referencia #347 por numero) y extiende el patron de #325.
+
+| Issue | Que se resuelve | Paso del plan |
+|-------|----------------|---------------|
+| #303 (guard perf-instrumentation, R7) | Los 3 call sites pasan a tener `measureAsync` inline → grep de R7 queda vacio. Paridad seed/labels (Regla 7). | Fase 1 (S1) + Fase 2 (S2) |
+| #325 (perf instrumentation hot paths) | Extiende el mismo patron `measureAsync` a los counts olvidados. | Fase 1 (S1) |
+
+No se introduce deuda nueva. No se agrava deuda existente: los archivos tocados quedan bajo 400 lineas (`follows.ts` ~106, `favorites.ts` ~71, `perfHelpers.ts` ~127).
+
+---
+
+## Validacion Tecnica
+
+(pendiente — Diego)
+
+## Revisión Técnica (Gate Diego)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Revisor:** Diego (solution architect)
+
+**Observaciones:**
+
+1. **Guard R7 hace matching línea-por-línea.** El check `R7-getCount-without-measure` corre `grep -rn "getCountOfflineSafe(" ... | grep -v measureAsync` (`scripts/guards/checks.mjs:271`), filtrando por línea física. El plan debe asegurar que en los 3 sites `measureAsync` y `getCountOfflineSafe` queden en la MISMA línea (patrón canónico `ratings.ts:141`). Atención especial a `followUser:41`, que es una asignación (`const followingCount = await getCountOfflineSafe(...)`): el specs muestra el ejemplo inline solo para `favorites_count`. Si el wrap parte `measureAsync` y `getCountOfflineSafe` en líneas distintas, el guard sigue reportando el hit pese a estar instrumentado. Criterio de done: `npm run guards` → R7 con 0 hits.
+
+2. **Naming de claves (camelCase en sufijo) es intencional, NO corregir.** `patterns.md:153` documenta `<feature>_<verb>` snake_case, pero `follows_followingCount` / `follows_followersCount` / `favorites_count` usan sufijo camelCase. Esto replica el precedente ya en producción (`follows_followersCount` en `perfHelpers.ts:72` y seed `:917`, `ratings_countByUser`). El plan no debe normalizar a snake puro: rompería la paridad con la fila `follows_followersCount` existente que ya recibe muestras.
+
+3. **`favorites.test.ts` parte sin infra de mock.** No mockea `getCountOfflineSafe` ni `measureAsync` ni importa `fetchUserFavoritesCount` (verificado). El plan debe contemplar setup de mocks completo (siguiendo el patrón de `follows.test.ts:12-14`), no solo "agregar un assert". `follows.test.ts` ya mockea `getCountOfflineSafe` pero NO `measureAsync` ni testea `fetchFollowersCount` — ambos requieren agregarse.
+
+4. **Verificado contra el código:** los 3 call sites sin `measureAsync` (confirmado), `measureAsync` preserva tipo y semántica offline (devuelve `fn()` directo sin `sessionId`, `perfMetrics.ts:38`), `follows_followingCount`/`favorites_count` ausentes en labels y seed (confirmado), comando canónico `npm run guards:check` (`guards.yml:43`) correcto. Sin cambios de data model, rules, Cloud Functions ni superficie de ataque — coincide con lo declarado. Sin BLOQUEANTES.

--- a/docs/feat/infra/offline-custom-tags-profile-mutations/plan.md
+++ b/docs/feat/infra/offline-custom-tags-profile-mutations/plan.md
@@ -1,0 +1,274 @@
+# Plan de implementación: Offline support para custom tags y profile mutations (#344)
+
+**Specs:** [specs.md](specs.md) — VALIDADO por Diego (Arquitecto, 2026-06-10)
+**PRD:** [prd.md](prd.md) — VALIDADO CON OBSERVACIONES por Sofia (2026-06-10)
+**Fecha:** 2026-06-12
+**Branch:** `feat/344-offline-custom-tags-profile-mutations`
+
+---
+
+## Estrategia y staging de riesgo
+
+El orden sube de "núcleo de datos sin UI" (tipos + service) hacia "wiring de componentes" y cierra con tests + rules + docs. El riesgo está concentrado en F2 (cambio `addDoc`→`setDoc` del service, que toca la ruta crítica de creación de tags) y se aísla en su propia fase con tests antes de cablear UI. La exhaustividad compile-time del `Record<OfflineActionType, OfflineHandler>` obliga a hacer F1 (tipos) y F3 (handlers) juntas o el build queda roto entre fases — ver "Orden e invariante de build".
+
+| Fase | Contenido | Riesgo | Por qué |
+|------|-----------|--------|---------|
+| F1 | 3 variantes `OfflineActionType` + payloads (`types/offline.ts`) | Bajo | Solo tipos; pero rompe build hasta que F3 agregue handlers (ver invariante) |
+| F2 | `generateCustomTagId()` + `createCustomTag(tagId?)` + fix trim (`services/tags.ts`) | **Medio** | Cambia el mecanismo de escritura de tags (ruta crítica); cubierto por tests en la misma fase |
+| F3 | 3 handlers en `registerOfflineHandlers.ts` | Bajo | Cierra la exhaustividad del Record abierta en F1 |
+| F4 | Wrap `withOfflineSupport` en `BusinessTags` | Medio | Toca un componente de uso frecuente; patrón ya presente (`handleToggleTag`) |
+| F5 | Gate offline profile (`EditDisplayNameDialog`, `AvatarPicker`, `ProfileScreen`, `AuthContext`) | Bajo | Gate UI + guard defensivo; sin nueva superficie de escritura |
+| F6 | Rules test `customTags` + tests de componentes restantes | Bajo | Cierra checkbox de inventario tests.md; no toca código de producción |
+| F7 | Documentación (obligatoria) | Bajo | patterns.md / features.md / firestore.md / security.md |
+
+### Orden e invariante de build
+
+Agregar las 3 variantes a la union `OfflineActionType` (F1) **rompe la compilación** del `Record<OfflineActionType, OfflineHandler>` en `registerOfflineHandlers.ts` hasta que F3 agregue los 3 handlers (esto es deseado — es el guardrail de exhaustividad). Por lo tanto **F1, F2 y F3 deben mergearse en el mismo commit/PR-state compilable**, o ejecutarse en secuencia inmediata sin commitear un estado intermedio que no buildea. Decisión: **commits atómicos por fase, pero F1→F2→F3 se implementan en bloque y el primer commit "verde" es al cerrar F3.** No commitear F1 sola.
+
+---
+
+## File ownership por agente
+
+| Fase | Archivos | Agente | Tipo de trabajo |
+|------|----------|--------|-----------------|
+| F1 | `src/types/offline.ts` | nico | Tipos / dominio offline |
+| F2 | `src/services/tags.ts`, `src/services/__tests__/tags.test.ts` | nico | Service + tests de service |
+| F3 | `src/services/registerOfflineHandlers.ts`, `src/services/__tests__/registerOfflineHandlers.test.ts` | nico | Registry + tests |
+| F4 | `src/components/business/BusinessTags.tsx`, `src/components/business/__tests__/BusinessTags.test.tsx`, `src/services/__tests__/offlineInterceptor.test.ts`, `src/services/__tests__/syncEngine.test.ts` | luna | Componente + tests de integración offline |
+| F5 | `src/components/profile/EditDisplayNameDialog.tsx`, `src/components/profile/AvatarPicker.tsx`, `src/components/profile/ProfileScreen.tsx`, `src/context/AuthContext.tsx` | luna | UI profile + guard context |
+| F6 | `tests/rules/customTags.rules.test.ts`, `src/components/profile/__tests__/EditDisplayNameDialog.test.tsx`, `src/components/profile/__tests__/AvatarPicker.test.tsx`, `src/context/AuthContext.test.tsx` | luna | Tests de UI + rules |
+| F7 | `docs/reference/*` | nico | Documentación |
+
+Sin conflicto de ownership: nico es dueño exclusivo de F1–F3 + F7 (capa de datos/tipos/docs), luna de F4–F6 (componentes y su testing). El único punto de contacto cruzado es la firma de `createCustomTag(tagId?)` y la union `OfflineActionType` — ambos quedan congelados al cerrar F3 antes de que luna empiece F4.
+
+---
+
+## Fase 1 — Variantes y payloads de `OfflineActionType` (S1)
+
+- **Archivo:** `src/types/offline.ts`. **Agente:** nico.
+- **Cambio:**
+  - Agregar a la union `OfflineActionType`: `'custom_tag_create' | 'custom_tag_update' | 'custom_tag_delete'`.
+  - Agregar payloads: `CustomTagCreatePayload { label: string }`, `CustomTagUpdatePayload { label: string }`, `CustomTagDeletePayload { _type: 'custom_tag_delete' }` (marker, alineado con `RatingDeletePayload`/`ListDeletePayload`).
+  - Sumar los 3 payloads a la union `OfflineActionPayload`.
+  - El `tagId` NO entra al payload: viaja en el campo genérico existente `OfflineAction.referenceId` (sin tocar el shape de `OfflineAction`).
+- **Test:** ninguno propio (tipos). El compilador valida en F3.
+- **Commit (NO verde aislado — ver invariante de build):** se incluye junto a F2/F3. Mensaje del bloque en F3.
+- **Rollback:** revert de la union + payloads (revierte build a estado previo).
+
+## Fase 2 — `generateCustomTagId()` + `createCustomTag(tagId?)` + fix trim (S1)
+
+- **Archivos:** `src/services/tags.ts`, `src/services/__tests__/tags.test.ts`. **Agente:** nico.
+- **Cambio en `tags.ts`:**
+  - Agregar `generateCustomTagId(): string` → `doc(collection(db, COLLECTIONS.CUSTOM_TAGS)).id` (espejo exacto de `generateListId()` en `sharedLists.ts`).
+  - Migrar `createCustomTag(userId, businessId, label, tagId?)`: si `tagId` viene → `setDoc(doc(db, COLLECTIONS.CUSTOM_TAGS, tagId), docData)`; si no → `addDoc(...)` (fallback online, mismo branch que `createList(listId?)`).
+  - **Fix de hardening:** enviar `label: trimmed` en AMBOS paths (hoy el `addDoc` manda `label` crudo aunque valida `trimmed`). Conservar el throw si `!trimmed || trimmed.length > MAX_CUSTOM_TAG_LENGTH`.
+  - `setDoc` no agrega campos extra: solo los 4 del whitelist (`userId`, `businessId`, `label`, `createdAt`). El `tagId` es el doc ID, NO un field.
+  - `updateCustomTag`/`deleteCustomTag`: sin cambio de firma.
+- **Test (misma fase, no diferida):** `tags.test.ts` — `generateCustomTagId` devuelve ID no vacío; `createCustomTag` con `tagId` llama `setDoc(doc(..., tagId))`; sin `tagId` llama `addDoc`; ambos paths envían `label` con trim; validación 1-30 sigue lanzando.
+- **Commit (NO verde aislado — la union de F1 rompe el Record hasta F3):** incluido en el bloque F1–F3.
+- **Rollback:** revert de `tags.ts` a `addDoc`-only + revert del test.
+
+## Fase 3 — Handlers de replay (S1) — cierra el build
+
+- **Archivos:** `src/services/registerOfflineHandlers.ts`, `src/services/__tests__/registerOfflineHandlers.test.ts`. **Agente:** nico.
+- **Cambio:** agregar 3 entradas al `Record<OfflineActionType, OfflineHandler>`:
+  - `custom_tag_create`: `{ userId, businessId, referenceId, payload }` → `createCustomTag(userId, businessId, payload.label, referenceId)` (referenceId = tagId client-side, lazy `import('./tags')`).
+  - `custom_tag_update`: `{ referenceId, payload }` → throw si falta `referenceId`; `updateCustomTag(referenceId, payload.label)`.
+  - `custom_tag_delete`: `{ referenceId }` → throw si falta `referenceId`; `deleteCustomTag(referenceId)`.
+  - Imports de tipo: `CustomTagCreatePayload`, `CustomTagUpdatePayload` (delete usa solo `referenceId`).
+- **Test:** `registerOfflineHandlers.test.ts` — los 3 handlers invocan el service con payload deserializado; update/delete lanzan si falta `referenceId`; create pasa `referenceId` como `tagId`.
+- **Commit (PRIMER commit verde del bloque F1–F3):** `feat(#344): custom tag offline action types, client-side id y handlers de replay`
+- **Rollback:** revert del bloque completo F1+F2+F3 (son interdependientes por exhaustividad).
+
+## Fase 4 — Wrap `withOfflineSupport` en `BusinessTags` (S1)
+
+- **Archivos:** `src/components/business/BusinessTags.tsx` (+ tests de integración). **Agente:** luna.
+- **Cambio:** modificar `handleSaveCustomTag` (create + update) y `handleDelete`, alineado con `handleToggleTag` (L84-105):
+  - **create:** `const tagId = generateCustomTagId()` ANTES de wrappear; `withOfflineSupport(isOffline, 'custom_tag_create', { userId, businessId, businessName, referenceId: tagId }, { label }, () => createCustomTag(user.uid, businessId, label, tagId), toast)`.
+  - **update:** `withOfflineSupport(isOffline, 'custom_tag_update', { userId, businessId, businessName, referenceId: editingTag.id }, { label }, () => updateCustomTag(editingTag.id, label), toast)`.
+  - **delete:** `withOfflineSupport(isOffline, 'custom_tag_delete', { userId, businessId, businessName, referenceId: menuTag.id }, { _type: 'custom_tag_delete' }, () => deleteCustomTag(menuTag.id), toast)`.
+  - Custom tags NO se deshabilitan offline — se encolan; el toast `OFFLINE_ENQUEUED_MSG` lo emite `withOfflineSupport`.
+  - Cada handler en `try/catch` con `logger.error`.
+  - Generar `tagId` client-side tanto online como offline (mismo doc referenciado por un update/delete posterior).
+- **Tamaño:** componente pasa de 271 a ~283 (< 300 warn). Si supera 300 en implementación → extraer los 3 handlers a `src/hooks/useCustomTagActions.ts` (riesgo bajo, ver Estimación de tamaño).
+- **Tests (misma fase):**
+  - `BusinessTags.test.tsx`: create/update/delete online ejecutan el service; offline encolan + toast `OFFLINE_ENQUEUED_MSG`; el `tagId` generado en create es el encolado (estable create→delete offline).
+  - `offlineInterceptor.test.ts` (extender): `withOfflineSupport` encola `custom_tag_*` con `referenceId` en meta y dispara `EVT_OFFLINE_ACTION_QUEUED` con `action_type` correcto.
+  - `syncEngine.test.ts` (extender): crear+editar mismo tag offline (mismo `referenceId`) → drenado FIFO aplica ambos en orden y `updateCustomTag` recibe el `tagId` del create; **delete de tag cuyo create falló permanentemente: `deleteCustomTag` de doc inexistente resuelve limpio → `executeAction` NO falla → NO reintenta → NO llega a `OFFLINE_MAX_RETRIES`** (observación Sofia).
+- **Commit:** `feat(#344): encolar custom tag create/update/delete con withOfflineSupport`
+- **Rollback:** revert del componente a writes directos + revert de los tests añadidos. No afecta F1–F3 (los handlers quedan inertes si nadie encola).
+
+## Fase 5 — Gate offline en profile mutations (S2)
+
+- **Archivos:** `EditDisplayNameDialog.tsx`, `AvatarPicker.tsx`, `ProfileScreen.tsx`, `src/context/AuthContext.tsx`. **Agente:** luna.
+- **Cambio:**
+  - `EditDisplayNameDialog`: importar `useConnectivity` (dialog de feature, aceptable); `disabled={... || isOffline}` en botón Guardar + `title={isOffline ? MSG_OFFLINE.requiresConnection : undefined}` nativo sobre el `<Button>` (sin `<Tooltip>`/`<span>` — patrón del proyecto, confirmado por Sofia); `handleSave` retorna early si `isOffline`.
+  - `AvatarPicker`: nueva prop `isOffline: boolean` (props-driven puro, NO importa `useConnectivity`); cada `<ButtonBase>` con `disabled={isOffline}` + `aria-disabled={isOffline}`.
+  - `ProfileScreen`: pasar `isOffline={isOffline}` a `<AvatarPicker>` (ya tiene `useConnectivity()`/`isOffline` en scope, L57 verificado). Handler `onSelect` real ya existente, no se toca.
+  - `AuthContext.setDisplayName` (L126-132) y `setAvatarId` (L134-145): **guard defense-in-depth** — early-return silencioso si `navigator.onLine === false`. Se lee `navigator.onLine` **directo** (NO `useConnectivity`, que es un hook React no usable dentro de los callbacks ya definidos del context), mismo criterio que `gateServiceWrite`/`getCountOfflineSafe`. NO encola, NO toast (la UI ya comunica vía disabled+title).
+- **Test:** diferidos a F6 (junto con el rules test) para mantener este commit acotado a cambios de UI/context.
+- **Commit:** `feat(#344): gate offline en profile mutations (dialog, avatar picker, authcontext guard)`
+- **Rollback:** revert de los 4 archivos. Independiente de custom tags (F1–F4).
+
+## Fase 6 — Tests de UI + rules test de `customTags` (S1/S2)
+
+- **Archivos:** `EditDisplayNameDialog.test.tsx`, `AvatarPicker.test.tsx`, `AuthContext.test.tsx` (extender), `tests/rules/customTags.rules.test.ts` (nuevo). **Agente:** luna.
+- **Cambio / qué testear:**
+  - `EditDisplayNameDialog.test.tsx`: botón `disabled` cuando `isOffline`; `title` == "Requiere conexión" offline, `undefined` online; `handleSave` no llama `setDisplayName` offline.
+  - `AvatarPicker.test.tsx`: `ButtonBase` `disabled`+`aria-disabled` cuando `isOffline=true`; `onSelect` NO se dispara offline, SÍ online.
+  - `AuthContext.test.tsx` (extender): `setDisplayName`/`setAvatarId` no llaman al service cuando `navigator.onLine === false`.
+  - `customTags.rules.test.ts` (nuevo, espejo de `users.rules.test.ts`, `@firebase/rules-unit-testing` v5): ALLOW create con ID client-side + label válido + owner; DENY label > 30; DENY campo extra fuera del whitelist; DENY update fuera de `label`; DENY delete de otro owner; **delete de doc inexistente resuelve sin error** (confirma el no-op tolerable del replay; documentar comportamiento si la rule deniega sobre `resource.data` ausente, observación Sofia) — marca el checkbox `customTags` en inventario tests.md.
+- **Commit:** `test(#344): rules test customTags + tests de gate offline profile`
+- **Rollback:** revert de los archivos de test (no afecta producción).
+
+## Fase 7 — Documentación (OBLIGATORIA)
+
+- **Agente:** nico.
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `docs/reference/patterns.md` | "Offline action types" 26 → 29; nota de `generateCustomTagId()` como espejo de `generateListId()`; patrón `referenceId` para transportar doc IDs client-side |
+| 2 | `docs/reference/features.md` | Custom tags ahora soportan create/update/delete offline (encolado tipado); profile mutations gateadas offline |
+| 3 | `docs/reference/firestore.md` | Sin colección nueva; nota de doc ID client-side en `customTags` (`setDoc` vs `addDoc`) |
+| 4 | `docs/reference/security.md` | Marcar rules test de `customTags` cubierto; nota del vector overwrite-via-setDoc mitigado por ownership |
+| 5 | `docs/reference/tests.md` | Marcar checkbox `customTags` en inventario; registrar `customTags.rules.test.ts`, `EditDisplayNameDialog.test.tsx`, `AvatarPicker.test.tsx` |
+
+- **Commit:** `docs(#344): offline custom tags + profile gate (patterns, features, firestore, security, tests)`
+- **Rollback:** revert de docs.
+
+---
+
+## Orden de implementacion
+
+1. `src/types/offline.ts` (F1) — sin dependencias; rompe build hasta paso 3.
+2. `src/services/tags.ts` + `tags.test.ts` (F2) — depende de `COLLECTIONS.CUSTOM_TAGS` (existente).
+3. `src/services/registerOfflineHandlers.ts` + test (F3) — cierra exhaustividad del Record; **primer estado verde**.
+4. `src/components/business/BusinessTags.tsx` + tests integración (F4) — depende de F2 (`generateCustomTagId`, `createCustomTag(tagId?)`) y F1 (action types).
+5. Profile: `EditDisplayNameDialog`, `AvatarPicker`, `ProfileScreen`, `AuthContext` (F5) — independiente de custom tags.
+6. Tests UI + rules (F6) — depende de F5 (componentes) y de las rules existentes.
+7. Docs (F7) — al final.
+
+Pasos 1-3 en bloque atómico (invariante de build). Paso 5 puede correr en paralelo a 1-4 (sin overlap de archivos). Paso 6 tras 5. Paso 7 al cierre.
+
+---
+
+## Test plan global
+
+- **Unit/service:** `tags.test.ts` (F2), `registerOfflineHandlers.test.ts` (F3), `offlineInterceptor.test.ts` + `syncEngine.test.ts` (F4).
+- **Componente:** `BusinessTags.test.tsx` (F4), `EditDisplayNameDialog.test.tsx` + `AvatarPicker.test.tsx` (F6).
+- **Context:** `AuthContext.test.tsx` (F6).
+- **Rules:** `customTags.rules.test.ts` contra emulador (F6).
+- **Cobertura:** >= 80% del código nuevo; branches global no baja de 81.86%.
+- **Compile-time:** `tsc` valida exhaustividad del `Record<OfflineActionType, OfflineHandler>` (los 3 handlers obligatorios).
+- **Gate:** `npm run lint` + `npm run build` + suite completa verde antes de merge.
+
+---
+
+## Riesgos
+
+1. **Build roto entre F1 y F3** (medio): agregar la union sin handlers rompe el `Record` exhaustivo. **Mitigación:** F1–F3 se mergean como bloque atómico; el primer commit verde es al cerrar F3 (ver invariante de build). No commitear F1 aislada.
+2. **`createCustomTag` con parámetro posicional `tagId?` al final** (bajo): los call sites existentes que pasan 3 args (`userId, businessId, label`) siguen funcionando (`tagId` queda `undefined` → branch `addDoc`). Solo `BusinessTags` pasará el 4º arg. **Mitigación:** firma append-only, no reordena parámetros.
+3. **Rate limit server-side borra tags al drenar cola grande** (tech debt aceptado, observación Sofia): el `setDoc` resuelve OK (rule pasa), `syncEngine` marca `synced`, pero `onCustomTagCreated` puede hacer `snap.ref.delete()` al exceder 10/business o 50/día. El toast "Guardado offline" no distingue ese caso. **Mitigación:** documentado como tech debt conocido en specs (Cloud Functions); NO se mitiga acá (fuera de scope: no se tocan rules ni trigger). Telemetría futura registrada como followup.
+4. **`BusinessTags.tsx` cruza 300 líneas** (bajo): los wraps suman ~12 líneas (271 → ~283). **Mitigación:** si supera 300, extraer los 3 handlers a `src/hooks/useCustomTagActions.ts`.
+
+---
+
+## Estimacion de tamano de archivos
+
+| Archivo | Lineas actuales | Estimadas post-cambio | Dentro del limite? |
+|---------|----------------|----------------------|--------------------|
+| `src/types/offline.ts` | (union + payloads) | +~10 | Si (< 400) |
+| `src/services/tags.ts` | ~70 | ~90 | Si (< 400) |
+| `src/services/registerOfflineHandlers.ts` | (Record) | +~20 | Si (< 400) |
+| `src/components/business/BusinessTags.tsx` | 271 | ~283 | Si (< 300 warn; vigilar) |
+| `src/components/profile/EditDisplayNameDialog.tsx` | — | +~6 | Si (< 400) |
+| `src/components/profile/AvatarPicker.tsx` | — | +~6 | Si (< 400) |
+| `src/context/AuthContext.tsx` | — | +~6 | Si (< 400) |
+| `tests/rules/customTags.rules.test.ts` | 0 (nuevo) | ~130 | Si (< 400) |
+
+---
+
+## Guardrails de modularidad
+
+- [x] Ningún componente importa `firebase/firestore` — writes vía `services/tags.ts`; guard usa `navigator.onLine` (no Firebase)
+- [x] Archivos en carpeta de dominio correcta (`business/`, `profile/`, `services/`, `types/`) — no `menu/`
+- [x] Lógica de negocio (gen ID, persistencia) en `services/`, no en componentes
+- [x] `AvatarPicker` sigue props-driven puro (recibe `isOffline` por prop, no importa contexto)
+- [x] Action type strings en la union de `types/offline.ts` (no magic strings)
+- [x] Se toca un archivo con deuda menor conocida (`createCustomTag` sin trim) e incluye el fix
+- [x] Ningún archivo resultante supera 400 líneas (BusinessTags vigilado a 300)
+
+## Guardrails de seguridad
+
+- [x] `customTags` create conserva `hasOnly(['userId','businessId','label','createdAt'])` — `setDoc` no agrega campos
+- [x] `label` valida `is string` + `size() <= 30` (rule existente); service envía `label: trimmed`
+- [x] Update conserva `affectedKeys().hasOnly(['label'])`; immutables fuera de la lista
+- [x] ID client-side no abre vector: ownership server-side (create `userId == auth.uid`, update/delete `resource.data.userId == auth.uid`) bloquea overwrite
+- [x] Rate limit server-side existente (10/business + 50/día con delete on exceed) — no se introduce colección nueva
+- [x] `getCountFromServer` → N/A (no hay count queries nuevas)
+- [x] No hay secrets ni credenciales en archivos commiteados
+
+## Guardrails de observabilidad
+
+- [x] No hay CF nueva (trigger `customTags.ts` existente, sin tocar)
+- [x] `generateCustomTagId`/`createCustomTag` son writes, no queries nuevas → no requieren `measureAsync`
+- [x] `EVT_OFFLINE_ACTION_QUEUED` reusado (ya registrado); `custom_tag_*` aparecen como `action_type` libre, sin registro adicional
+- [x] `logger.error` en handlers de `BusinessTags`, nunca dentro de `if (import.meta.env.DEV)`
+
+## Guardrails de accesibilidad y UI
+
+- [x] `AvatarPicker` ButtonBase con `disabled` + `aria-disabled` (no solo visual) offline
+- [x] Botón Guardar con `title` nativo offline (sin `<Tooltip>`/`<span>` wrapper)
+- [x] Custom tags NO se deshabilitan (encolables) — feedback vía toast
+- [x] Touch targets >= 44x44 (IconButtons ya cumplen)
+- [x] `<IconButton>` existentes conservan `aria-label`
+
+## Guardrails de copy
+
+- [x] No se crean textos nuevos — `OFFLINE_ENQUEUED_MSG` y `MSG_OFFLINE.requiresConnection` reusados
+- [x] Tildes correctas ("sincronizará", "conexión")
+- [x] Terminología "etiquetas"/"comercios" en copy auxiliar
+
+---
+
+## Rollback global
+
+Fases mayormente independientes. **F1–F3 son un bloque atómico** (interdependencia por exhaustividad del Record): revertir requiere revertir las tres juntas. F4 (BusinessTags) depende de F1–F3 pero su revert deja los handlers inertes (nadie encola) sin romper el build. F5 (profile) es totalmente independiente y revertible por sí sola. F6/F7 son tests + docs, revertibles sin impacto de producción.
+
+---
+
+## Criterios de done
+
+- [ ] Crear/editar/eliminar custom tags offline encola `custom_tag_*` tipado, replay correcto al reconectar, toast "Guardado offline"
+- [ ] Custom tag creado offline tiene ID client-side estable (editar/eliminar offline referencia el mismo doc; replay no falla)
+- [ ] Botón Guardar de `EditDisplayNameDialog` y avatares de `AvatarPicker` deshabilitados con "Requiere conexión" offline; guard `navigator.onLine` en `AuthContext`
+- [ ] Rules de `customTags`/`users` sin cambios; rules test allow+deny de `customTags` agregado (cierra checkbox tests.md)
+- [ ] Cobertura >= 80% del código nuevo; branches global >= 81.86%; exhaustividad de los 3 handlers en compile-time
+- [ ] No lint errors; build verde
+- [ ] Seed data: N/A (sin schema change)
+- [ ] Reference docs actualizados (patterns, features, firestore, security, tests)
+
+---
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Ciclo:** 1
+
+**Observaciones para el implementador:**
+
+1. **Invariante de build F1–F3 (punto sensible) — bien resuelto, blindar en los prompts de agente.** El plan secuencia F1→F2→F3 como bloque atómico con un solo commit verde al cerrar F3, lo cual es correcto: agregar las 3 variantes a la union sin los 3 handlers rompe la exhaustividad del `Record<OfflineActionType, OfflineHandler>` (verificado en `registerOfflineHandlers.ts:36`). Riesgo de delivery: nico es dueño de las 3 fases pero el pre-push hook corre `tsc + vite build`; si por algún motivo intenta pushear un estado intermedio (F1 o F2 sin F3) el push FALLA. Asegurar que el prompt de nico diga explícitamente "no commitear/pushear hasta cerrar F3; el primer estado compilable es con los 3 handlers registrados".
+
+2. **F4 y F5 pueden correr en paralelo (ambas de luna) sin overlap, pero F4 depende de F1–F3 cerrado.** F5 (profile) es independiente de custom tags y puede arrancar en paralelo a F1–F3 de nico. F4 (BusinessTags) NO: consume `generateCustomTagId` y `createCustomTag(tagId?)` (F2) y las action types (F1). Secuenciar F4 después del commit verde de F3. El plan ya lo dice en "Orden de implementacion" (paso 4 tras paso 3); mantenerlo al delegar.
+
+3. **F4 toca `offlineInterceptor.test.ts` y `syncEngine.test.ts` (extensión, no creación).** Son archivos de test compartidos del dominio offline. Asignados a luna en F4 — ownership exclusivo correcto, sin overlap con nico (que no toca tests de interceptor/syncEngine). Solo confirmar que nico en F3 NO extienda esos dos archivos: su scope de test es `registerOfflineHandlers.test.ts` exclusivamente.
+
+4. **Límite de archivo: el blocker del merge skill es 400 líneas, no 300** (verificado en `merge/SKILL.md:228`). BusinessTags proyectado a ~283 está holgado bajo el blocker. El umbral de 300 es un warn interno con plan de mitigación (extraer a `useCustomTagActions.ts`). No bloquea entrega; vigilar en implementación como dice el plan.
+
+5. **Estimación coherente con el PRD (esfuerzo total M).** 7 fases, mayoría S, F4 es la única M. Suma razonable para M. Sin pasos "triviales" que escondan 20 archivos.
+
+6. **Rate limit server-side en replay = tech debt aceptado, correctamente fuera de scope.** El plan no agenda mitigación (no toca trigger ni rules) y lo documenta como followup de telemetría. Alineado con specs y observación de Sofia. No es un gap de delivery.
+
+**Listo para pasar a implementacion:** Sí. Sin bloqueantes. El punto sensible (invariante F1–F3) está correctamente staged. Delegar nico→F1-F3 (bloque) + F7; luna→F5 en paralelo, luego F4 (tras commit verde de F3) + F6.

--- a/docs/feat/infra/offline-custom-tags-profile-mutations/prd.md
+++ b/docs/feat/infra/offline-custom-tags-profile-mutations/prd.md
@@ -1,0 +1,297 @@
+# PRD: Offline support para custom tags y profile mutations
+
+**Feature:** offline-custom-tags-profile-mutations
+**Categoria:** infra
+**Fecha:** 2026-06-09
+**Issue:** #344
+**Prioridad:** Media (severidad HIGH/MEDIUM en /health-check)
+
+---
+
+## Contexto
+
+El proyecto ya tiene una cola offline madura (`withOfflineSupport` + `OfflineActionType` de 26 variantes, `syncEngine` con registry de handlers tipados, #304/#323/#335). El audit `/health-check` detectó dos huecos: el CRUD de **custom tags** en `BusinessTags.tsx` ejecuta `addDoc/updateDoc/deleteDoc` directos sin `withOfflineSupport` ni guard `isOffline` (mientras que `addUserTag`/`removeUserTag` del mismo componente SÍ están cubiertos), y las **profile mutations** (`setDisplayName`/`setAvatarId`) escriben sin feedback offline al usuario.
+
+## Problema
+
+- `createCustomTag`/`updateCustomTag`/`deleteCustomTag` (BusinessTags.tsx:139,141,154) corren writes directos sin gate offline. Estando offline: el write queda buffered por Firestore sin feedback al usuario ni replay tipado por el `syncEngine`, rompiendo el contrato de "Guardado offline — se sincronizará al reconectar" que el resto del componente sí cumple.
+- `createCustomTag` usa `addDoc` (ID auto-generado por Firestore). Encolar un `custom_tag_create` offline no produce un ID estable, por lo que un `update`/`delete` posterior del mismo tag offline no tiene a qué referenciar — mismo problema que resolvió `generateListId()` en #304 para listas.
+- `setDisplayName` (AuthContext.tsx:130) y `setAvatarId` (AuthContext.tsx:140) escriben sin guard; `EditDisplayNameDialog` (botón Guardar) y `AvatarPicker` no tienen awareness de offline, así que el usuario no sabe que el cambio quedó pendiente.
+
+## Solucion
+
+### S1 — Custom tag CRUD con `withOfflineSupport` + ID client-side
+
+Tres nuevas variantes de `OfflineActionType`: `custom_tag_create`, `custom_tag_update`, `custom_tag_delete`. Patrón idéntico al de listas (#304):
+
+- Agregar `generateCustomTagId()` a `services/tags.ts` (espejo de `generateListId()` en `sharedLists.ts`): `doc(collection(db, COLLECTIONS.CUSTOM_TAGS)).id`. Migrar `createCustomTag` para aceptar un `tagId?` opcional y usar `setDoc(doc(..., tagId))` cuando viene, conservando `addDoc` como fallback online (mismo shape que `createList`).
+- En `BusinessTags.handleSaveCustomTag` y `handleDelete`, wrappear con `withOfflineSupport(isOffline, 'custom_tag_*', { userId, businessId, businessName }, payload, onlineAction, toast)`. El componente ya tiene `isOffline` de `useConnectivity()` y `toast` — alinear con el patrón existente de `handleToggleTag` (líneas 86-101).
+- Generar el `tagId` client-side **antes** de encolar (tanto online como offline) para que el optimistic UI y un eventual `update`/`delete` offline referencien el mismo doc.
+- Registrar los 3 handlers en `registerOfflineHandlers.ts` (el `Record<OfflineActionType, OfflineHandler>` fuerza exhaustividad en compile-time — agregar el tipo sin handler rompe el build).
+- Payloads tipados en `types/offline.ts`: `CustomTagCreatePayload { label: string }`, `CustomTagUpdatePayload { tagId: string; label: string }`, `CustomTagDeletePayload { tagId: string }`. El `tagId` del create va en `OfflineAction.referenceId` (campo genérico existente) o se deriva del doc ID — definir en specs cuál, alineado con cómo `list_create` usa `listId`.
+
+**Ordering del replay (create → update/delete del mismo tag offline)**: como el `syncEngine` procesa la cola en orden FIFO (`getPending` ordena por `createdAt`), un `custom_tag_create` encolado antes de un `custom_tag_update`/`delete` del mismo `tagId` se replaya primero — el doc ya existe cuando llega el update/delete. A diferencia de `comment_edit`/`comment_delete` (#340 W6), aquí NO se necesita un guard de "edit no confirmado" porque el create y el update/delete comparten el `tagId` client-side y el orden FIFO garantiza la secuencia. Caso a cubrir en tests: crear tag offline → editarlo offline → reconectar ⇒ ambas acciones se aplican en orden y el doc final tiene el label editado. Caso límite: crear offline → eliminar offline ⇒ el delete del mismo `tagId` puede fallar si el create falló permanentemente (>= `OFFLINE_MAX_RETRIES`); especificar en specs que un delete de un tag cuyo create nunca persistió es un no-op tolerable (deleteDoc de doc inexistente no lanza en Firestore).
+
+**Seguridad** (security.md): la regla `customTags` ya valida `hasOnly(['userId','businessId','label','createdAt'])`, `label` 1-30, `isValidBusinessId`, `createdAt == request.time`, y `affectedKeys().hasOnly(['label'])` en update. El cambio de `addDoc` → `setDoc` con ID client-side NO afecta las rules (el ID del doc no se valida; lo que importa son los campos). Validar que `setDoc` no introduzca campos extra fuera del whitelist.
+
+### S2 — Feedback offline en profile mutations
+
+- `EditDisplayNameDialog`: importar `useConnectivity`, agregar `|| isOffline` al `disabled` del botón Guardar + `Tooltip` "Requiere conexión". Mismo patrón usado en operaciones destructivas bloqueadas (#304/#323).
+- `AvatarPicker`: recibe `isOffline` por prop desde su consumidor `ProfileScreen.tsx` (que ya tiene `useConnectivity()` e `isOffline` en scope, verificado) — el componente es props-driven puro y NO debe importar contextos (ver modularización). Deshabilita los `ButtonBase` de avatares con feedback visual cuando offline.
+- `AuthContext.setDisplayName`/`setAvatarId`: estas mutaciones escriben a la colección `users` (no a una colección con `OfflineActionType` propio). Decisión de producto a definir en specs: (a) bloquear con guard offline + toast (más simple, consistente con el resto del issue que pide "deshabilitar + tooltip"), o (b) crear `OfflineActionType` `profile_displayname_update`/`profile_avatar_update` con replay. **El issue pide la opción (a)** ("agregar `|| isOffline` al `disabled` + tooltip"). Adoptar (a): gate en UI, sin nuevos action types para profile.
+
+**UX**: el tooltip "Requiere conexión" y el `disabled` deben ser consistentes con los gates offline ya existentes. Para custom tags, en cambio, NO se bloquea — se encola y se muestra el toast `OFFLINE_ENQUEUED_MSG` (custom tags son no-destructivos y replayables, a diferencia de profile que toca la colección `users` sin handler de replay).
+
+### S3 — Analytics y observabilidad
+
+Reusar `EVT_OFFLINE_ACTION_QUEUED` (ya disparado dentro de `withOfflineSupport` con `action_type`). No hace falta evento nuevo. Verificar que `custom_tag_create/update/delete` aparezcan en el reporte de tipos encolados sin cambios adicionales.
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| 3 nuevas variantes `OfflineActionType` + payloads tipados (`types/offline.ts`) | Alta | S |
+| `generateCustomTagId()` + `createCustomTag(tagId?)` en `services/tags.ts` | Alta | S |
+| Wrap `withOfflineSupport` en `BusinessTags` (create/update/delete) | Alta | M |
+| 3 handlers en `registerOfflineHandlers.ts` | Alta | S |
+| Gate offline + tooltip en `EditDisplayNameDialog` | Media | S |
+| Prop `isOffline` + disabled en `AvatarPicker` | Media | S |
+| Guard offline en `AuthContext.setDisplayName`/`setAvatarId` (opción a) | Media | S |
+| Tests (offline.ts, tags.ts, registerOfflineHandlers, BusinessTags, dialogs) | Alta | M |
+
+**Esfuerzo total estimado:** M
+
+---
+
+## Out of Scope
+
+- Replay con `OfflineActionType` propio para profile mutations (displayName/avatar) — se gatea en UI, no se encola (decisión S2 opción a).
+- Limpieza del dead code `inviteListEditor`/`removeListEditor` sin callers (sharedLists.ts:159,167) — reportado en severidad Baja del issue; tratarlo en issue separado de tech debt.
+- Optimistic UI nuevo para custom tags más allá del refetch `onTagsChange()` ya existente.
+- Cambios en las Firestore rules de `customTags` (las actuales ya cubren el caso; solo se agregan rules tests).
+
+---
+
+## Tests
+
+Política tests.md: >= 80% cobertura del código nuevo. Branches global ya en 81.86% — no bajar.
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `src/services/tags.ts` | Service | `generateCustomTagId` devuelve ID no vacío; `createCustomTag` con `tagId` usa `setDoc` en ese ID, sin `tagId` usa `addDoc`; validación label 1-30 sigue lanzando |
+| `src/services/registerOfflineHandlers.ts` | Registry | Los 3 handlers `custom_tag_*` invocan el service correcto con payload deserializado; `custom_tag_update`/`delete` requieren `tagId` (referenceId); exhaustividad compile-time |
+| `src/services/offlineInterceptor.ts` | Service | (existente) `withOfflineSupport` encola `custom_tag_*` con meta correcta y dispara `EVT_OFFLINE_ACTION_QUEUED` |
+| `src/components/business/BusinessTags.tsx` | Componente | create/update/delete online ejecutan el service; offline encolan + toast `OFFLINE_ENQUEUED_MSG`; tagId estable entre create y delete offline |
+| `src/services/syncEngine.ts` (o `registerOfflineHandlers`) | Replay ordering | crear+editar mismo tag offline → al drenar, ambas aplican en orden FIFO y el doc final tiene el label editado; delete de tag cuyo create falló es no-op tolerable |
+| `src/components/profile/EditDisplayNameDialog.tsx` | Componente | botón Guardar `disabled` cuando `isOffline`; tooltip "Requiere conexión" presente |
+| `src/components/profile/AvatarPicker.tsx` | Componente | avatares `disabled` cuando prop `isOffline=true`; onSelect no se dispara offline |
+| `tests/rules/customTags.rules.test.ts` | Rules | allow create con ID client-side + label válido; deny label > 30; deny campo extra; deny update fuera de `label`; deny delete de otro owner (marca checkbox `customTags` en inventario tests.md) |
+
+### Criterios de testing
+
+- Cobertura >= 80% del codigo nuevo
+- Tests de validacion para todos los inputs del usuario (label 1-30)
+- Todos los paths condicionales cubiertos (online vs offline; create con/sin tagId)
+- Side effects verificados (enqueue en IndexedDB, `trackEvent`, refetch `onTagsChange`)
+
+---
+
+## Seguridad
+
+- [ ] La regla `customTags` create mantiene `keys().hasOnly(['userId','businessId','label','createdAt'])` — el cambio `addDoc`→`setDoc` con ID client-side no agrega campos
+- [ ] `label` valida `is string` + `size()` 1-30 (ya presente); `setDoc` no debe enviar `label` sin trim ni > 30
+- [ ] Update rule conserva `affectedKeys().hasOnly(['label'])` — campos immutables (`userId`, `businessId`, `createdAt`) fuera de la lista
+- [ ] Ownership en update/delete vía `resource.data.userId == request.auth.uid` (ya presente)
+- [ ] ID generado client-side NO se valida en rules — confirmar que no abre vector (el doc ID arbitrario está OK; los campos son lo validado, y el `businessId` del payload pasa por `isValidBusinessId`)
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| `customTags` create con ID client-side | Colisión/overwrite de doc de otro usuario via `setDoc` en ID arbitrario | El whitelist + `userId == request.auth.uid` impide escribir un doc con userId ajeno; un overwrite requeriría conocer un docId existente Y pasar ownership — rule lo bloquea |
+| Replay de cola corrupta | `custom_tag_update`/`delete` con tagId apuntando a doc ajeno | Rule de update/delete valida ownership server-side; el replay no bypasea rules |
+| Spam de tags offline | Encolar N tags offline → drenar todos al reconectar | Rate limit server-side ya existe: `customTags` 10/business + 50/día por usuario (trigger `customTags.ts` con `checkRateLimit`); el replay respeta el límite |
+
+Custom tags escribe a Firestore:
+
+- [x] Create rule tiene `hasOnly()` con whitelist (existente, sin cambios)
+- [x] CADA campo en `hasOnly()` tiene validacion de tipo (`label is string`, `createdAt == request.time`)
+- [x] Campos string tienen limite de longitud (`label.size() <= 30`)
+- [x] Update rule tiene `affectedKeys().hasOnly(['label'])`
+- [x] Campos immutables (userId, businessId) no estan en affectedKeys
+- [x] Rate limit server-side ya existe en trigger `customTags.ts` (10/business + 50/día, con delete on exceed) — NO se introduce colección nueva
+- [ ] Agregar rules test allow+delete para `customTags` (inventario tests.md lo lista como pendiente)
+
+Profile mutations (colección `users`):
+
+- [x] La regla `users` update ya valida `affectedKeys().hasOnly(['displayName','displayNameLower','avatarId'])` + `displayNameLower == displayName.lower()` (#322 R12) — no se tocan rules
+
+---
+
+## Deuda tecnica y seguridad
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| #344 (este) | resuelve | Cierra el hueco offline de custom tags + feedback profile |
+| Dead code `inviteListEditor`/`removeListEditor` sin callers (sharedLists.ts:159,167) | identificado en el audit (severidad Baja) | NO resolver acá — issue separado de tech debt para evitar scope creep |
+| #335 (`createPendingByUserStore` factory followup) | no afecta | Profile mutations NO usan el patrón pendingByUser (se gatean, no se batch-flushean) |
+
+> Antes de specs/plan correr `gh issue list --label security --state open` y `--label "tech debt"` para confirmar que no hay deuda de rules de `customTags` o `users` abierta que este feature deba considerar.
+
+### Mitigacion incorporada
+
+- Cierra el hueco de replay tipado para custom tags (antes: write buffered sin feedback).
+- Agrega el primer rules test de `customTags` (inventario tests.md lo tiene pendiente) — paso explícito en el plan.
+
+---
+
+## Robustez del codigo
+
+### Checklist de hooks async
+
+- [ ] Handlers async en `BusinessTags` (`handleSaveCustomTag`, `handleDelete`) tienen `try/catch` con `logger.error` + (vía `withOfflineSupport`) toast offline — alinear con `handleToggleTag` existente
+- [ ] No hay `setState` tras async sin guard (componente memoizado, refetch via callback)
+- [ ] `generateCustomTagId`/`createCustomTag` viven en `services/` (no en hooks)
+- [ ] Constantes nuevas (action type strings) NO son magic strings — van en `types/offline.ts` como parte de la union
+- [ ] `logger.error` NUNCA dentro de `if (import.meta.env.DEV)`
+- [ ] Archivos nuevos/modificados no superan 300 (warn) / 400 (blocker) líneas — `BusinessTags.tsx` está en 271; los wraps no deben empujarlo sobre 300, extraer handlers a hook si crece
+
+### Checklist de observabilidad
+
+- [ ] No hay Cloud Function nueva (trigger `customTags.ts` ya existe con rate limit + `trackFunctionTiming` si aplica)
+- [ ] `generateCustomTagId`/`createCustomTag` no son queries nuevas (writes) — no requieren `measureAsync`
+- [ ] `EVT_OFFLINE_ACTION_QUEUED` reusado (ya registrado); verificar que `custom_tag_*` aparezcan como `action_type` válidos en el reporte
+
+### Checklist offline
+
+- [ ] `EditDisplayNameDialog` y `AvatarPicker` deshabilitan submit cuando `isOffline`
+- [ ] Custom tags NO se deshabilitan — se encolan con toast (no-destructivo, replayable)
+- [ ] Error handlers muestran feedback en todos los environments (toast offline vía `withOfflineSupport`)
+
+### Checklist de documentacion
+
+- [ ] Nuevos action types documentados en `types/offline.ts` (no appendear al barrel; van en el archivo de dominio offline)
+- [ ] `docs/reference/patterns.md` — actualizar "Offline action types" (26 → 29 tipos) y nota de `generateCustomTagId` espejo de `generateListId`
+- [ ] `docs/reference/features.md` — nota de custom tags offline
+- [ ] `docs/reference/firestore.md` — sin colección nueva; nota de ID client-side en `customTags`
+- [ ] `docs/reference/security.md` — marcar rules test de `customTags` cubierto
+
+---
+
+## Offline
+
+### Data flows
+
+| Operacion | Tipo | Estrategia offline | Fallback UI |
+|-----------|------|-------------------|-------------|
+| Crear custom tag | write | Encolar `custom_tag_create` con tagId client-side | Toast "Guardado offline" + chip aparece (refetch al reconectar) |
+| Editar custom tag | write | Encolar `custom_tag_update` (referencia tagId) | Toast "Guardado offline" |
+| Eliminar custom tag | write | Encolar `custom_tag_delete` (referencia tagId) | Toast "Guardado offline" |
+| Cambiar displayName | write | Bloqueado offline (gate UI) | Botón disabled + tooltip "Requiere conexión" |
+| Cambiar avatar | write | Bloqueado offline (gate UI) | ButtonBase disabled |
+| Leer tags del comercio | read | Persistencia offline Firestore + readCache (existente) | StaleBanner (existente) |
+
+### Checklist offline
+
+- [ ] Reads de Firestore: usan persistencia offline (existente, sin cambio)
+- [ ] Writes custom tags: queue offline tipado vía `withOfflineSupport`
+- [ ] Writes profile: gate UI (no queue, decisión S2 opción a)
+- [ ] APIs externas: N/A (solo Firestore)
+- [ ] UI: tooltip "Requiere conexión" en profile; toast offline en custom tags
+- [ ] Datos criticos: tags ya cacheados vía readCache 3-tier
+
+### Esfuerzo offline adicional: M
+
+---
+
+## Modularizacion y % monolitico
+
+Proyecto en 30% monolitico. Este feature mantiene o reduce el acoplamiento.
+
+### Checklist modularizacion
+
+- [ ] Lógica de generación de ID y persistencia en `services/tags.ts` (no en componente)
+- [ ] `AvatarPicker` sigue props-driven puro — recibe `isOffline` por prop, NO importa `useConnectivity` (evita acoplar un componente de dominio profile a un contexto de layout)
+- [ ] `EditDisplayNameDialog` ya consume `useAuth`; importar `useConnectivity` es aceptable (es un dialog de feature, no de layout) — pero preferir prop si el consumidor ya tiene `isOffline`
+- [ ] No se agregan useState de negocio a AppShell/SideMenu
+- [ ] Handlers reales (no noop) — `onSelect`, `onSave`, `onConfirm` ya cableados
+- [ ] Ningún componente importa de `firebase/firestore` — los writes pasan por `services/tags.ts`
+- [ ] Handlers en `src/services/` (no en `src/hooks/` — no usan React hooks)
+- [ ] `BusinessTags.tsx` no supera 400 líneas (vigilar 300; extraer custom-tag handlers a hook si excede)
+- [ ] `custom_tag_*` payloads en `types/offline.ts` (archivo de dominio, no append a barrel)
+- [ ] Archivos en carpeta de dominio correcta (`business/`, `profile/`) — no `menu/`
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | = | `BusinessTags` ya usa `useConnectivity`; `AvatarPicker` recibe prop, no nuevo import cruzado |
+| Estado global | = | Sin contexto nuevo; reusa `ConnectivityContext` + cola IndexedDB existente |
+| Firebase coupling | = | Writes en `services/tags.ts`; ID generado en service, no en componente |
+| Organizacion por dominio | = | Cambios en `business/` y `profile/`, types en dominio offline |
+
+---
+
+## Accesibilidad y UI mobile
+
+### Checklist de accesibilidad
+
+- [ ] El chip "Agregar" y los chips de custom tag ya son interactivos (Chip MUI) — mantener
+- [ ] Botón Guardar disabled con feedback offline: usar el patrón establecido del proyecto `title={isOffline ? MSG_OFFLINE.requiresConnection : undefined}` directamente en el botón (igual que `FeedbackForm`, `MenuPhotoUpload`, `InviteEditorDialog`). NO envolver en `<Tooltip>`/`<span>` — el atributo `title` nativo funciona sobre botones disabled y es el patrón consistente del resto de los gates offline
+- [ ] `AvatarPicker` `ButtonBase` con `aria-disabled` cuando offline, no solo visual
+- [ ] Touch targets >= 44x44 (los IconButtons del componente ya usan `minWidth/minHeight: 44`)
+- [ ] Estados de error/offline comunicados (toast + tooltip), no solo color
+
+### Checklist de copy
+
+- [ ] Reusar `MSG_OFFLINE.requiresConnection` ("Requiere conexión", ya existe en `src/constants/messages/offline.ts`, verificado) — NO crear un string nuevo ni duplicarlo en `common.ts`
+- [ ] Toast offline reusa `OFFLINE_ENQUEUED_MSG` ("Guardado offline — se sincronizará al reconectar") de `offlineInterceptor.ts`
+- [ ] Voseo y terminología "comercios"/"etiquetas" consistentes
+- [ ] Mensajes accionables, no "Error" genérico
+
+---
+
+## Success Criteria
+
+1. Crear, editar y eliminar custom tags estando offline encola acciones tipadas (`custom_tag_create/update/delete`) que se replayan correctamente al reconectar, con toast "Guardado offline".
+2. Un custom tag creado offline tiene un ID client-side estable, de modo que editarlo o eliminarlo offline en la misma sesión referencia el mismo doc y el replay no falla.
+3. El botón Guardar de `EditDisplayNameDialog` y los avatares de `AvatarPicker` quedan deshabilitados con feedback ("Requiere conexión") cuando no hay conexión.
+4. Las Firestore rules de `customTags` y `users` no cambian; se agrega un rules test allow+deny para `customTags` (cierra el checkbox pendiente en tests.md).
+5. Cobertura >= 80% del código nuevo; branches global no baja de 81.86%; el `Record<OfflineActionType, OfflineHandler>` garantiza exhaustividad de los 3 handlers nuevos en compile-time.
+
+---
+
+## Validacion Funcional
+
+**Analista**: Sofia (checklist funcional aplicado por prd-writer; el harness de este entorno no expone spawn de subagente, por lo que se ejecutó el protocolo de Sofia — incluyendo verificación con `gh`/`grep`/`find` antes de afirmar ausencia — de forma directa)
+**Fecha**: 2026-06-10
+**Estado**: VALIDADO CON OBSERVACIONES
+
+### Hallazgos cerrados en esta iteracion
+
+- IMPORTANTE: "tooltip de botón disabled requería `<span>` wrapper" → corregido: el proyecto usa el atributo nativo `title={isOffline ? MSG_OFFLINE.requiresConnection : undefined}` directamente sobre el botón (verificado en `FeedbackForm`, `MenuPhotoUpload`, `InviteEditorDialog`). Se eliminó la indicación errónea de wrapper.
+- IMPORTANTE: "string del tooltip a centralizar en `common.ts` si no existe" → corregido: `MSG_OFFLINE.requiresConnection` ya existe en `src/constants/messages/offline.ts` (verificado). Se reusa, no se duplica.
+- IMPORTANTE: "consumidor que pasa `isOffline` a `AvatarPicker` sin nombrar" → corregido: el consumidor es `ProfileScreen.tsx`, que ya tiene `useConnectivity()`/`isOffline` en scope (verificado).
+- IMPORTANTE: "ordering del replay create→update/delete del mismo tag offline no especificado" → resuelto en S1: FIFO garantiza el orden; delete de tag cuyo create falló es no-op tolerable; caso agregado a Tests.
+- OBSERVACION: "`EVT_OFFLINE_ACTION_QUEUED` ya registrado en barrel; los 3 `action_type` nuevos no requieren registro adicional" → confirmado (verificado en `analyticsEvents/offline.ts` + barrel snapshot). El PRD ya lo trataba en S3.
+
+### Observaciones abiertas para el implementador
+
+- Verificar al armar el plan que `BusinessTags.tsx` (hoy 271 líneas) no supere 300 al agregar los wraps; si lo hace, extraer los handlers de custom-tag a un hook dedicado en `src/hooks/` (riesgo bajo).
+- El rate limit server-side de `customTags` (10/business + 50/día, trigger existente) aplica al drenar una cola offline grande: el replay puede toparse con el límite y el doc encolado se borraría server-side. Es comportamiento esperado (defensa anti-spam), pero el toast de "sincronizado" no distingue ese caso — aceptable para este tech debt, mencionar en plan por si se quiere telemetría futura.
+- Sin overlap con issues abiertos (#341-#349 son otros tech debts de dominios distintos; el dead code `inviteListEditor`/`removeListEditor` quedó explícitamente fuera de scope).
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** El trigger customTags hace snap.ref.delete() al exceder rate limit: definir comportamiento esperado en replay (toast dice 'guardado' pero el chip desaparece). Confirmar en rules test que delete de doc inexistente resuelve limpio. Path real: src/context/ (singular).

--- a/docs/feat/infra/offline-custom-tags-profile-mutations/specs.md
+++ b/docs/feat/infra/offline-custom-tags-profile-mutations/specs.md
@@ -1,0 +1,401 @@
+# Specs: Offline support para custom tags y profile mutations
+
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-10
+**Issue:** #344
+
+---
+
+## Modelo de datos
+
+No se introducen colecciones nuevas. No se modifican campos. El cambio es de **mecanismo de escritura** (de `addDoc` con ID auto-generado a `setDoc` con ID client-side opcional) y de **encolado offline tipado**.
+
+### Colección afectada: `customTags` (sin cambios de schema)
+
+```typescript
+// src/types/business.ts — SIN CAMBIOS
+interface CustomTag {
+  id: string;
+  userId: string;
+  businessId: string;
+  label: string;       // 1-30
+  createdAt: Date;
+}
+```
+
+El doc ID pasa de auto-generado por Firestore (`addDoc`) a uno generado client-side (`generateCustomTagId()` → `doc(collection(db, COLLECTIONS.CUSTOM_TAGS)).id`). Firestore NO valida el doc ID en las rules; el ID arbitrario es seguro (ver Rules impact). El campo `id` del tipo `CustomTag` ya se hidrata desde el doc snapshot (`customTagConverter`), no se persiste como field.
+
+### Nuevos tipos en `src/types/offline.ts`
+
+```typescript
+// 3 nuevas variantes de la union OfflineActionType
+| 'custom_tag_create'
+| 'custom_tag_update'
+| 'custom_tag_delete'
+
+// Payloads (agregados a la union OfflineActionPayload)
+export interface CustomTagCreatePayload {
+  label: string;
+}
+
+export interface CustomTagUpdatePayload {
+  label: string;
+}
+
+export interface CustomTagDeletePayload {
+  _type: 'custom_tag_delete';
+}
+```
+
+**Decisión sobre dónde vive el `tagId`** (alineado con cómo `list_create` usa `listId`): el `tagId` client-side se transporta en el campo genérico existente `OfflineAction.referenceId` para los **tres** tipos (`custom_tag_create/update/delete`). No se reutiliza `listId` (es de dominio listas) ni se agrega un campo nuevo a `OfflineAction`. Esto mantiene `CustomTagCreatePayload` minimal (solo `label`) y deja que create/update/delete compartan la misma referencia de doc. `businessId` sigue viajando en `OfflineAction.businessId` (requerido por el shape de `enqueue`). Para `custom_tag_update`/`delete`, `businessId` no es estrictamente necesario para el replay pero se conserva por backward-compat del meta (se pasa el `businessId` del scope).
+
+### Índices
+
+Ninguno nuevo.
+
+## Firestore Rules
+
+Sin cambios en `firestore.rules`. Las rules de `customTags` (L251-270) ya cubren el caso: el cambio `addDoc` → `setDoc` con ID client-side no agrega campos ni altera el whitelist. Solo se agrega un **rules test** (no se modifican rules).
+
+### Rules impact analysis
+
+| Query (service file) | Collection | Auth context | Rule que la permite | Cambio? |
+|---------------------|------------|-------------|--------------------|---------|
+| `createCustomTag(userId, businessId, label, tagId?)` → `setDoc(doc(..., tagId))` | customTags | Owner (`userId == auth.uid`) | `allow create: keys().hasOnly([...]) && userId == auth.uid && isValidBusinessId && label 1-30 && createdAt == request.time` (L253-260) | No |
+| `updateCustomTag(tagId, label)` → `updateDoc` | customTags | Owner del doc | `allow update: resource.data.userId == auth.uid && affectedKeys().hasOnly(['label']) && label 1-30` (L261-267) | No |
+| `deleteCustomTag(tagId)` → `deleteDoc` | customTags | Owner del doc | `allow delete: resource.data.userId == auth.uid` (L268-269) | No |
+| `updateUserDisplayName(uid, name)` (existente, ahora gateado en UI) | users | Owner | `allow update` con `affectedKeys().hasOnly(['displayName','displayNameLower','avatarId'])` (#322 R12) | No |
+| `updateUserAvatar(uid, id)` (existente, ahora gateado en UI) | users | Owner | idem | No |
+
+**Vector evaluado — overwrite via `setDoc` con ID arbitrario:** un atacante que adivine el docId de otro usuario e intente `setDoc` no puede, porque el create rule exige `userId == request.auth.uid` (no puede escribir un doc con `userId` ajeno) y el update/delete exige `resource.data.userId == request.auth.uid` (ownership del doc existente). El ID arbitrario NO abre vector — los campos son lo validado.
+
+### Field whitelist check
+
+No se agregan ni modifican campos. El `setDoc` envía **exactamente** los mismos 4 campos que el `addDoc` actual (`userId`, `businessId`, `label`, `createdAt`), que ya están en `hasOnly(['userId','businessId','label','createdAt'])`.
+
+| Collection | New/modified field | In create `hasOnly()`? | In update `affectedKeys().hasOnly()`? | Rule change? |
+|-----------|-------------------|----------------------|--------------------------------------|--------------|
+| customTags | (ninguno — `setDoc` reusa los 4 campos del `addDoc` actual) | SI (sin cambios) | N/A | No |
+
+**Guardrail de implementación:** `createCustomTag` con `tagId` debe enviar el `label` ya con `trim()` aplicado y ≤ 30 (la validación actual del service ya lanza si no cumple — conservarla). `setDoc` no debe filtrar campos extra (no agregar `tagId` como field del doc; el `tagId` es solo el doc ID).
+
+## Cloud Functions
+
+Ninguna nueva. El trigger `functions/src/triggers/customTags.ts` (`onCustomTagCreated` / `onCustomTagDeleted`) ya existe con rate limit (10/business + 50/día) + moderación. **No se toca.**
+
+### Comportamiento del rate limit en replay de cola offline (tech debt aceptado — observación de Sofia)
+
+`onCustomTagCreated` ejecuta `await snap.ref.delete()` cuando se excede 10/business, 50/día, o el label es flaggeado por moderación. En el flujo offline esto produce un escenario silencioso:
+
+1. Usuario crea N custom tags offline → cada uno muestra toast `OFFLINE_ENQUEUED_MSG` ("Guardado offline — se sincronizará al reconectar") y aparece el chip (refetch local optimista no aplica acá; el chip aparece tras `onTagsChange()` al reconectar).
+2. Al reconectar, `syncEngine` drena la cola FIFO. Cada `custom_tag_create` hace `setDoc` exitoso (la rule pasa) → `syncEngine` lo marca `synced` y lo remueve de la cola.
+3. **Pero** el trigger server-side, al exceder el límite, borra el doc recién creado (`snap.ref.delete()`). El cliente ya consideró la acción "sincronizada".
+
+**Decisión de producto (alineada con Sofia): tech debt aceptado, sin enforcement adicional en este issue.**
+
+- El `setDoc` desde el cliente **resuelve OK** (la rule permite el create; el límite NO está en rules sino en el trigger post-write). Por lo tanto `syncEngine.executeAction` NO falla → no reintenta → no llega a `OFFLINE_MAX_RETRIES`. Correcto: el cliente no debe reintentar un write que Firestore aceptó.
+- La pérdida del tag (borrado server-side por el trigger) es el **comportamiento esperado anti-spam**. Un replay de cola grande que excede el límite pierde los tags por encima del cap — igual que ocurriría online creando rápido. El toast "Guardado offline" no distingue este caso (no tiene visibilidad del trigger server-side).
+- **Mismo comportamiento en multi-device**: el mismo comercio editado en 2 devices offline genera 2 `custom_tag_create` con `tagId` distintos (cada device genera su propio ID); al drenar ambas colas, el segundo que cruce el cap de 10/business será borrado por el trigger. Esperado.
+- **No se mitiga en este issue** (fuera de scope explícito: no se tocan rules ni el trigger). Se documenta como tech debt conocido.
+
+**Telemetría futura (NO en este issue):** para cerrar el gap de feedback, una mejora futura sería que `onCustomTagCreated` escriba un doc de notificación / abuseLog ya existente (lo hace: `logAbuse` con `type: 'rate_limit'`) y que el cliente lo lea para mostrar un toast diferenciado ("Algunas etiquetas no se guardaron: límite alcanzado"). Queda registrado como followup, NO se implementa acá.
+
+## Seed Data
+
+No aplica. No se crean colecciones nuevas ni campos requeridos nuevos. `customTags` ya existe en los seeds actuales; el cambio de `addDoc` → `setDoc` no altera el shape sembrado.
+
+## Componentes
+
+### `BusinessTags.tsx` (modificado)
+
+Componente ya existente (271 líneas). Ya consume `useConnectivity()` (`isOffline`), `useToast()`, `useBusinessScope()` (`businessId`, `businessName`), `useAuth()` (`user`). Ya importa `withOfflineSupport`. Solo se modifican `handleSaveCustomTag` y `handleDelete` para wrappear con `withOfflineSupport`, y se genera el `tagId` client-side antes de encolar.
+
+- **Props:** sin cambios (`seedTags`, `userTags`, `customTags`, `isLoading`, `onTagsChange`).
+- **Comportamiento nuevo:**
+  - `handleSaveCustomTag` (create): genera `tagId = generateCustomTagId()` antes de wrappear; `withOfflineSupport(isOffline, 'custom_tag_create', { userId, businessId, businessName, referenceId: tagId }, { label }, () => createCustomTag(user.uid, businessId, label, tagId), toast)`.
+  - `handleSaveCustomTag` (update): `withOfflineSupport(isOffline, 'custom_tag_update', { userId, businessId, businessName, referenceId: editingTag.id }, { label }, () => updateCustomTag(editingTag.id, label), toast)`.
+  - `handleDelete`: `withOfflineSupport(isOffline, 'custom_tag_delete', { userId, businessId, businessName, referenceId: menuTag.id }, { _type: 'custom_tag_delete' }, () => deleteCustomTag(menuTag.id), toast)`.
+  - Custom tags NO se deshabilitan offline (son no-destructivos y replayables) — se encolan con toast.
+  - Cada handler envuelve la llamada en `try/catch` con `logger.error` (alinear con `handleToggleTag` L84-105).
+- **Tamaño:** los wraps agregan ~8-12 líneas netas. El componente pasaría de 271 a ~283. Bajo el warn de 300 — **no requiere extracción a hook** (verificado en file-size estimation). Si en implementación supera 300, extraer los 3 custom-tag handlers a `src/hooks/useCustomTagActions.ts` (riesgo bajo).
+
+### `EditDisplayNameDialog.tsx` (modificado)
+
+- **Props:** sin cambios (`open`, `onClose`).
+- **Comportamiento nuevo:** importar `useConnectivity` (es un dialog de feature, no de layout — aceptable per modularización). Agregar `|| isOffline` al `disabled` del botón Guardar y `title={isOffline ? MSG_OFFLINE.requiresConnection : undefined}` directamente sobre el `<Button>` (atributo nativo, sin wrapper `<Tooltip>`/`<span>` — patrón consistente con `FeedbackForm`, `MenuPhotoUpload`, `InviteEditorDialog`, confirmado por Sofia).
+- `handleSave` retorna early si `isOffline` (defense-in-depth además del `disabled`).
+
+### `AvatarPicker.tsx` (modificado)
+
+- **Props nuevas:** `isOffline: boolean` (props-driven puro — NO importa `useConnectivity`, lo recibe de `ProfileScreen`).
+- **Comportamiento nuevo:** cada `<ButtonBase>` de avatar recibe `disabled={isOffline}` + `aria-disabled={isOffline}` (no solo visual). `onSelect`/`onClose` no se disparan offline (el `ButtonBase` disabled no emite `onClick`).
+- MUI `ButtonBase` con `disabled` ya aplica opacidad/cursor; agregar `aria-disabled` explícito por a11y.
+
+### `ProfileScreen.tsx` (modificado — wiring)
+
+- Ya tiene `useConnectivity()` / `isOffline` en scope (L57, verificado). Pasar `isOffline={isOffline}` a `<AvatarPicker>` (L133-138). Handler real ya existente: `onSelect={(a) => setAvatarId(a.id)}` — no se toca.
+
+### `AuthContext.tsx` (modificado — guard defense-in-depth)
+
+- `setDisplayName` (L126-132) y `setAvatarId` (L134-145): agregar guard early-return si `navigator.onLine === false` (defense-in-depth a nivel context, NO encola — decisión S2 opción a). Esto cubre el caso de un caller que invoque la acción sin pasar por la UI gateada. NO se importa `useConnectivity` (es un hook de React, no usable dentro de los callbacks del context que ya existen); se lee `navigator.onLine` directamente, mismo criterio que `gateServiceWrite`/`getCountOfflineSafe`. El guard es silencioso (no toast) porque la UI ya comunica vía `disabled`+tooltip.
+
+### Mutable prop audit
+
+| Component | Prop | Editable fields | Local state needed? | Parent callback |
+|-----------|------|----------------|-------------------|-----------------|
+| BusinessTags | customTags | label (create/update/delete) | No — usa `dialogValue` local + `onTagsChange()` refetch (patrón existente, sin cambio) | `onTagsChange()` |
+| AvatarPicker | selectedId, isOffline | ninguno (es selector, no editor de la prop) | No | `onSelect(avatar)` |
+| EditDisplayNameDialog | (lee `displayName` de `useAuth`) | nameValue | Ya usa `useState(displayName)` local | `setDisplayName` (via context) |
+
+## Textos de usuario
+
+| Texto | Donde se usa | Notas |
+|-------|-------------|-------|
+| `OFFLINE_ENQUEUED_MSG` = "Guardado offline — se sincronizará al reconectar" | toast en `BusinessTags` (create/update/delete offline) | Reusado de `offlineInterceptor.ts`, NO se crea nuevo. Tilde en "sincronizará". |
+| `MSG_OFFLINE.requiresConnection` = "Requiere conexión" | atributo `title` del botón Guardar en `EditDisplayNameDialog` | Reusado de `src/constants/messages/offline.ts`, NO se duplica. Tilde en "conexión". |
+
+No se crean textos nuevos.
+
+## Hooks
+
+Ninguno nuevo (a menos que `BusinessTags.tsx` supere 300 líneas en implementación — ver Componentes). `useConnectivity` (de `src/context/ConnectivityContext.tsx`) se reusa.
+
+## Servicios
+
+### `src/services/tags.ts` (modificado)
+
+```typescript
+/** Generate a Firestore-compatible custom tag ID client-side (no network). Mirror of generateListId(). */
+export function generateCustomTagId(): string {
+  return doc(collection(db, COLLECTIONS.CUSTOM_TAGS)).id;
+}
+
+export async function createCustomTag(
+  userId: string,
+  businessId: string,
+  label: string,
+  tagId?: string,          // NEW: opcional, ID client-side (offline-first)
+): Promise<void> {
+  const trimmed = label.trim();
+  if (!trimmed || trimmed.length > MAX_CUSTOM_TAG_LENGTH) {
+    throw new Error('Custom tag label must be 1-30 characters');
+  }
+  const docData = { userId, businessId, label: trimmed, createdAt: serverTimestamp() };
+  if (tagId) {
+    await setDoc(doc(db, COLLECTIONS.CUSTOM_TAGS, tagId), docData);  // client-side ID
+  } else {
+    await addDoc(collection(db, COLLECTIONS.CUSTOM_TAGS), docData);  // fallback online
+  }
+  trackEvent('custom_tag_create', { business_id: businessId });
+}
+```
+
+- **Nota de hardening:** el `addDoc` actual envía `label` SIN trim (bug menor: L62-67 usa `label` crudo aunque valida `trimmed`). La migración corrige esto enviando `label: trimmed` en ambos paths (cierra el checkbox de seguridad del PRD "`setDoc` no debe enviar `label` sin trim").
+- `updateCustomTag(tagId, label)` y `deleteCustomTag(tagId)`: sin cambios de firma (ya aceptan `tagId`).
+- `setDoc` ya está importado en `tags.ts`. No requiere import nuevo.
+
+### `src/services/registerOfflineHandlers.ts` (modificado)
+
+Agregar 3 entradas al `Record<OfflineActionType, OfflineHandler>` (la exhaustividad compile-time del `Record` fuerza su presencia; agregar el tipo a la union sin handler rompe el build):
+
+```typescript
+custom_tag_create: async ({ userId, businessId, referenceId, payload }: OfflineAction) => {
+  const { label } = payload as CustomTagCreatePayload;
+  const { createCustomTag } = await import('./tags');
+  await createCustomTag(userId, businessId, label, referenceId);  // referenceId = tagId client-side
+},
+custom_tag_update: async ({ referenceId, payload }: OfflineAction) => {
+  const { label } = payload as CustomTagUpdatePayload;
+  const { updateCustomTag } = await import('./tags');
+  if (!referenceId) throw new Error('custom_tag_update requires referenceId (tagId)');
+  await updateCustomTag(referenceId, label);
+},
+custom_tag_delete: async ({ referenceId }: OfflineAction) => {
+  const { deleteCustomTag } = await import('./tags');
+  if (!referenceId) throw new Error('custom_tag_delete requires referenceId (tagId)');
+  await deleteCustomTag(referenceId);
+},
+```
+
+Agregar los imports de tipo `CustomTagCreatePayload`, `CustomTagUpdatePayload` (el delete no necesita payload tipado, usa solo `referenceId`).
+
+## Integracion
+
+- `BusinessTags` → ya cableado a `withOfflineSupport` + `useConnectivity` + `useToast`; solo se extienden 2 handlers.
+- `ProfileScreen` → pasa `isOffline` a `AvatarPicker` (1 prop nueva).
+- `EditDisplayNameDialog` → importa `useConnectivity`.
+- `AuthContext` → guard `navigator.onLine` en 2 callbacks.
+- `registerOfflineHandlers` → 3 handlers nuevos en el Record.
+- `types/offline.ts` → 3 variantes + 3 payloads (en el archivo de dominio, NO en barrel).
+
+### Preventive checklist
+
+- [x] **Service layer**: `BusinessTags` NO importa `firebase/firestore`; los writes pasan por `services/tags.ts`. `AuthContext` guard usa `navigator.onLine` (no Firebase). OK.
+- [x] **Duplicated constants**: `OFFLINE_ENQUEUED_MSG` y `MSG_OFFLINE.requiresConnection` se reusan, no se duplican. Action type strings van en la union de `types/offline.ts` (no magic strings). OK.
+- [x] **Context-first data**: `isOffline` viene de `useConnectivity`; `user`/`displayName`/`avatarId` de `useAuth`. Sin `getDoc` extra. OK.
+- [x] **Silent .catch**: handlers usan `logger.error`. No `.catch(() => {})`. OK.
+- [x] **Stale props**: BusinessTags usa `onTagsChange()` refetch (fuente de verdad en parent); AvatarPicker/EditDisplayNameDialog ya manejan local state. OK.
+
+## Tests
+
+| Archivo test | Que testear | Tipo |
+|-------------|-------------|------|
+| `src/services/__tests__/tags.test.ts` (existente, extender) | `generateCustomTagId()` devuelve ID no vacío; `createCustomTag` con `tagId` usa `setDoc(doc(..., tagId))`; sin `tagId` usa `addDoc`; ambos paths envían `label` con trim; validación 1-30 sigue lanzando | Service |
+| `src/services/__tests__/registerOfflineHandlers.test.ts` (existente, extender) | los 3 `custom_tag_*` invocan el service correcto con payload deserializado; `custom_tag_update`/`delete` lanzan si falta `referenceId`; `custom_tag_create` pasa `referenceId` como `tagId` a `createCustomTag` | Registry |
+| `src/services/__tests__/offlineInterceptor.test.ts` (existente, extender) | `withOfflineSupport` encola `custom_tag_*` con `referenceId` (tagId) en meta y dispara `EVT_OFFLINE_ACTION_QUEUED` con `action_type` correcto | Service |
+| `src/components/business/__tests__/BusinessTags.test.tsx` (nuevo o extender) | create/update/delete online ejecutan el service; offline encolan + toast `OFFLINE_ENQUEUED_MSG`; el `tagId` generado en create es el que se encola (estable entre create y delete offline) | Componente |
+| `src/services/__tests__/syncEngine.test.ts` (existente, extender) | crear+editar mismo tag offline (mismo `referenceId`) → al drenar FIFO, ambos `executeAction` aplican en orden y el `updateCustomTag` recibe el `tagId` del create; **delete de tag cuyo create falló permanentemente: `deleteCustomTag` de doc inexistente resuelve limpio (Firestore `deleteDoc` no lanza) → `executeAction` NO falla → NO reintenta → NO llega a `OFFLINE_MAX_RETRIES`** (observación de Sofia) | Replay ordering |
+| `src/components/profile/__tests__/EditDisplayNameDialog.test.tsx` (nuevo) | botón Guardar `disabled` cuando `isOffline`; atributo `title` == "Requiere conexión" cuando offline, `undefined` cuando online; `handleSave` no llama `setDisplayName` offline | Componente |
+| `src/components/profile/__tests__/AvatarPicker.test.tsx` (nuevo) | `ButtonBase` con `disabled`+`aria-disabled` cuando `isOffline=true`; `onSelect` NO se dispara offline; se dispara online | Componente |
+| `src/context/AuthContext.test.tsx` (existente, extender) | `setDisplayName`/`setAvatarId` no llaman al service cuando `navigator.onLine === false` (guard defense-in-depth) | Context |
+| `tests/rules/customTags.rules.test.ts` (nuevo) | ALLOW create con ID client-side + label válido + owner; DENY label > 30; DENY campo extra (fuera del whitelist); DENY update fuera de `label`; DENY delete de otro owner; **delete de doc inexistente resuelve sin error (rule permite, no hay `resource.data` → la rule `resource.data.userId == auth.uid` evalúa sobre doc ausente: confirmar comportamiento esperado)** (observación de Sofia) | Rules |
+
+**Mock strategy:**
+
+- Firestore: mock SDK (`setDoc`, `addDoc`, `deleteDoc`, `updateDoc`, `doc`, `collection`) en service tests.
+- Analytics: mock `trackEvent`.
+- Offline queue: en `BusinessTags.test.tsx`, mock `enqueue`/`offlineQueue` y verificar el payload encolado. Para online path, mock `services/tags`.
+- `useConnectivity`/`useAuth`/`useToast`/`useBusinessScope`: mock de los contextos (patrón existente de tests de componentes).
+- Rules: `@firebase/rules-unit-testing` v5 contra emulador, siguiendo `tests/rules/users.rules.test.ts`.
+
+**Nota sobre el rules test de delete de doc inexistente:** confirmar que `deleteDoc` de un doc que no existe (1) en el emulador resuelve sin lanzar — esto valida el caso "delete de un create que falló permanentemente" del flujo offline (S1). Si la rule evalúa `resource.data.userId` sobre un doc ausente y deniega, el test debe documentar que en producción el `deleteDoc` del replay resolvería igualmente sin error en el cliente (Firestore SDK no lanza en delete-not-found). El objetivo es: el replay NO debe quedar reintentando hasta `OFFLINE_MAX_RETRIES`.
+
+## Analytics
+
+- Reusa `EVT_OFFLINE_ACTION_QUEUED` (disparado dentro de `withOfflineSupport` con `action_type` = `custom_tag_create/update/delete`). NO se crea evento nuevo.
+- `trackEvent('custom_tag_create', { business_id })` ya existe en el service (se conserva; se dispara en el replay/online del create).
+- Verificar que `custom_tag_create/update/delete` aparezcan como `action_type` válidos en el reporte de tipos encolados (sin registro adicional — `action_type` es un parámetro libre, no enum registrado).
+
+---
+
+## Offline
+
+### Cache strategy
+
+| Dato | Estrategia | TTL | Storage |
+|------|-----------|-----|---------|
+| Tags del comercio (read) | Persistencia offline Firestore + readCache 3-tier (existente) | 5 min (memory) / LRU 20 (IndexedDB) | IndexedDB `modo-mapa-read-cache` |
+| Custom tag writes (create/update/delete) | Cola tipada `withOfflineSupport` → IndexedDB | hasta reconexión + `OFFLINE_MAX_RETRIES` | IndexedDB `offlineQueue` |
+| Profile writes (displayName/avatar) | NO se cachea — gate UI (no se encola) | N/A | N/A |
+
+### Writes offline
+
+| Operacion | Mecanismo | Conflict resolution |
+|-----------|-----------|-------------------|
+| Crear custom tag | Encolar `custom_tag_create` con `referenceId` = tagId client-side | FIFO: el create se replaya antes que cualquier update/delete del mismo `tagId` (ambos comparten el ID); el doc existe cuando llega el update/delete. **Rate limit server-side puede borrar el doc tras el create (tech debt aceptado, ver Cloud Functions).** |
+| Editar custom tag | Encolar `custom_tag_update` (referenceId = tagId) | El `updateCustomTag` apunta al mismo doc creado por el create previo (FIFO garantiza orden). |
+| Eliminar custom tag | Encolar `custom_tag_delete` (referenceId = tagId) | Si el create del mismo tag falló permanentemente (no-op tolerable): `deleteDoc` de doc inexistente resuelve limpio → no reintenta. |
+| Cambiar displayName | Bloqueado offline (gate UI, NO se encola) | N/A — botón disabled |
+| Cambiar avatar | Bloqueado offline (gate UI, NO se encola) | N/A — ButtonBase disabled |
+
+**Ordering del replay (create → update/delete del mismo tag):** `syncEngine.getPending()` ordena FIFO por `createdAt`. Un `custom_tag_create` encolado antes de un `custom_tag_update`/`custom_tag_delete` del mismo `referenceId` se replaya primero. A diferencia de `comment_edit`/`comment_delete` (#340 W6, que SÍ necesita guard de "edit no confirmado"), aquí NO se necesita guard porque create y update/delete comparten el `tagId` client-side y FIFO garantiza la secuencia. El doc ya existe cuando llega el update/delete.
+
+### Fallback UI
+
+- Custom tags: toast `OFFLINE_ENQUEUED_MSG` (no se bloquea; el chip aparece tras refetch al reconectar).
+- Profile: botón Guardar / avatares deshabilitados + tooltip "Requiere conexión".
+- Reads: `StaleBanner` existente (sin cambios).
+
+---
+
+## Accesibilidad y UI mobile
+
+| Componente | Elemento | aria-label | Min touch target | Error state |
+|-----------|----------|------------|-----------------|-------------|
+| BusinessTags | Chip "Agregar" / chips custom (existentes) | (Chip MUI interactivo, sin cambio) | ya ≥ 44 (IconButtons) | toast offline |
+| AvatarPicker | ButtonBase de avatar | `avatar.label` (existente) + `aria-disabled` cuando offline | width 100% grid cell (≥ 44) | disabled visual + aria |
+| EditDisplayNameDialog | Botón Guardar | (texto "Guardar") + `title` offline | botón MUI estándar | disabled + title nativo |
+
+### Reglas aplicadas
+
+- `AvatarPicker` ButtonBase: `disabled` + `aria-disabled` (no solo visual) cuando offline.
+- Botón Guardar disabled con `title={isOffline ? MSG_OFFLINE.requiresConnection : undefined}` nativo (NO `<Tooltip>`/`<span>` wrapper — patrón del proyecto).
+- Custom tags NO se deshabilitan (encolables) — feedback vía toast.
+- Touch targets: los IconButtons ya usan `minWidth/minHeight: 44`. Sin nuevos elementos < 44.
+
+## Textos y copy
+
+| Texto | Donde | Regla aplicada |
+|-------|-------|----------------|
+| "Guardado offline — se sincronizará al reconectar" (`OFFLINE_ENQUEUED_MSG`) | toast custom tags | reusado, tilde en "sincronizará" |
+| "Requiere conexión" (`MSG_OFFLINE.requiresConnection`) | title botón Guardar | reusado, tilde en "conexión" |
+
+### Reglas de copy
+
+- No se crean textos nuevos. Ambos strings se reusan de constantes existentes (cumple "strings reutilizables en `src/constants/messages/`").
+- Terminología: "etiquetas"/"comercios" en cualquier copy auxiliar.
+
+---
+
+## Decisiones tecnicas
+
+1. **`tagId` en `referenceId` (no en payload ni campo nuevo):** se reusa el campo genérico `OfflineAction.referenceId` (ya existente para `recommendation_read`) para los 3 tipos custom tag. Alternativa rechazada: agregar `tagId` al payload de cada uno — más verboso y desalineado con cómo `list_*` usa el campo dedicado `listId`. Se prefiere `referenceId` (genérico) sobre agregar un campo `tagId` a `OfflineAction` para no inflar el shape global por un solo dominio.
+
+2. **Profile mutations: gate UI, sin OfflineActionType (opción a):** el issue pide explícitamente deshabilitar + tooltip. `users` no tiene handler de replay y las mutaciones de perfil tocan campos con validación bidireccional (`displayNameLower`). Encolarlas (opción b) agregaría 2 action types + handlers + riesgo de conflicto con `displayNameLower` server-side por marginal beneficio. Rechazada.
+
+3. **Guard `navigator.onLine` en AuthContext (defense-in-depth):** además del gate UI, los callbacks `setDisplayName`/`setAvatarId` retornan early si offline. Cubre callers que no pasen por la UI gateada. Se lee `navigator.onLine` directo (no `useConnectivity`, que es un hook React no usable dentro de callbacks ya definidos), mismo criterio que `gateServiceWrite`.
+
+4. **Corrección del trim en `createCustomTag`:** la migración aprovecha para enviar `label: trimmed` (hoy el `addDoc` manda `label` crudo). Cierra checkbox de seguridad del PRD sin scope creep.
+
+5. **Rate limit server-side en replay = tech debt aceptado:** ver sección Cloud Functions. No se mitiga (fuera de scope: no se tocan rules/trigger).
+
+---
+
+## Hardening de seguridad
+
+### Firestore rules requeridas
+
+Sin cambios. Las rules de `customTags` (L251-270) y `users` (#322 R12) ya cubren todos los invariantes. Solo se agrega un rules test (`tests/rules/customTags.rules.test.ts`).
+
+### Rate limiting
+
+| Coleccion | Limite | Implementacion |
+|-----------|--------|---------------|
+| customTags | 10/business + 50/día por usuario | `checkRateLimit` en `onCustomTagCreated` (trigger existente, sin cambio); `snap.ref.delete()` on exceed (enforcement real, no log-only) |
+| users (profile) | N/A (gate UI, no nueva superficie de escritura) | — |
+
+### Vectores de ataque mitigados
+
+| Ataque | Mitigacion | Archivo |
+|--------|-----------|---------|
+| Overwrite de doc ajeno via `setDoc` con ID arbitrario | create rule exige `userId == auth.uid`; update/delete exige `resource.data.userId == auth.uid` | `firestore.rules` L253-269 |
+| Replay de cola corrupta apuntando a doc ajeno | update/delete validan ownership server-side; el replay NO bypasea rules | `firestore.rules` L261-269 |
+| Spam de tags offline (encolar N → drenar) | rate limit server-side 10/business + 50/día con delete on exceed (existente) | `functions/src/triggers/customTags.ts` |
+| Field injection via `setDoc` | `hasOnly(['userId','businessId','label','createdAt'])` + `label` trim ≤ 30 en service | `firestore.rules` L254 + `services/tags.ts` |
+| Profile write offline sin awareness | gate UI (disabled + tooltip) + guard `navigator.onLine` en context | `EditDisplayNameDialog`, `AvatarPicker`, `AuthContext` |
+
+---
+
+## Deuda tecnica: mitigacion incorporada
+
+`gh issue list --label security --state open` → `[]` (sin issues abiertos).
+`gh issue list --label "tech debt" --state open` → `[]` (sin issues abiertos).
+
+| Issue | Que se resuelve | Paso del plan |
+|-------|----------------|---------------|
+| (interno, no trackeado) `createCustomTag` enviaba `label` sin trim | enviar `label: trimmed` en ambos paths | Fase 1, paso 2 |
+| Inventario tests.md: `customTags` rules test pendiente | agregar `tests/rules/customTags.rules.test.ts` (allow+deny) | Fase 4 |
+| Hueco offline de custom tags (audit /health-check) | encolar tipado vía `withOfflineSupport` | Fases 1-3 |
+
+No se agrava deuda existente. Dead code `inviteListEditor`/`removeListEditor` queda explícitamente fuera de scope (issue separado).
+
+---
+
+## Validacion Tecnica
+
+**Arquitecto**: Diego
+**Fecha**: 2026-06-10
+**Estado**: VALIDADO
+
+**Hallazgos**: Sin hallazgos. Listo para generar el plan.
+
+### Verificaciones realizadas (Ciclo 1)
+
+- Data model coherente con el codebase: las 3 variantes `custom_tag_*` y sus payloads siguen el patron `_type`-marker establecido (`RatingDeletePayload`, `ListDeletePayload`); `CustomTagCreatePayload { label }` minimal, `tagId` en el campo generico existente `OfflineAction.referenceId` (verificado en `types/offline.ts` L44). Sin inflar el shape global.
+- `generateCustomTagId()` es espejo exacto de `generateListId()` (verificado en `sharedLists.ts` L30-32); `createCustomTag(tagId?)` replica el branch `setDoc(doc(...,id))` vs `addDoc(...)` de `createList(listId?)` (verificado).
+- `withOfflineSupport` ya soporta `referenceId` en `actionMeta` y lo propaga a `enqueue` (verificado en `offlineInterceptor.ts` L8-46). El wrap propuesto no requiere cambios en el interceptor.
+- Exhaustividad compile-time: `Record<OfflineActionType, OfflineHandler>` en `registerOfflineHandlers.ts` L36 fuerza los 3 handlers nuevos (verificado).
+- Edge cases cubiertos: replay FIFO create→update/delete del mismo `tagId`; comportamiento del `snap.ref.delete()` del trigger en replay (incl. multi-device); delete de tag cuyo create fallo = no-op tolerable. Todos con el escenario explicito que pidio Sofia.
+- Rules sin cambio (correctamente justificado); el ID client-side NO abre vector (el whitelist + ownership server-side bloquean overwrite). Rules test allow+deny agregado con caso de delete de doc inexistente.
+- Path real `src/context/` (singular) verificado y usado consistentemente en specs.
+- Modularizacion neutral: ningun componente importa `firebase/firestore`; writes en `services/tags.ts`; `AvatarPicker` sigue props-driven puro.

--- a/docs/feat/security/deps-vulnerables-secrets-env/plan.md
+++ b/docs/feat/security/deps-vulnerables-secrets-env/plan.md
@@ -1,0 +1,133 @@
+# Plan de implementación: Deps vulnerables + secrets en .env + isValidStorageUrl (#342)
+
+> Basado en `specs.md` (VALIDADO CON OBSERVACIONES por Diego, 2026-06-10) y `prd.md` (VALIDADO CON OBSERVACIONES por Sofia).
+
+## Estrategia y staging de riesgo
+
+| Fase | Sub-tarea | Riesgo | Esfuerzo | Owner | Notas |
+|------|-----------|--------|----------|-------|-------|
+| F1 — Bump react-router-dom | S1 | Bajo | S | luna (frontend) | API declarativa, sin breaking |
+| F2 — Bump firebase-admin | S2 | Medio | M | nico (backend) | functions runtime; correr tests; redefinir invariante audit |
+| F3 — Secrets a Secret Manager | S3 | Alto | M | nico (backend) | requiere deploy + smoke a instancia compartida prod/staging |
+| F4 — Hardening isValidStorageUrl | S4 | Bajo | S | luna (frontend) | validación cliente independiente de la rule |
+| F5 — Documentación | (transversal) | Bajo | S | owner de la fase que mergea último | security.md + devops.md + project-reference.md |
+
+**Esfuerzo total:** M (consistente con el PRD: S1=S, S2=M, S3=M, S4=S).
+
+### Merge strategy (declarada — hallazgo Pablo #4)
+
+**Dos PRs:**
+
+- **PR-A (F1 + F2 + F4 + F5-parcial):** cambios de bajo/medio riesgo que se mergean por gate de CI estándar (build + tests + audit). F5 docs de S1/S2/S4 viajan en este PR.
+- **PR-B (F3 + F5-parcial):** aislado por su gate de **deploy + smoke a la instancia compartida prod/staging**. F3 toca código (`claims.ts`, `env.ts`) + Secret Manager + provisioning, y su validación NO es CI-only sino verificación empírica de runtime post-deploy. Las docs de S3 (origen de `ADMIN_EMAIL`/`APP_CHECK_ENFORCEMENT` en security.md y devops.md) viajan en este PR para que el doc no quede stale respecto del estado real desplegado.
+
+**Rationale del split:** F3 tiene un perfil de riesgo y un gate de validación distintos (deploy real + smoke) de F1/F4 (revert de lockfile/util, gate CI). Mantenerlos juntos obligaría a bloquear el merge de bumps de seguridad de bajo riesgo detrás del gate de deploy de F3.
+
+### Dependencia de orden entre PRs (hallazgo Pablo #5)
+
+- **F2 antes de F3.** Ambas tocan el árbol de `functions/`: F2 modifica `functions/package.json` + lockfile; F3 modifica `functions/src/admin/claims.ts`, `functions/src/helpers/env.ts` y `functions/.env`. No hay overlap de archivos, pero F3 hace `firebase deploy --only functions` — el lockfile de functions debe estar estable (post-F2) antes del deploy de F3 para que el deploy use las deps parcheadas. **Por lo tanto: PR-A se mergea antes que PR-B.**
+- F1 (`package.json` root) y F4 (`src/utils/media.ts`) no se solapan con functions ni entre sí; pueden ir en cualquier orden dentro de PR-A.
+
+### Confirmación de no-overlap de archivos
+
+| Fase | Archivos | Overlap con otra fase |
+|------|----------|----------------------|
+| F1 | `package.json`, `package-lock.json` (root) | Ninguno |
+| F2 | `functions/package.json`, `functions/package-lock.json` | Comparte árbol `functions/` con F3 (lockfile vs código) → orden F2→F3 |
+| F3 | `functions/.env`, `functions/src/admin/claims.ts`, `functions/src/helpers/env.ts`, `functions/src/__tests__/admin/claims.test.ts`, `functions/src/__tests__/helpers/env.test.ts` | Comparte árbol `functions/` con F2 |
+| F4 | `src/utils/media.ts`, `src/utils/media.test.ts` | Ninguno |
+| F5 | `docs/reference/*`, `functions/.env` (comentario cabecera) | Ninguno de código |
+
+## Fase 1 — Bump `react-router-dom >= 7.14.2` (S1)
+
+- **Archivo:** `package.json` / `package-lock.json`.
+- **Cambio:** `npm i react-router-dom@^7.14.2`; verificar `npm audit` que limpia GHSA-49rj/8646/2j2x.
+- **Test:** build + smoke de rutas (`src/main.tsx`, `src/App.tsx` usan API declarativa, sin loaders/RSC → sin cambio de API).
+- **Commit:** `fix(#342): bump react-router-dom a >=7.14.2 (RCE/XSS/open-redirect)`
+- **Rollback:** revert del lockfile.
+
+## Fase 2 — Bump `firebase-admin` (S2)
+
+- **Archivo:** `functions/package.json` / lockfile.
+- **Cambio:** subir `firebase-admin` al patch que trae `google-gax`/`protobufjs` parcheados; `cd functions && npm audit`.
+- **Test:** `cd functions && npm run test:run` verde; build de functions.
+- **Commit:** `fix(#342): bump firebase-admin para limpiar protobufjs/google-gax (functions)`
+- **Rollback:** revert del lockfile de functions.
+
+## Fase 3 — `ADMIN_EMAIL` + `APP_CHECK_ENFORCEMENT` a Secret Manager (S3)
+
+> **Orden interno NO negociable (observacion abierta de Diego, specs L356-357).** Invertir estos pasos deja la funcion sin valor en runtime.
+
+- **Archivos:** `functions/.env`, `functions/src/admin/claims.ts`, `functions/src/helpers/env.ts`, `functions/src/__tests__/admin/claims.test.ts`, `functions/src/__tests__/helpers/env.test.ts` (nuevo).
+
+**Paso 3.0 — Provisionar antes de remover.** Provisionar `ADMIN_EMAIL` (secret) y `APP_CHECK_ENFORCEMENT` (parameter) en Secret Manager / parameter store ANTES de tocar el `.env`. Valor de `APP_CHECK_ENFORCEMENT` = `enabled` en la instancia desplegada (preserva prod=enabled exacto).
+
+**Paso 3.1 — `secrets:` array antes del cambio de tipo.** Agregar `secrets: ['ADMIN_EMAIL']` al config de `onCall` de `setAdminClaim` ANTES de cambiar `defineString`→`defineSecret` (sin el array, `.value()` no resuelve en runtime). Patron de `analyticsReport.ts:160`.
+
+**Paso 3.2 — Cambio de codigo.** En `claims.ts`: `defineString('ADMIN_EMAIL')` → `defineSecret('ADMIN_EMAIL')` (decision tecnica #4 de specs; `.value()` se invoca DENTRO del handler, no a top-level). En `helpers/env.ts`: `process.env.APP_CHECK_ENFORCEMENT` → `defineString('APP_CHECK_ENFORCEMENT', { default: 'disabled' }).value()` (Opcion A, decision #5; evalua a top-level, drop-in). Remover ambas lineas del `.env`; actualizar comentario de cabecera del `.env`.
+
+**Paso 3.3 — Tests EN esta fase (no en un paso final).**
+- `functions/src/__tests__/helpers/env.test.ts` (CREAR): ramas `ENFORCE_APP_CHECK` enabled/disabled, `default:'disabled'`→false, `IS_EMULATOR=true`→false. `vi.resetModules()` por caso (se evalua al import).
+- `functions/src/__tests__/admin/claims.test.ts` (AJUSTAR mock): ampliar el factory de `firebase-functions/params` para exportar `defineSecret` con `{ value: () => 'admin@test.com' }`.
+
+**Paso 3.4 — Deploy + smoke antes de mergear.** `firebase deploy --only functions --project modo-mapa-app`; verificar empiricamente que `ENFORCE_APP_CHECK` sigue resolviendo al valor esperado (smoke de una callable user-facing + inspeccion del parameter desplegado). En emulador, `FUNCTIONS_EMULATOR=true` → siempre false (invariante `!IS_EMULATOR` intacto).
+
+- **Aclaracion SC (Sofia):** `npm audit --audit-level=high` corre en CI con `continue-on-error`. **Decision:** actualizar texto del invariante documentado (Fase 5); gate duro queda fuera de scope.
+- **Commit:** `chore(#342): mover ADMIN_EMAIL (defineSecret) y APP_CHECK_ENFORCEMENT (defineString) a Secret Manager + tests`
+- **Rollback:** revert del codigo + restaurar parameter/secret; `.env` local para desarrollo (no commitear secrets reales). El parameter desplegado permanece.
+
+## Fase 4 — Hardening `isValidStorageUrl` (S4)
+
+- **Archivo:** `src/utils/media.ts` (+ `media.test.ts`).
+- **Cambio:** exigir el segmento `/v0/b/<bucket>/o/` además del host. **Tratar cliente y rule como validaciones INDEPENDIENTES** (la rule `firestore.rules:222` usa `%2F` y `.*`, no `/v0/b/` — no son espejo).
+- **Pre-decisión:** bucket exacto (`VITE_FIREBASE_STORAGE_BUCKET`) vs genérico (`/v0/b/[^/]+/o/`). Antes de elegir exacto, confirmar que no hay `mediaUrl` legacy en Firestore con otro bucket (rename/migración). **Default:** genérico (`[^/]+`) para no romper históricos.
+- **Test:** `media.test.ts` — URLs válidas, host correcto sin `/v0/b/` (rechaza), bucket distinto (acepta si genérico).
+- **Commit:** `fix(#342): endurecer isValidStorageUrl exigiendo /v0/b/<bucket>/o/`
+- **Rollback:** revert del util + test.
+
+## Fase 5 — Documentación (S2/S3)
+
+- **`docs/reference/security.md`:** nuevo origen de `ADMIN_EMAIL` (Secret Manager / `defineSecret`) y `APP_CHECK_ENFORCEMENT` (parameter / `defineString`). Invariante #300 satisfecho.
+- **`docs/reference/devops.md`:** (a) actualizar tabla de variables de entorno (qué vive en `.env` vs Secret Manager); (b) **redefinir el texto del invariante `npm audit`** distinguiendo runtime functions (0 vulns HIGH, exit 0) de dev/CLI transitivas en root (documentadas, `continue-on-error` se mantiene) — esto es Success Criteria #3 del PRD, sin este paso S2 queda incompleto; (c) corregir el stale `devops.md:34` (`defineString ... en backups.ts` → el codigo real esta en `claims.ts`).
+- **`docs/reference/project-reference.md`:** bump de version si corresponde tras el cambio de deps.
+- **Owner:** quien mergea PR-B (las docs de S3 viajan con PR-B; las de S1/S2/S4 pueden ir en PR-A).
+- **Commit:** `docs(#342): actualizar security.md + devops.md (origen de secrets + invariante audit runtime-vs-dev)`
+- **Rollback:** revert del commit de docs (sin impacto de runtime).
+
+## Test plan global
+
+Tests escritos EN la fase que toca el codigo (no en un paso final):
+
+- **F1:** build + smoke de routing (`src/main.test.ts` verde post-bump).
+- **F2:** `cd functions && npm run test:run` verde; `npm audit --audit-level=high` functions exit 0.
+- **F3:** `functions/src/__tests__/helpers/env.test.ts` (nuevo) + ajuste de mock en `claims.test.ts`; deploy + smoke de `ENFORCE_APP_CHECK`.
+- **F4:** `src/utils/media.test.ts` ampliado — acepta `/v0/b/<bucket>/o/`, rechaza host sin segmento, preserva guards prefix-bypass/scheme-confusion/arbitrary-content/typeof/empty.
+- Cobertura >=80% branches del codigo modificado (gate del merge skill).
+- `npm audit` root y functions → documentar resultado en devops.md (F5).
+
+## Rollback global
+
+Fases independientes y revertibles. F3 es la sensible: mantener los valores en Secret Manager y poder restaurar `.env` local para desarrollo.
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Ciclo:** 1
+
+**Cerrado en este ciclo:**
+- BLOQUEANTE #1 "Tests del specs ausentes en las fases" -> resuelto: `env.test.ts` (crear) + ajuste de mock `defineSecret` en `claims.test.ts` ahora viven en el Paso 3.3 de la Fase 3 (junto al cambio de codigo, no en un paso final). Test plan global desglosado por fase.
+- BLOQUEANTE #2 "Orden interno de la Fase 3 no documentado" -> resuelto: pasos 3.0->3.4 con la secuencia no-negociable de Diego (provisionar -> `secrets:` array -> cambio de tipo -> deploy+smoke). Corregido el "ya usa defineString" a la conversion `defineString`->`defineSecret` (decision tecnica #4 de specs).
+- BLOQUEANTE #3 "Falta fase de documentacion" -> resuelto: Fase 5 con `security.md`, `devops.md` (incluye redefinicion del invariante audit = Success Criteria #3 del PRD + fix del stale `devops.md:34` backups.ts->claims.ts) y `project-reference.md`.
+- IMPORTANTE #4 "Sin estimacion ni merge strategy" -> resuelto: tabla con esfuerzo S/M por fase + merge strategy explicita (PR-A bajo/medio riesgo via gate CI; PR-B aislado por gate deploy+smoke de F3).
+- IMPORTANTE #5 "Ownership sin asignar" -> resuelto: owners (luna F1/F4, nico F2/F3), tabla de no-overlap de archivos y dependencia de orden F2->F3 (lockfile estable antes del deploy de F3).
+
+**Observaciones para el implementador:**
+1. Dos pre-decisiones quedan correctamente diferidas a tiempo de implementacion y deben resolverse ANTES de codear su fase: (a) F4 bucket generico vs exacto — depende de la query no-legacy-bucket a `feedback.mediaUrl`; el default seguro es generico `[^/]+`; (b) F3 mecanismo exacto de provisioning del parameter `APP_CHECK_ENFORCEMENT` — el plan exige verificarlo empiricamente en el Paso 3.4.
+2. F3 (PR-B) NO se mergea hasta completar el Paso 3.4 (deploy + smoke de `ENFORCE_APP_CHECK` en la instancia compartida prod/staging). El gate de F3 no es CI-only; es verificacion de runtime post-deploy. Respetar el orden interno 3.0->3.4 al pie de la letra: invertirlo deja `setAdminClaim` sin valor en runtime.
+3. PR-A (F1+F2+F4+docs S1/S2/S4) se mergea antes que PR-B porque F2 estabiliza el lockfile de functions que F3 despliega.
+4. El merge skill corre coverage >=80% branches: el test de `env.ts` (Paso 3.3) es lo que evita que ese gate bloquee a F3 por las ramas nuevas del mecanismo `defineString.value()`.
+5. S2 mantiene `continue-on-error: true` en el audit de CI; la Fase 5 redefine el invariante en TEXTO, NO introduce un gate duro en `deploy.yml`/`guards.yml`. Verificar que F2 no rompe el pipeline.
+
+**Listo para pasar a implementacion?** Si.

--- a/docs/feat/security/deps-vulnerables-secrets-env/prd.md
+++ b/docs/feat/security/deps-vulnerables-secrets-env/prd.md
@@ -1,0 +1,285 @@
+# PRD: Tech debt seguridad — deps vulnerables (react-router) + secrets en functions/.env + isValidStorageUrl prefix-only
+
+**Feature:** deps-vulnerables-secrets-env
+**Categoria:** security
+**Fecha:** 2026-06-09
+**Issue:** #342
+**Prioridad:** Alta (HIGH — 3 advisories, 2 con CVSS ~8.0)
+
+---
+
+## Contexto
+
+El reporte `/health-check` detecto 5 hallazgos de seguridad de deuda tecnica en el proyecto (actualmente en v2.52.1): `react-router-dom@^7.13.1` arrastra 3 advisories de seguridad (dos con CVSS ~8.0), el invariante documentado "exit 0 en `npm audit --audit-level=high` en root y functions" esta violado, `functions/.env` (commiteado al repo publico desde 2026-03-15) contiene `ADMIN_EMAIL` y `APP_CHECK_ENFORCEMENT` cuando el invariante #300 exige Secret Manager, y `isValidStorageUrl` valida solo el prefijo del host sin exigir el segmento canonico `/v0/b/<bucket>/o/`.
+
+## Problema
+
+- **Dependencia vulnerable (HIGH):** `react-router-dom` 7.13.1 esta sujeto a GHSA-49rj-9fvp-4h2h (turbo-stream RCE, CVSS 8.1, `>=7.0.0 <=7.14.1`), GHSA-8646-j5j9-6r62 (XSS en RSC redirect, CVSS 8.0, `>=7.7.0 <7.13.2`) y GHSA-2j2x-hqr9-3h42 (open redirect `//`, moderate). El RCE/XSS no son alcanzables con la API declarativa actual (sin loaders/actions/RSC) pero el open-redirect tiene superficie real.
+- **Invariante de audit roto:** `npm audit --audit-level=high` falla tanto en root (18 vulns, 8 high — mayormente transitivas via `firebase-tools` dev/CLI) como en functions (2 high via `firebase-admin` → `@google-cloud/firestore` → `google-gax` → `protobufjs`, runtime server-side). Viola el invariante documentado.
+- **Secrets commiteados (#300):** `functions/.env` contiene `ADMIN_EMAIL` y `APP_CHECK_ENFORCEMENT=enabled`. El repo es publico. El codigo de `claims.ts` ya usa `defineString('ADMIN_EMAIL')` (leeria del parameter/secret store), por lo que mover ambos a Secret Manager no requiere cambio de logica de runtime.
+- **Validacion debil (defense-in-depth):** `src/utils/media.ts` valida `startsWith('https://firebasestorage.googleapis.com/')`. El control de autorizacion real es la regla de Firestore (que ya exige el path `feedback-media/{uid}/{feedbackId}/`), pero `isValidStorageUrl` deberia endurecerse para exigir tambien el segmento `/v0/b/<bucket>/o/` y cerrar el gap de defense-in-depth en el cliente.
+
+## Solucion
+
+### S1 — Bump `react-router-dom` a `>=7.14.2` (H-1)
+
+- Bump `react-router-dom` de `^7.13.1` a `^7.14.2` (o el ultimo patch 7.x disponible) en `package.json`. Las tres advisories quedan parchadas con `>=7.14.2`.
+- Sin cambio de API: el proyecto usa la API declarativa (`BrowserRouter`, `Routes`, `Route`, `useNavigate`, `useParams`, `useSearchParams`) — no usa loaders/actions/RSC. Los 10+ callsites en `src/` (`main.tsx`, `App.tsx`, `AuthContext.tsx`, `BusinessDetailScreen.tsx`, `BusinessSheetCompactContent.tsx`, `BusinessNotFound.tsx`, etc.) no requieren cambios.
+- Verificar que la suite de tests de routing (`main.test.ts`, `BusinessDetailScreen.test.tsx`, `AuthContext.test.tsx`, `BusinessSheet.error.test.tsx`) pasa post-bump.
+
+### S2 — Restaurar invariante `npm audit --audit-level=high` (H-2, H-3)
+
+- **Functions (H-3):** bump `firebase-admin` al ultimo patch disponible (cadena `@google-cloud/firestore` → `google-gax` → `protobufjs`). Verificar `cd functions && npm audit --audit-level=high` → exit 0.
+- **Root (H-2):** la mayoria de las 18 vulns son transitivas via `firebase-tools` (dev/CLI, no shipean al bundle de produccion). Evaluar:
+  - `npm audit fix` sin `--force` para los parches no-breaking.
+  - Para las que solo se resuelven con bump mayor de `firebase-tools`: documentar la decision (riesgo dev-only) y, si no se puede llegar a exit 0 limpio, ajustar el invariante en `docs/reference/devops.md` para distinguir vulns de runtime (deben ser 0) de vulns dev/CLI transitivas (documentadas con justificacion).
+- **Nota de scope:** #168 (Vite 8 y ESLint 10 bloqueados por peer deps) es un bloqueante conocido de bumps mayores. Este PRD NO desbloquea #168 — se limita a parches que no rompan peer deps.
+
+### S3 — Mover `ADMIN_EMAIL` y `APP_CHECK_ENFORCEMENT` a Secret Manager (M-1)
+
+- Migrar ambos valores de `functions/.env` a Firebase Secret Manager / parameter store.
+- `ADMIN_EMAIL`: el codigo ya usa `defineString('ADMIN_EMAIL')` en `claims.ts:9`. Confirmar que el parameter resuelve desde Secret Manager (o convertir a `defineSecret` y declararlo en el array `secrets:` de las funciones consumidoras — patron ya usado en `analyticsReport.ts:160` con `GA4_PROPERTY_ID`) y remover la linea del `.env`.
+- `APP_CHECK_ENFORCEMENT`: `helpers/env.ts:17` lo lee via `process.env.APP_CHECK_ENFORCEMENT` (NO es un parameter `defineX` hoy). A diferencia de `ADMIN_EMAIL`, este NO tiene mecanismo de parameter store existente — su migracion **requiere una decision de mecanismo** que debe quedar pinneada en specs:
+  - Opcion A: convertir a `defineString('APP_CHECK_ENFORCEMENT')` y leer `.value()` en vez de `process.env`.
+  - Opcion B: setearlo como env de runtime via config de deploy (`--set-env-vars`) en lugar del `.env` commiteado.
+  - **Invariante a preservar (no negociable):** el comportamiento documentado en `env.ts:9` debe mantenerse exacto — production = `enabled`, staging = unset/`disabled`, emuladores = siempre disabled. `ENFORCE_APP_CHECK` no debe cambiar de valor efectivo en ningun entorno tras la migracion.
+- **`GITHUB_OWNER` / `GITHUB_REPO`:** son metadata publica del repo (no secretos). Decision de este PRD: **permanecen en `functions/.env`** (ya consumidos via `defineString` en `feedback.ts:9`). El `.env` sigue siendo un archivo valido commiteado para valores NO sensibles — el invariante #300 prohibe *secretos* en el `.env`, no toda configuracion. Actualizar el comentario de cabecera de `functions/.env` para reflejar que solo contiene valores no-sensibles.
+- **No re-ignorar `functions/.env`:** el archivo esta deliberadamente un-ignored en `.gitignore:29` (`!functions/.env`) y debe seguir asi para que `GITHUB_OWNER`/`GITHUB_REPO` viajen en el repo. La mitigacion es remover los *secretos* del archivo, NO re-ignorar el archivo. No tocar `.gitignore`.
+- Actualizar `docs/reference/devops.md` y `docs/reference/security.md` con el nuevo origen de cada valor.
+- **Consideracion de seguridad (#300):** este es exactamente el invariante "Secretos sensibles en Secret Manager" de `security.md` L170. El repo es publico — un `ADMIN_EMAIL` expuesto facilita phishing dirigido a la cuenta admin (mitigado parcialmente por el bootstrap gate #322 R14, pero defense-in-depth exige no exponerlo).
+- **Nota sobre `ADMIN_EMAIL` y rotacion:** `ADMIN_EMAIL` es una *identidad* (un email), no un token rotatable. Removerlo del `.env` reduce su exposicion en el HEAD del repo, pero el valor sigue en el historial de commits (el repo es publico desde 2026-03-15). No es "rotable" como un secreto: la mitigacion efectiva contra su exposicion historica es el bootstrap gate #322 R14 (ya desplegado) + Email Enumeration Protection. Este PRD no intenta purgar historial (fuera de scope, costo alto, beneficio marginal dado que el gate ya cierra el vector de hijack).
+
+### S4 — Endurecer `isValidStorageUrl` (M-2)
+
+- Cambiar la validacion en `src/utils/media.ts` de prefix-only a un check que exija el segmento canonico `/v0/b/<bucket>/o/` despues del host.
+- Patron de validacion: anclar host exacto + segmento `/v0/b/` + bucket + `/o/`. Reusar el estilo de las rules de Firestore (`^https://firebasestorage.googleapis.com/...`) para consistencia. El bucket puede validarse contra `VITE_FIREBASE_STORAGE_BUCKET` o aceptarse generico (`/v0/b/[^/]+/o/`) — definir en specs.
+- Mantener el `typeof url === 'string'` guard y los regression guards existentes (prefix-bypass con dominio similar, scheme-confusion `http://`, contenido arbitrario antes del prefijo).
+- **UX:** sin impacto visual. `isValidStorageUrl` se usa en `FeedbackMediaPreview.tsx` y `MyFeedbackList.tsx` para decidir si renderizar la media; un endurecimiento solo afecta URLs malformadas (que ya deberian estar bloqueadas por las rules en escritura).
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| S1 — bump react-router-dom >=7.14.2 + verificar tests routing | Alta | S |
+| S2 — bump firebase-admin + audit fix root + actualizar invariante devops | Alta | M |
+| S3 — migrar ADMIN_EMAIL + APP_CHECK_ENFORCEMENT a Secret Manager, remover del .env | Alta | M |
+| S4 — endurecer isValidStorageUrl con `/v0/b/<bucket>/o/` + tests | Media | S |
+
+**Esfuerzo total estimado:** M
+
+---
+
+## Out of Scope
+
+- Bump mayor de `firebase-tools`, Vite 8 o ESLint 10 — bloqueados por peer deps (#168), seguimiento separado.
+- Migrar `GITHUB_TOKEN` (ya en Secret Manager) o cualquier otro secreto ya gestionado correctamente.
+- Cambiar la API de routing (migrar a data router / loaders) — el bump es drop-in sobre la API declarativa.
+- Endurecer las Storage rules o Firestore rules de `feedback`/`specials` (la regla ya valida el path canonico) — solo se toca el helper client-side `isValidStorageUrl`.
+
+---
+
+## Tests
+
+Politica del proyecto: >=80% cobertura para codigo nuevo/modificado (enforced en CI via `deploy.yml`). `src/utils/media.ts` ya esta al 100% con regression guards — el endurecimiento DEBE conservar y ampliar esos guards.
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `src/utils/media.test.ts` | Util (existente, ampliar) | Aceptar URL canonica con `/v0/b/<bucket>/o/`; rechazar URL con host valido pero sin segmento `/v0/b/.../o/`; mantener guards de prefix-bypass, scheme-confusion (`http://`), contenido arbitrario antes del prefijo, host similar (`...googleapis.com.evil.com`); rechazar bucket de otro proyecto si se valida bucket exacto |
+| `src/main.test.ts` | Integracion routing (existente) | Verde post-bump react-router (smoke de montaje de router) |
+| `functions/src/__tests__/admin/claims.test.ts` | Cloud Function (existente) | Verde post-cambio de origen de `ADMIN_EMAIL` (el mock de `defineString` ya devuelve `{ value: () => 'admin@test.com' }`) |
+| `functions/src/helpers/env.ts` | Helper (sin test hoy) | Si se cambia el mecanismo de lectura de `APP_CHECK_ENFORCEMENT`, agregar test de la rama enabled/disabled (hoy es constante simple sin test) |
+
+### Criterios de testing
+
+- Cobertura >= 80% del codigo nuevo/modificado.
+- `media.test.ts` cubre todos los paths condicionales del nuevo regex (host valido + segmento valido, host valido + segmento ausente, host invalido).
+- Suites de routing existentes verdes post-bump (regresion).
+- No se introducen side effects nuevos (la funcion sigue siendo pura).
+
+---
+
+## Seguridad
+
+Items relevantes del checklist de `security.md`:
+
+- [ ] **Sin secretos en codigo (S3):** `ADMIN_EMAIL` y `APP_CHECK_ENFORCEMENT` salen de `functions/.env` (repo publico) hacia Secret Manager — invariante #300 / `security.md` L170.
+- [ ] **Revisar diffs por exposicion de secretos:** confirmar que el `.env` ya no contiene valores sensibles tras la migracion; verificar que ningun valor quedo en historial de commits relevante para rotacion.
+- [ ] **Validacion de input endurecida (S4):** `isValidStorageUrl` exige segmento canonico — defense-in-depth client-side.
+- [ ] **Dependencias sin vulnerabilidades HIGH (S1, S2):** `react-router-dom >=7.14.2`; `npm audit --audit-level=high` exit 0 en functions (runtime) y root (o invariante actualizado con justificacion para dev-only).
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| Open redirect (react-router GHSA-2j2x-hqr9-3h42) | Bot inyecta URL `//evil.com` en parametro de navegacion para phishing | Bump a `>=7.14.2` (S1) |
+| `ADMIN_EMAIL` expuesto en repo publico | Script scrapea el repo, identifica la cuenta admin para phishing/credential stuffing | Mover a Secret Manager (S3); bootstrap gate #322 R14 ya mitiga hijack post-compromiso |
+| Media URL falsificada en `mediaUrl` (feedback) | Cliente o script envia URL que pasa el prefix-check pero apunta a recurso no-Storage | Endurecer `isValidStorageUrl` (S4) + rule de Firestore ya valida path canonico (defense-in-depth) |
+| Dependencia transitiva vulnerable (protobufjs, turbo-stream) | Explotacion de RCE/parsing en runtime server-side | Bump `firebase-admin` (S2) |
+
+**Este feature NO escribe a Firestore ni agrega colecciones.** No aplican los checklists de `hasOnly()`, rate limit de triggers, ni `userSettings`. El cambio en `isValidStorageUrl` afecta lectura/render de media, no escritura — la rule de `feedback` (firestore.rules L222) ya valida el path en write.
+
+---
+
+## Deuda tecnica y seguridad
+
+Issues abiertos consultados (`gh issue list`): no hay labels `security` ni `tech debt` formales; el backlog actual tiene una tanda de items `Tech debt:` (#341-#349) generados por `/health-check`, mas #168.
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| #300 (invariante secrets en Secret Manager) | mitiga | S3 cierra el gap exacto de `ADMIN_EMAIL` / `APP_CHECK_ENFORCEMENT` en el `.env` commiteado |
+| #322 R14 (bootstrap admin gate) | refuerza | Ya mitiga el hijack del rol admin si `ADMIN_EMAIL` se compromete; S3 reduce la superficie de exposicion del email |
+| #168 (Vite 8 / ESLint 10 bloqueados por peer deps) | empeora si no se considera | S2 NO debe forzar bumps mayores que rompan peer deps; limitarse a patches |
+| #342 (este) | — | Cierra los 5 hallazgos H-1, H-2, H-3, M-1, M-2 |
+
+### Mitigacion incorporada
+
+- M-1: `ADMIN_EMAIL` + `APP_CHECK_ENFORCEMENT` fuera del repo publico → Secret Manager (S3, invariante #300).
+- M-2: `isValidStorageUrl` endurecido a segmento canonico (S4).
+- Invariante de audit restaurado o redefinido explicitamente con criterio runtime-vs-dev (S2).
+
+---
+
+## Robustez del codigo
+
+Este feature NO agrega hooks ni componentes async. S4 modifica una funcion pura existente; S1/S2 son bumps de dependencias; S3 es config de deploy + remocion de lineas del `.env`.
+
+### Checklist de hooks async
+
+- [x] No aplica — sin hooks/componentes nuevos. `isValidStorageUrl` es una funcion pura sin async.
+- [ ] Funciones exportadas que no se usan fuera del archivo y tests: `isValidStorageUrl` sigue exportado y consumido por `FeedbackMediaPreview.tsx` y `MyFeedbackList.tsx`.
+- [ ] `src/utils/media.ts` se mantiene como util pura (sin hooks) — ubicacion correcta.
+- [ ] Archivos modificados no superan 400 lineas (`media.ts` tiene ~6 lineas; `env.ts` ~42).
+- [x] No hay `logger.error` envuelto en `if (import.meta.env.DEV)` — no se toca logging.
+
+### Checklist de observabilidad
+
+- [x] No hay Cloud Function trigger nuevo (no aplica `trackFunctionTiming`).
+- [x] No hay service nuevo con queries Firestore (no aplica `measureAsync`).
+- [x] No hay `trackEvent` nuevo.
+
+### Checklist offline
+
+- [x] No hay formularios/dialogs nuevos que escriban a Firestore.
+- [x] `isValidStorageUrl` no toca catch blocks de toast.
+
+### Checklist de documentacion
+
+- [ ] `docs/reference/security.md` actualizado: origen de `ADMIN_EMAIL`/`APP_CHECK_ENFORCEMENT` (Secret Manager), endurecimiento de `isValidStorageUrl`.
+- [ ] `docs/reference/devops.md` actualizado: variables de entorno + invariante `npm audit` (runtime vs dev-only).
+- [ ] `docs/reference/project-reference.md`: bump de version si corresponde tras el cambio de dependencias.
+- [x] No hay colecciones/campos Firestore nuevos (no aplica `firestore.md`).
+- [x] No hay patrones nuevos (no aplica `patterns.md`), salvo documentar el criterio audit runtime-vs-dev si se redefine el invariante.
+
+---
+
+## Offline
+
+Ningun cambio afecta flujos de datos online/offline. S1/S2 son bumps de deps; S3 es config server-side; S4 endurece una validacion de URL sincrona usada en render.
+
+### Data flows
+
+| Operacion | Tipo (read/write) | Estrategia offline | Fallback UI |
+|-----------|-------------------|-------------------|-------------|
+| Render de media de feedback (validada por `isValidStorageUrl`) | read (validacion sincrona, no I/O) | Sin cambio — la validacion no hace fetch | Sin cambio — si la URL es invalida, no se renderiza el preview (comportamiento actual) |
+
+### Checklist offline
+
+- [x] Reads de Firestore: sin cambios.
+- [x] Writes: sin cambios.
+- [x] APIs externas: sin cambios.
+- [x] UI: sin indicador offline nuevo necesario.
+- [x] Datos criticos: sin cambios de cache.
+
+### Esfuerzo offline adicional: S (ninguno)
+
+---
+
+## Modularizacion y % monolitico
+
+El proyecto esta en ~30% monolitico. Este feature NO agrega componentes, hooks ni estado global. Modifica una util pura (`media.ts`), bumps de `package.json`, config de deploy y `functions/.env`.
+
+### Checklist modularizacion
+
+- [x] Logica de negocio en util pura (no inline en layout).
+- [x] No se agregan componentes nuevos.
+- [x] No se agregan useState a AppShell/SideMenu.
+- [x] `isValidStorageUrl` ya recibe la URL como argumento (sin dependencias implicitas).
+- [x] Ningun componente nuevo importa de `firebase/firestore|functions|storage`.
+- [x] `src/utils/media.ts` se mantiene como util (no es hook).
+- [x] Ningun archivo modificado supera 400 lineas.
+- [x] No hay converters nuevos.
+- [x] No hay archivos nuevos en `components/menu/` (cajon legacy).
+- [x] No se crea contexto global nuevo.
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | = | No se agregan/quitan imports cruzados |
+| Estado global | = | Sin estado nuevo |
+| Firebase coupling | - | S3 reduce config sensible en `.env` |
+| Organizacion por dominio | = | `media.ts` y `env.ts` permanecen en su capa |
+
+---
+
+## Accesibilidad y UI mobile
+
+Este feature no agrega ni modifica componentes interactivos. S4 solo cambia la condicion bajo la cual se renderiza un preview de media ya existente.
+
+### Checklist de accesibilidad
+
+- [x] No hay `<IconButton>` nuevos.
+- [x] No se agregan elementos interactivos.
+- [x] Sin touch targets nuevos.
+- [x] Sin estados de carga nuevos.
+- [x] `FeedbackMediaPreview` ya maneja URLs invalidas (no renderiza); el endurecimiento mantiene el comportamiento.
+- [x] Sin formularios nuevos.
+
+### Checklist de copy
+
+- [x] No hay copy user-facing nuevo (el cambio es de validacion/config, sin texto visible).
+- [x] Sin cambios de terminologia.
+- [x] Sin mensajes de error nuevos.
+
+---
+
+## Success Criteria
+
+1. `react-router-dom >=7.14.2` instalado; las 3 advisories (GHSA-49rj-9fvp-4h2h, GHSA-8646-j5j9-6r62, GHSA-2j2x-hqr9-3h42) ya no aparecen en `npm audit`; suites de routing verdes.
+2. `cd functions && npm audit --audit-level=high` retorna exit 0 (sin vulns HIGH de runtime).
+3. `npm audit --audit-level=high` en root retorna exit 0, o el invariante de `docs/reference/devops.md` queda redefinido distinguiendo runtime (0 vulns) de dev/CLI transitivas (documentadas con justificacion).
+4. `ADMIN_EMAIL` y `APP_CHECK_ENFORCEMENT` no estan en `functions/.env` (verificable por inspeccion del archivo commiteado); el runtime los lee desde Secret Manager / parameter store; deploy de functions funciona en prod y staging.
+5. `isValidStorageUrl` exige el segmento canonico `/v0/b/<bucket>/o/`; `media.test.ts` cubre el nuevo path al 100% manteniendo los regression guards existentes (prefix-bypass, scheme-confusion, contenido arbitrario).
+
+---
+
+## Validacion Funcional
+
+**Analista**: Sofia
+**Fecha**: 2026-06-09
+**Estado**: VALIDADO CON OBSERVACIONES
+
+### Hallazgos cerrados en esta iteracion
+
+- IMPORTANTE: "Decision de re-ignorar `functions/.env` no especificada" → resuelto en S3. El archivo esta deliberadamente un-ignored (`.gitignore:29 !functions/.env`) para que `GITHUB_OWNER`/`GITHUB_REPO` (no-secretos) viajen en el repo. La mitigacion es remover los secretos del archivo, NO re-ignorarlo ni tocar `.gitignore`.
+- IMPORTANTE: "Mecanismo de migracion de `APP_CHECK_ENFORCEMENT` ambiguo" → resuelto en S3. Se documentan Opcion A (`defineString` + `.value()`) y Opcion B (`--set-env-vars` de deploy), con la decision final delegada a specs, y se fija como invariante no-negociable el comportamiento por entorno de `env.ts:9` (prod=enabled, staging=unset, emuladores=disabled) que no debe cambiar de valor efectivo.
+- OBSERVACION: "`ADMIN_EMAIL` no es rotable" → resuelto en S3. Se aclara que es una identidad (no token), que el valor persiste en historial de commits, que la purga de historial queda fuera de scope, y que el vector de hijack ya esta cerrado por el bootstrap gate #322 R14.
+
+### Observaciones abiertas para el implementador
+
+- Al armar el plan, validar empiricamente que el deploy de functions a staging (donde `APP_CHECK_ENFORCEMENT` debe quedar unset/disabled) sigue resolviendo `ENFORCE_APP_CHECK === false` tras la migracion — riesgo bajo pero es el unico punto donde un error de mecanismo (Opcion A vs B) podria activar App Check en staging por accidente.
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** npm audit corre con continue-on-error (no es gate duro hoy) — aclarar SC. La rule usa %2F y .*, NO /v0/b/: tratar cliente y rule como validaciones independientes. Confirmar que no hay mediaUrl legacy con otro bucket. Validar en staging que ENFORCE_APP_CHECK sigue false tras migrar APP_CHECK_ENFORCEMENT.

--- a/docs/feat/security/deps-vulnerables-secrets-env/specs.md
+++ b/docs/feat/security/deps-vulnerables-secrets-env/specs.md
@@ -1,0 +1,358 @@
+# Specs: Tech debt seguridad — deps vulnerables + secrets en .env + isValidStorageUrl prefix-only
+
+**PRD:** [prd.md](prd.md)
+**Fecha:** 2026-06-10
+**Issue:** #342
+
+---
+
+## Resumen
+
+Cuatro cambios independientes de deuda tecnica de seguridad, sin colecciones nuevas ni componentes nuevos:
+
+- **S1** — bump `react-router-dom@^7.13.1` → `^7.14.2` (parcha 3 advisories).
+- **S2** — bump `firebase-admin` (cadena `protobufjs`) + `npm audit fix` no-force en root; redefinir el **texto** del invariante de audit en `devops.md` distinguiendo runtime (0 vulns) de dev/CLI transitivas.
+- **S3** — migrar `ADMIN_EMAIL` y `APP_CHECK_ENFORCEMENT` fuera del `functions/.env` commiteado (repo publico); dejar `GITHUB_OWNER`/`GITHUB_REPO` (metadata publica) en el `.env`.
+- **S4** — endurecer `isValidStorageUrl` para exigir el segmento canonico `/v0/b/<bucket>/o/`, como validacion **independiente** de la rule de Firestore.
+
+No hay modelo de datos nuevo, ni Cloud Functions nuevas, ni seed data (no hay colecciones/campos Firestore nuevos).
+
+---
+
+## Modelo de datos
+
+Sin cambios. Este feature no agrega ni modifica colecciones, documentos, indices ni tipos de Firestore.
+
+`feedback.mediaUrl` (string) ya existe y su contrato no cambia. S4 endurece solo la **validacion client-side de render**, no el shape del dato.
+
+## Firestore Rules
+
+**Sin cambios.** La rule de `feedback` (`firestore.rules:222`) ya valida `mediaUrl` en write y NO se toca (explicitamente fuera de scope, PRD "Out of Scope").
+
+### Aclaracion critica (observacion Sofia) — rule y cliente son validaciones INDEPENDIENTES, no espejo
+
+La rule real en `firestore.rules:222` (create) y `:242` (update) valida:
+
+```
+request.resource.data.mediaUrl.matches(
+  '^https://firebasestorage\\.googleapis\\.com/.*/feedback-media%2F' + request.auth.uid + '%2F' + docId + '%2F.*'
+)
+```
+
+Caracteristicas de la rule que **NO** debe replicar `isValidStorageUrl`:
+
+- Usa el path **URL-encoded** (`%2F`, no `/`).
+- Usa `.*` comodin entre el host y `feedback-media%2F` — **NO** ancla el segmento `/v0/b/<bucket>/o/`.
+- Ata el path a `request.auth.uid` y `docId` (ownership server-side), datos que el cliente no tiene en `isValidStorageUrl`.
+
+Por lo tanto, S4 endurece el cliente con un criterio **distinto y complementario** (segmento `/v0/b/<bucket>/o/` decodificado), no un mirror de la rule. Son dos capas de defense-in-depth con responsabilidades separadas:
+
+| Capa | Que valida | Donde |
+|------|-----------|-------|
+| Rule (write, server) | Path canonico encoded + ownership (`uid`/`docId`) | `firestore.rules:222,242` (no se toca) |
+| `isValidStorageUrl` (read/render, client) | Host exacto + segmento `/v0/b/<bucket>/o/` | `src/utils/media.ts` (S4) |
+
+No hay que cambiar la rule para que ambas convivan: la URL real de Firebase Storage contiene tanto `/v0/b/<bucket>/o/` (lo que valida el cliente) como `feedback-media%2F<uid>%2F<docId>%2F` (lo que valida la rule, como parte del path encodeado dentro del segmento `/o/`).
+
+### Rules impact analysis
+
+No hay queries Firestore nuevas. S4 afecta render client-side; S3 afecta lectura de config server-side via parameter/secret store, no Firestore.
+
+| Query (service file) | Collection | Auth context | Rule que la permite | Cambio? |
+|---------------------|------------|-------------|--------------------|---------|
+| (ninguna nueva) | — | — | — | No |
+
+### Field whitelist check
+
+No se agregan ni modifican campos de Firestore. No aplica.
+
+## Cloud Functions
+
+**Sin funciones nuevas.** S3 cambia el **origen de configuracion** (de `.env` commiteado a Secret Manager / runtime env) de dos funciones existentes, sin cambiar su logica:
+
+- `setAdminClaim` (`functions/src/admin/claims.ts`) — consume `ADMIN_EMAIL`.
+- Todas las callables user-facing que importan `ENFORCE_APP_CHECK` de `helpers/env.ts` — consumen `APP_CHECK_ENFORCEMENT` indirectamente.
+
+### Inventario de consumidores (verificado en codigo)
+
+`ENFORCE_APP_CHECK` (derivado de `APP_CHECK_ENFORCEMENT`) se importa de `functions/src/helpers/env.ts` en:
+
+- `functions/src/admin/menuPhotos.ts`
+- `functions/src/admin/featuredLists.ts`
+- `functions/src/admin/perfMetrics.ts`
+- `functions/src/callable/cleanAnonymousData.ts`
+- `functions/src/callable/deleteUserAccount.ts`
+- `functions/src/callable/removeListEditor.ts`
+- `functions/src/callable/inviteListEditor.ts`
+
+`env.ts:17` es el **unico lector** de `process.env.APP_CHECK_ENFORCEMENT` (verificado por grep). Esto acota el blast radius de la migracion a un solo punto.
+
+## Seed Data
+
+No aplica. El feature no introduce colecciones nuevas ni campos requeridos. No se modifica `scripts/seed-admin-data.mjs` ni `scripts/seed-staging.ts`.
+
+## Componentes
+
+Sin componentes nuevos ni modificados. `FeedbackMediaPreview.tsx` y `MyFeedbackList.tsx` consumen `isValidStorageUrl` sin cambios en su codigo — el endurecimiento es transparente para ellos (solo rechaza URLs malformadas que ya deberian estar bloqueadas por la rule de write).
+
+### Mutable prop audit
+
+No aplica — sin pantallas de detalle/formularios editables nuevos.
+
+## Textos de usuario
+
+No hay copy user-facing nuevo. El cambio en `isValidStorageUrl` solo decide si renderizar un preview ya existente; no agrega toasts, labels ni mensajes.
+
+## Hooks
+
+Sin hooks nuevos ni modificados.
+
+## Servicios
+
+Sin servicios nuevos. Detalle por sub-tarea:
+
+### S4 — `isValidStorageUrl` (`src/utils/media.ts`)
+
+Funcion pura existente. Firma actual:
+
+```ts
+const STORAGE_URL_PREFIX = 'https://firebasestorage.googleapis.com/';
+export const isValidStorageUrl = (url: string | undefined): url is string =>
+  typeof url === 'string' && url.startsWith(STORAGE_URL_PREFIX);
+```
+
+Endurecimiento propuesto: mantener el `typeof` guard + anclar host exacto + exigir segmento `/v0/b/<bucket>/o/`. Firma de salida (sin cambio de tipo, sigue siendo pura, sigue siendo type guard `url is string`):
+
+```ts
+// Host exacto + segmento canonico /v0/b/<bucket>/o/.
+// El ^ ancla el inicio (cierra prefix-bypass y arbitrary-content-before-prefix).
+const STORAGE_URL_RE =
+  /^https:\/\/firebasestorage\.googleapis\.com\/v0\/b\/[^/]+\/o\//;
+
+export const isValidStorageUrl = (url: string | undefined): url is string =>
+  typeof url === 'string' && STORAGE_URL_RE.test(url);
+```
+
+#### Decision: bucket generico `[^/]+` vs bucket exacto — PENDIENTE de verificacion empirica
+
+El PRD deja la decision a specs entre validar el bucket exacto (contra `VITE_FIREBASE_STORAGE_BUCKET`) o generico (`/v0/b/[^/]+/o/`).
+
+**Decision: bucket generico `/v0/b/[^/]+/o/`**, condicionada a la verificacion del paso de plan "confirmar no-legacy-bucket". Rationale:
+
+1. **Riesgo de legacy mediaUrl (observacion Sofia):** existe `feedback.mediaUrl` historico en Firestore. Si algun doc antiguo apunta a un bucket distinto del actual `VITE_FIREBASE_STORAGE_BUCKET` (ej. `*.appspot.com` vs `*.firebasestorage.app`, o un bucket de un proyecto anterior), un check de bucket exacto **rompe el render** de esa media para el usuario y el admin. El plan incluye un paso de verificacion (query a Firestore) ANTES de elegir; si la query confirma que todos los `mediaUrl` usan el bucket actual, se puede endurecer a bucket exacto en un followup, pero el default seguro para este PRD es generico.
+2. El bucket exacto requiere que `media.ts` (util pura, sin acceso a `import.meta.env` deseable) lea config de entorno — acopla la util a la config de Vite. El generico la mantiene pura y sin dependencias.
+3. La autorizacion real (que la media pertenezca al feedback del owner) la da la rule de write, no este check. El cliente solo necesita garantizar "es una URL de Firebase Storage bien formada", para lo cual `[^/]+` es suficiente.
+
+El segmento `[^/]+` (un solo segmento de path, sin `/`) ya impide que un atacante meta `firebasestorage.googleapis.com/v0/b/evil.com/x/o/` con sub-paths inyectados en la posicion del bucket.
+
+#### Regression guards a preservar (verificados en `media.test.ts` actual)
+
+El nuevo regex DEBE seguir rechazando, y los tests existentes deben quedar verdes:
+
+- prefix-bypass con dominio similar (`...googleapis.com.evil.com`) — el `^...com\/v0\/b\/` lo bloquea.
+- scheme-confusion (`http://...`) — el `^https://` lo bloquea.
+- contenido arbitrario antes del prefijo (`evil-https://...`) — el `^` lo bloquea.
+- `typeof` no-string (undefined, null, number, object, boolean) — guard preservado.
+- empty string — no matchea el regex.
+
+Nuevos guards a agregar (cubren el path nuevo):
+
+- host valido **sin** segmento `/v0/b/.../o/` (ej. `https://firebasestorage.googleapis.com/some/other/path`) → debe rechazar.
+- URL canonica con `/v0/b/<bucket>/o/<encoded-path>?alt=media` → debe aceptar (es el formato real que ya testea el caso "canonical" actual; verificar que sigue verde).
+
+### S3 — origen de `ADMIN_EMAIL` y `APP_CHECK_ENFORCEMENT`
+
+#### `ADMIN_EMAIL` (decision: convertir a `defineSecret`)
+
+Estado actual: `claims.ts:9` usa `defineString('ADMIN_EMAIL')`, que resuelve desde `functions/.env` (committeado). Para sacarlo del `.env` publico hay que cambiar el mecanismo, porque `defineString` lee del `.env` o del parameter store, pero el valor hoy vive en el `.env`.
+
+Decision: **convertir a `defineSecret('ADMIN_EMAIL')`** y agregarlo al array `secrets:` de `setAdminClaim` (patron ya usado en `analyticsReport.ts:160` con `GA4_PROPERTY_ID` via `secrets: ['GA4_PROPERTY_ID']` + `process.env`). El cambio de codigo en `claims.ts`:
+
+- `import { defineSecret } from 'firebase-functions/params'` (en vez de `defineString`).
+- `const ADMIN_EMAIL_PARAM = defineSecret('ADMIN_EMAIL');`
+- `ADMIN_EMAIL_PARAM.value()` sigue funcionando igual en el handler (la API `.value()` es identica entre `defineString` y `defineSecret`).
+- Agregar `secrets: ['ADMIN_EMAIL']` al config de `onCall` de `setAdminClaim` (donde ya esta `enforceAppCheck: ENFORCE_APP_CHECK_ADMIN`).
+- Provisionar el secret en Secret Manager: `firebase functions:secrets:set ADMIN_EMAIL`.
+- Remover la linea `ADMIN_EMAIL=...` de `functions/.env`.
+
+El test `claims.test.ts` ya mockea `defineString` devolviendo `{ value: () => 'admin@test.com' }`; el mock debe ampliarse para cubrir `defineSecret` con la misma forma (ambos exportados de `firebase-functions/params`).
+
+#### `APP_CHECK_ENFORCEMENT` (decision: Opcion A — `defineString` + `.value()`) — con caveat operativo decisivo
+
+El PRD ofrece Opcion A (`defineString('APP_CHECK_ENFORCEMENT')` + `.value()`) y Opcion B (`--set-env-vars` en deploy).
+
+**Hallazgo decisivo (verificado en CI):** `deploy.yml:88` y `deploy-staging.yml:97` despliegan funciones al **mismo proyecto** `modo-mapa-app` con `firebase deploy --only functions`. No hay un proyecto/entorno de functions separado para staging — staging y prod comparten la misma instancia de Cloud Functions, que hoy lee `APP_CHECK_ENFORCEMENT=enabled` del `.env` commiteado en **ambos** pipelines. La distincion "production=enabled / staging=unset" descrita en `env.ts:9` y `security.md:44` es la **intencion documentada del mecanismo**, pero operativamente hoy el deploy es unico y el valor efectivo es `enabled` en la unica instancia desplegada.
+
+Implicancia para la decision:
+
+- **Opcion B (`--set-env-vars`)** requeriria dos pipelines de deploy de functions con distinto `--set-env-vars` (uno por entorno). Como hoy hay un solo deploy compartido, B no aporta la separacion staging/prod sin un rework de CI que esta fuera de scope (#168-adjacent infra).
+- **Opcion A (`defineString` + `.value()`)** es drop-in: `defineString` resuelve desde un parameter (que puede setearse por entorno cuando exista separacion) o desde el `.env`. Para sacar el valor del `.env` commiteado y mantener el comportamiento actual, se provisiona el parameter `APP_CHECK_ENFORCEMENT` (no es secreto sensible — es un flag operativo, pero se mueve igual para no dejar config de seguridad en el repo publico).
+
+Decision: **Opcion A**. Cambios:
+
+- En `helpers/env.ts`: `import { defineString } from 'firebase-functions/params'`; `const APP_CHECK_ENFORCEMENT_PARAM = defineString('APP_CHECK_ENFORCEMENT', { default: 'disabled' });` y `export const ENFORCE_APP_CHECK = !IS_EMULATOR && APP_CHECK_ENFORCEMENT_PARAM.value() === 'enabled';`.
+- `default: 'disabled'` preserva el invariante "ausente → disabled" (staging/emulador no rompen si el parameter no esta seteado).
+- Provisionar el parameter para la instancia actual con valor `enabled` (mantiene prod=enabled exacto): via `.env` de deploy NO (se quita del `.env`), sino via parameter config de Firebase (`firebase functions:params:set` / archivo `.env.<project>` no commiteado, o config de runtime). El plan fija el mecanismo exacto de provisioning y lo valida empiricamente.
+
+**Invariante NO-negociable (PRD S3, preservar exacto):**
+
+- production = `enabled`
+- staging = unset/`disabled`
+- emuladores = siempre disabled (via `!IS_EMULATOR`, que no cambia)
+
+`ENFORCE_APP_CHECK` NO debe cambiar de valor efectivo en ningun entorno tras la migracion. Dado el caveat de deploy unico arriba, el valor efectivo en la instancia desplegada hoy es `enabled` y debe seguir siendo `enabled` post-migracion (el plan lo verifica con `firebase functions:config`/inspeccion del parameter desplegado + smoke de una callable user-facing).
+
+#### `GITHUB_OWNER` / `GITHUB_REPO` (decision PRD: permanecen en `.env`)
+
+No son secretos (metadata publica del repo). Ya consumidos via `defineString` en `feedback.ts:9,12`. **Permanecen en `functions/.env`**. No se toca `.gitignore` (la linea `!functions/.env` en `.gitignore:29` se mantiene). Solo se actualiza el comentario de cabecera del `.env` para reflejar que ya no contiene valores sensibles.
+
+### S1 / S2 — bumps de dependencias
+
+Sin cambios de codigo de runtime (verificado: la API declarativa de react-router no cambia entre 7.13 y 7.14). `firebase-admin` bump: `.value()`/API sin cambios para el codigo del proyecto.
+
+## Integracion
+
+S4 es transparente: `FeedbackMediaPreview.tsx` y `MyFeedbackList.tsx` siguen llamando `isValidStorageUrl(url)` sin cambios. S3 es config server-side. S1/S2 son `package.json`/`package-lock.json`.
+
+### Preventive checklist
+
+- [x] **Service layer**: ningun componente importa `firebase/firestore` para writes. No aplica.
+- [x] **Duplicated constants**: el regex de S4 vive solo en `media.ts`. No se duplica.
+- [x] **Context-first data**: sin `getDoc` nuevos.
+- [x] **Silent .catch**: no se introduce ningun `.catch(() => {})`.
+- [x] **Stale props**: sin componentes que muten props.
+
+## Tests
+
+| Archivo test | Que testear | Tipo |
+|-------------|-------------|------|
+| `src/utils/media.test.ts` (ampliar) | Aceptar URL canonica con `/v0/b/<bucket>/o/`; rechazar host valido sin segmento `/v0/b/.../o/`; preservar guards prefix-bypass, scheme-confusion (`http://`), arbitrary-content-before-prefix, typeof no-string, empty string; bucket generico `[^/]+` acepta cualquier bucket bien formado | Util (existente) |
+| `src/main.test.ts` (regresion) | Verde post-bump react-router (smoke de montaje del router) | Integracion routing |
+| `functions/src/__tests__/admin/claims.test.ts` (ajustar mock) | Verde post-cambio `defineString`→`defineSecret` de `ADMIN_EMAIL`; ampliar el mock de `firebase-functions/params` para exportar `defineSecret` con `{ value: () => 'admin@test.com' }` | Cloud Function (existente) |
+| `functions/src/__tests__/helpers/env.test.ts` (crear) | Rama `ENFORCE_APP_CHECK` enabled/disabled con el nuevo mecanismo `defineString('APP_CHECK_ENFORCEMENT').value()`; verificar `default: 'disabled'` → `false`; `'enabled'` → `true`; `IS_EMULATOR=true` → siempre `false` | Helper (nuevo) |
+
+### Mock strategy
+
+- `media.test.ts`: sin mocks (funcion pura).
+- `claims.test.ts`: ya mockea `firebase-functions/params`; extender el factory mock para incluir `defineSecret`.
+- `env.test.ts`: mockear `firebase-functions/params` (`defineString`) + setear/limpiar `process.env.FUNCTIONS_EMULATOR`. Reset de modulo entre casos (`vi.resetModules()`) porque `ENFORCE_APP_CHECK` se evalua al import.
+
+### Criterios
+
+- Cobertura >= 80% del codigo modificado. `media.ts` debe cubrir las 3 ramas del nuevo check (host+segmento ok / host ok sin segmento / no-string).
+- Suites de routing verdes post-bump (regresion S1).
+- `npm audit` post-bump no lista las 3 advisories de react-router (S1) ni las HIGH de runtime de functions (S2).
+
+## Analytics
+
+Sin `logEvent`/`trackEvent` nuevos.
+
+---
+
+## Offline
+
+Ningun cambio afecta flujos online/offline. `isValidStorageUrl` es sincrona y no hace I/O.
+
+### Cache strategy
+
+| Dato | Estrategia | TTL | Storage |
+|------|-----------|-----|---------|
+| (sin cambios) | — | — | — |
+
+### Writes offline
+
+| Operacion | Mecanismo | Conflict resolution |
+|-----------|-----------|-------------------|
+| (sin cambios) | — | — |
+
+### Fallback UI
+
+Sin cambios. Si `isValidStorageUrl` rechaza una URL, el preview no se renderiza (comportamiento actual de `FeedbackMediaPreview`).
+
+---
+
+## Accesibilidad y UI mobile
+
+Sin componentes interactivos nuevos. No aplica la tabla de aria-labels / touch targets.
+
+### Reglas
+
+No hay `<IconButton>`, `<Typography onClick>`, ni `<img>` con URL dinamica nuevos. El render de media existente no cambia su markup.
+
+## Textos y copy
+
+Sin textos user-facing nuevos. No aplica voseo/tildes (no hay strings nuevos).
+
+---
+
+## Decisiones tecnicas
+
+1. **S2 — el invariante de audit se redefine en TEXTO, NO se convierte en gate duro de CI (observacion Sofia).** Verificado: `deploy.yml:20-21` y `deploy-staging.yml:22-23` corren `npm audit --audit-level=high` con `continue-on-error: true` — ya es un soft-gate documentado (`devops.md:98`). Este PRD NO convierte el audit en gate duro (romperia el pipeline ante cualquier vuln dev/CLI transitiva, fuera de scope y riesgo alto dado #168). S2 actualiza el **texto del invariante documentado** en `devops.md` para distinguir: runtime (functions: debe ser 0 vulns HIGH, verificable con `cd functions && npm audit --audit-level=high` exit 0) vs dev/CLI transitivas en root (documentadas con justificacion, el `continue-on-error` se mantiene). El Success Criteria #3 del PRD ya contempla esta salida ("o el invariante queda redefinido").
+
+2. **S4 — bucket generico `[^/]+`, no exacto.** Mantiene `media.ts` pura (sin leer `import.meta.env`), evita romper render de `mediaUrl` legacy que pudiera apuntar a otro bucket, y delega la autorizacion real a la rule de write. Condicionado a la verificacion de plan "no-legacy-bucket"; si la verificacion sale limpia, endurecer a exacto queda como followup opcional.
+
+3. **S4 — cliente y rule son validaciones independientes (observacion Sofia).** La rule (`firestore.rules:222`) valida path encoded (`%2F`) + ownership con `.*` y NO ancla `/v0/b/`. El cliente valida host + `/v0/b/<bucket>/o/` decodificado. No se replica ni se cambia la rule. Dos capas complementarias.
+
+4. **S3 `ADMIN_EMAIL` → `defineSecret`.** Reusa el patron `secrets:` array de `analyticsReport.ts`. La API `.value()` es identica a `defineString`, cambio minimo en `claims.ts`.
+
+5. **S3 `APP_CHECK_ENFORCEMENT` → Opcion A (`defineString` + `.value()`), no Opcion B.** Verificado que staging y prod despliegan functions al MISMO proyecto `modo-mapa-app` con un unico deploy — Opcion B (`--set-env-vars` por entorno) no aporta separacion sin rework de CI fuera de scope. Opcion A es drop-in y `env.ts:17` es el unico lector. `default: 'disabled'` preserva el invariante "unset → disabled".
+
+6. **`ADMIN_EMAIL` no es rotable (observacion Sofia).** Es una identidad (email), no un token. Removerlo del `.env` reduce exposicion en HEAD pero el valor persiste en historial (repo publico desde 2026-03-15). Purga de historial fuera de scope. El vector de hijack ya esta cerrado por el bootstrap gate #322 R14 (`claims.ts:36-48`, verificado).
+
+---
+
+## Hardening de seguridad
+
+### Firestore rules requeridas
+
+Ninguna rule nueva ni modificada. La rule de `feedback` (`firestore.rules:206-244`) ya tiene `hasOnly()` en create, `affectedKeys().hasOnly()` en update, type guards y validacion de `mediaUrl` por ownership. No se toca.
+
+### Rate limiting
+
+Sin colecciones nuevas escribibles. No aplica rate limit nuevo. `setAdminClaim` deliberadamente no tiene rate limit (documentado en `claims.ts:13-17`, threat model #322 S5) — no cambia.
+
+### Vectores de ataque mitigados
+
+| Ataque | Mitigacion | Archivo |
+|--------|-----------|---------|
+| Open redirect (`//evil.com`, GHSA-2j2x-hqr9-3h42) | Bump react-router `>=7.14.2` (S1) | `package.json` |
+| turbo-stream RCE / RSC XSS (GHSA-49rj-9fvp-4h2h, GHSA-8646-j5j9-6r62) | Bump react-router `>=7.14.2` (S1); no alcanzables con API declarativa pero parchados | `package.json` |
+| `ADMIN_EMAIL` scrapeado del repo publico → phishing dirigido | Mover a Secret Manager (S3, `defineSecret`); hijack ya cerrado por bootstrap gate #322 R14 | `functions/.env`, `claims.ts` |
+| `mediaUrl` falsificada que pasa el prefix-check pero no apunta a un objeto de Storage | Endurecer `isValidStorageUrl` a `/v0/b/<bucket>/o/` (S4) + rule de write valida path canonico (defense-in-depth) | `src/utils/media.ts`, `firestore.rules:222` |
+| RCE/parsing en dependencia transitiva runtime (protobufjs via firebase-admin) | Bump `firebase-admin` (S2), verificar `cd functions && npm audit --audit-level=high` exit 0 | `functions/package.json` |
+
+---
+
+## Deuda tecnica: mitigacion incorporada
+
+`gh issue list --label security/tech debt`: el PRD documenta que no hay labels formales `security`/`tech debt`; el backlog tiene `Tech debt:` #341-#349 (de `/health-check`) + #168.
+
+| Issue | Que se resuelve | Paso del plan |
+|-------|----------------|---------------|
+| #300 (secrets en Secret Manager) | `ADMIN_EMAIL` + `APP_CHECK_ENFORCEMENT` fuera del `.env` publico | Fase 3 |
+| #322 R14 (bootstrap gate) | Ya mitiga hijack si `ADMIN_EMAIL` se compromete; S3 reduce superficie de exposicion. No se toca | (refuerzo, sin paso) |
+| #168 (Vite 8 / ESLint 10 por peer deps) | NO se desbloquea — S2 se limita a patches que no rompan peer deps | Fase 2 (constraint) |
+| #342 (este) | Cierra H-1, H-2, H-3, M-1, M-2 | Todas las fases |
+
+Nota: `devops.md:34` tiene una referencia stale (`defineString ... en backups.ts`) — el codigo real esta en `claims.ts`. Corregir esta linea como parte de la Fase de documentacion (no agravar deuda de doc en un archivo que ya tocamos).
+
+---
+
+## Validacion Tecnica
+
+**Arquitecto**: Diego
+**Fecha**: 2026-06-10
+**Estado**: VALIDADO CON OBSERVACIONES
+
+### Hallazgos cerrados en esta iteracion
+
+- BLOQUEANTE: "`defineSecret('ADMIN_EMAIL').value()` solo resuelve en runtime si el secret esta en el array `secrets:` de la funcion" → resuelto. Verificado en codigo: `claims.ts:34` llama `ADMIN_EMAIL_PARAM.value()` DENTRO del handler de `setAdminClaim` (no a nivel modulo). La Fase 3 del plan exige agregar `secrets: ['ADMIN_EMAIL']` al config de `onCall` ANTES de cambiar `defineString`→`defineSecret`, y que `.value()` NO se invoque a top-level. Patron identico a `analyticsReport.ts:160` (`secrets: ['GA4_PROPERTY_ID']` + lectura dentro del handler).
+- IMPORTANTE: "`defineString('APP_CHECK_ENFORCEMENT')` migra de `process.env` a `.value()` — verificar que `env.ts:17` evalua a top-level del modulo, no en handler" → resuelto. `ENFORCE_APP_CHECK` se evalua al import del modulo (top-level). `defineString.value()` (a diferencia de `defineSecret`) SI resuelve a top-level desde el parameter/`.env`, por lo que la migracion es drop-in. Esto es la razon tecnica adicional por la que `APP_CHECK_ENFORCEMENT` debe ser `defineString` y NO `defineSecret` (un secret no resolveria a top-level y romperia el modulo). Documentado en la decision tecnica #5 y reforzado en la Fase 3 del plan.
+- IMPORTANTE: "Riesgo de activar App Check en staging por error de mecanismo (observacion Sofia)" → resuelto. Verificado: ambos pipelines (`deploy.yml:88`, `deploy-staging.yml:97`) despliegan al MISMO proyecto `modo-mapa-app`. No hay separacion de instancia. El valor efectivo post-migracion debe seguir siendo `enabled` (la unica instancia). El `default: 'disabled'` solo aplica si el parameter no esta provisionado. La Fase 3 incluye un paso de smoke empirico (`validar ENFORCE_APP_CHECK === false en emulador con FUNCTIONS_EMULATOR=true` + inspeccion del parameter desplegado) como red de seguridad. El invariante `!IS_EMULATOR` no se toca, garantizando emuladores=disabled siempre.
+- OBSERVACION: "S4 bucket generico vs exacto depende de no-legacy-bucket" → resuelto. La decision (generico `[^/]+`) ya esta condicionada al paso de verificacion empirica de la Fase 4 (query a `feedback` para confirmar que no hay `mediaUrl` con bucket distinto). El generico es el default seguro independiente del resultado; el exacto queda como followup opcional solo si la query sale limpia.
+- OBSERVACION: "`devops.md:34` referencia stale `backups.ts`" → confirmado el stale (`ADMIN_EMAIL ... defineString en backups.ts`; el codigo real esta en `claims.ts`). Fix incluido en la Fase de documentacion (Fase 5).
+
+### Observaciones tecnicas abiertas para el plan
+
+- El orden de la Fase 3 es critico: (1) provisionar secret/parameter en Secret Manager ANTES de remover del `.env`; (2) agregar `secrets:` array ANTES de cambiar a `defineSecret`; (3) deploy + smoke ANTES de mergear. Pablo debe verificar que el plan respeta esta secuencia (un orden invertido deja la funcion sin valor en runtime).
+- S2: el invariante de audit se redefine en TEXTO (no gate duro). Confirmado que `continue-on-error: true` se mantiene. Pablo debe verificar que la Fase 2 no introduce un cambio de `deploy.yml` que rompa el pipeline.

--- a/docs/feat/ux/345-techdebt-chips-touch-targets-fab-safe-area/plan.md
+++ b/docs/feat/ux/345-techdebt-chips-touch-targets-fab-safe-area/plan.md
@@ -1,0 +1,179 @@
+# Plan: Tech debt ui-ux — chips ad-hoc (R5/R8), touch targets <44px y FAB sin safe-area
+
+**PRD:** [prd.md](prd.md)
+**Specs:** [specs.md](specs.md)
+**Issue:** #345
+**Fecha:** 2026-06-12
+
+---
+
+## Estrategia
+
+Deuda técnica de UI agrupada en 3 bloques (S1/S2/S3). Una sola rama desde `new-home`. Sin worktree: los 9 archivos son independientes entre sí (ningún archivo se toca en más de un bloque). Riesgo bajo: solo `sx`/posición, sin lógica, sin Firestore, sin tests nuevos. El gate de regresión es el guard `check-chip-height.mjs` (exit 0).
+
+**Branch:** `fix/345-chips-touch-targets-fab-safe-area`
+
+---
+
+## Estimación de tamaño de archivos
+
+| Archivo | Líneas actuales (aprox) | Δ | ¿>400? |
+|---------|------------------------|---|--------|
+| `BusinessComments.tsx` | ~290 | +1 import, ±0 | No |
+| `BusinessQuestions.tsx` | ~280 | +1 import | No |
+| `QuestionAnswerThread.tsx` | ~150 | +1 import | No |
+| `TrendingBusinessCard.tsx` | ~80 | +1 import, -1 (icono) | No |
+| `VerificationBadge.tsx` | ~90 | +1 import, neto -3 (sx más corto) | No |
+| `UserProfileContent.tsx` | ~200 | +1 import | No |
+| `FilterChips.tsx` | 71 | +2 (minHeight/minWidth) | No |
+| `BusinessTags.tsx` | ~230 | ±0 (mismo `sx`, +2 props) | No |
+| `LocationFAB.tsx` | 33 | ±0 | No |
+
+Ningún archivo se acerca a 400 líneas. Sin decomposición necesaria.
+
+---
+
+## Fases de implementación
+
+### Fase 1: S1 — Migrar los 6 chips a `CHIP_SMALL_SX` (Alta)
+
+**Branch:** `fix/345-chips-touch-targets-fab-safe-area`
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/components/business/BusinessComments.tsx` | Agregar `import { CHIP_SMALL_SX } from '../../theme/cards';`. En el Chip que abre en :262, reemplazar `sx={{ height: 24, fontSize: '0.7rem' }}` (:269) por `sx={CHIP_SMALL_SX}`. |
+| 2 | `src/components/business/BusinessQuestions.tsx` | Agregar import. Reemplazar `sx={{ height: 20, fontSize: '0.65rem', mb: 0.5 }}` (:264) por `sx={{ ...CHIP_SMALL_SX, mb: 0.5 }}`. |
+| 3 | `src/components/business/QuestionAnswerThread.tsx` | Agregar import. Reemplazar `sx={{ height: 20, fontSize: '0.65rem', mb: 0.5 }}` (:130) por `sx={{ ...CHIP_SMALL_SX, mb: 0.5 }}`. |
+| 4 | `src/components/home/TrendingBusinessCard.tsx` | Agregar import. Reemplazar `sx={{ fontSize: '0.7rem', height: 24 }}` (:67) por `sx={CHIP_SMALL_SX}`. Quitar `sx={{ fontSize: 14 }}` del `<Icon>` (:63) → `<Icon />` (obs #2: el token ya fija `fontSize: 14` en `.MuiChip-icon`). |
+| 5 | `src/components/social/VerificationBadge.tsx` | Agregar import. Reemplazar el `sx` ad-hoc (:38-44) por `sx={{ ...CHIP_SMALL_SX, borderColor: badge.earned ? GOLD_HEX : undefined, bgcolor: badge.earned ? goldBg : undefined }}`. Se eliminan `height`, `fontSize` y `'& .MuiChip-label': { px: 0.75 }` (el token aporta `px: 1`). |
+| 6 | `src/components/user/UserProfileContent.tsx` | Agregar import. Reemplazar `sx={{ fontSize: '0.7rem', height: 22 }}` (:69) por `sx={CHIP_SMALL_SX}`. |
+| 7 | — | Correr `node scripts/guards/lib/check-chip-height.mjs` → debe salir **exit 0** (las 6 violaciones cerradas). |
+| 8 | — | Correr `npx tsc --noEmit` → sin errores por los imports nuevos. |
+
+**Commit:** `fix(#345): migrate 6 ad-hoc chips to CHIP_SMALL_SX (R5/R8)`.
+
+### Fase 2: S2 — Touch targets 44x44 (Media)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/components/search/FilterChips.tsx` | En el helper `chipSx(isActive)` agregar `minHeight: 44, minWidth: 44`. Aplica a chips de tag y precio (ambos ya usan `sx={chipSx(isActive)}`). |
+| 2 | `src/components/business/BusinessTags.tsx` | En el chip clicable (:194) reemplazar `sx={{ opacity: isVisible ? 1 : 0.6, borderRadius: 1 }}` por `sx={{ opacity: isVisible ? 1 : 0.6, borderRadius: 1, minHeight: 44, minWidth: 44 }}`. |
+| 3 | — | Verificación visual DevTools 360px: fila de filtros de `FilterChips` no se solapa con el contenido inferior ni recorta chips; chips de `BusinessTags` mantienen densidad del header. Si `FilterChips` muestra solapamiento → aplicar plan B (pseudo-elemento táctil, ver specs). |
+| 4 | — | Re-correr `node scripts/guards/lib/check-chip-height.mjs` → sigue exit 0 (`minHeight`/`minWidth` no disparan el guard; verificado: `/\bheight\s*:/` no matchea `minHeight`). |
+
+**Commit:** `fix(#345): enforce 44x44 touch targets in FilterChips + BusinessTags (WCAG 2.5.5)`.
+
+### Fase 3: S3 — FAB safe-area (Media)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `src/components/map/LocationFAB.tsx` | Reemplazar `bottom: 24` (:16) por `bottom: 'calc(24px + env(safe-area-inset-bottom))'`. Preservar `aria-label`, `position: absolute`, `right: 16`, `zIndex` y demás `sx`. |
+| 2 | — | Verificación visual en emulador con notch: el FAB queda por encima del home indicator. |
+
+**Commit:** `fix(#345): LocationFAB respects safe-area-inset-bottom`.
+
+### Fase 4: Verificación + build
+
+| Paso | Comando | Criterio |
+|------|---------|----------|
+| 1 | `node scripts/guards/lib/check-chip-height.mjs` | exit 0 |
+| 2 | `npm run guards` | sin nuevas violaciones |
+| 3 | `npx tsc --noEmit` (o `npm run build`) | sin errores |
+| 4 | `npm run lint` | sin errores nuevos |
+| 5 | `npm run test:run` | tests existentes no rompen |
+
+### Fase 5: Documentación (obligatoria)
+
+| Paso | Archivo | Cambio |
+|------|---------|--------|
+| 1 | `docs/reference/patterns.md` | Confirmar nota de `CHIP_SMALL_SX` (ya documenta spread): agregar que la adopción se completó en los 6 chips restantes (#345). Sin cambio de patrón. |
+| 2 | `docs/_sidebar.md` | Agregar entradas PRD/Specs/Plan de #345 bajo categoría **UX**. |
+
+Filas no aplicables eliminadas: `security.md` (no toca rules/auth/storage), `firestore.md` (no toca datos), `features.md` (no es feature de usuario, es deuda de estilo), `project-reference.md` (sin cambio de funcionalidad), `HelpSection.tsx` (sin cambio visible de comportamiento).
+
+---
+
+## Orden de implementación
+
+1. **Fase 1 (S1)** — 6 chips a `CHIP_SMALL_SX`. Es el bloque que cierra el guard (Success Criteria #1). Hacer primero para validar el gate.
+2. **Fase 2 (S2)** — touch targets. Independiente de S1 (archivos distintos).
+3. **Fase 3 (S3)** — FAB safe-area. Independiente.
+4. **Fase 4** — verificación cruzada (guard + tsc + lint + tests).
+5. **Fase 5** — docs + sidebar.
+
+Las 3 fases de código son paralelizables (sin archivos compartidos), pero el orden propuesto valida el gate primero.
+
+## Riesgos
+
+1. **`FilterChips` scroller crece en alto con `minHeight: 44`.** Mitigación: el scroller solo tiene `overflowX: auto` (no `overflowY`), así que crece sin scroll vertical; verificación visual en 360px en Fase 2 paso 3; plan B (pseudo-elemento táctil) documentado en specs si hay solapamiento.
+2. **Diffs cosméticos de fontSize (obs #3).** Crecimientos de 1-2px aceptados en el PRD; se confirman en la revisión visual (legibilidad, sin solapamiento).
+3. **Limpieza del icono en TrendingBusinessCard (obs #2).** Si el slot `.MuiChip-icon` no aplicara `fontSize: 14`, revertir a dejar el `sx` inline del `<Icon>`. No bloqueante.
+
+## Guardrails de modularidad
+
+- [x] Ningún componente nuevo importa `firebase/firestore` (solo `theme/cards`).
+- [x] Archivos nuevos: ninguno; los 9 modificados están en su carpeta de dominio correcta.
+- [x] Lógica de negocio: no se agrega (solo `sx`).
+- [x] Se toca deuda técnica (#345) — el fix ES el plan; no se agrava deuda.
+- [x] Ningún archivo resultante supera 400 líneas (ver tabla de estimación).
+
+## Guardrails de seguridad
+
+- [x] No hay colección nueva, callable, rule ni rate limit (no aplica `hasOnly`/`affectedKeys`).
+- [x] No hay secrets, admin emails ni credenciales en el diff (revisar antes de commit — repo público).
+- [x] No se usa `getCountFromServer`.
+
+## Guardrails de observabilidad
+
+- [x] No hay CF trigger nuevo (no aplica `trackFunctionTiming`).
+- [x] No hay service nuevo con queries (no aplica `measureAsync`).
+- [x] No hay `trackEvent` nuevo; los existentes se preservan.
+- [x] No se agrega `logger.error` dentro de `if (import.meta.env.DEV)`.
+
+## Guardrails de accesibilidad y UI
+
+- [x] No se agregan `<IconButton>` (los existentes con `aria-label` se preservan).
+- [x] No hay `<Typography onClick>`.
+- [x] Touch targets: S2 garantiza 44x44 en ambos ejes; no se usa `p: 0.25` ni `width: 32`.
+- [x] Componentes con fetch: sin cambios en error state.
+- [x] `<img>` dinámica: N/A.
+- [x] httpsCallable: ninguno.
+
+## Guardrails de copy
+
+- [x] Sin textos nuevos.
+- [x] Tildes/voseo: sin cambios de copy.
+- [x] Terminología consistente: sin cambios.
+
+## Criterios de done
+
+- [ ] `node scripts/guards/lib/check-chip-height.mjs` retorna exit 0 (las 6 violaciones de S1 cerradas).
+- [ ] Chips clicables de `FilterChips` y `BusinessTags` tienen área táctil >=44x44px sin romper densidad ni introducir scroll vertical.
+- [ ] `LocationFAB` usa `bottom: 'calc(24px + env(safe-area-inset-bottom))'`.
+- [ ] `npx tsc --noEmit`, `npm run guards` y `npm run lint` pasan sin errores ni nuevas violaciones.
+- [ ] `npm run test:run` no rompe tests existentes.
+- [ ] Verificación visual manual en mobile/emulador con notch (chips no se solapan, FAB alcanzable).
+- [ ] `docs/reference/patterns.md` y `docs/_sidebar.md` actualizados.
+
+---
+
+## Validacion de Plan
+
+**Validador:** Pablo (Delivery Lead — Modo Mapa)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Ciclo:** 1
+
+**Observaciones para el implementador:**
+
+1. **Ratchet de baseline atado al commit de S1 (IMPORTANTE).** `.guards-baseline.json` tiene `305/R5-chip-height-adhoc: 6`. Al cerrar las 6 violaciones (Fase 1), el merge skill (Phase 0a/0a-bis) exige `npm run guards:baseline` + `git add .guards-baseline.json` y commitear el baseline EN EL MISMO COMMIT que el codigo de S1. El plan define el gate como "guard exit 0" pero no agenda el ratchet; el implementador debe incluir `.guards-baseline.json` en el commit de Fase 1 (no en commit/rama aparte), si no la reduccion 6->0 no queda lockeada.
+
+2. **Orden atomico S1 -> guard exit 0 -> ratchet -> commit (IMPORTANTE).** Aplicar los 6 archivos, confirmar guard exit 0, recien entonces ratchear baseline y commitear todo junto. El ratchet depende de que S1 ya este aplicado.
+
+3. **Verificacion visual 360px: dueno y solapamiento con ViewToggle (OBSERVACION).** Diego marco que la fila de FilterChips comparte ancho con el ViewToggle hermano via `gap:1` y `minWidth:0`. El check manual a 360px (Fase 2 paso 3) lo ejecuta luna ANTES de cerrar S2 — no hay E2E que lo capture, no se difiere al merge. Verificar explicitamente solapamiento/recorte contra ViewToggle, no solo "contenido inferior". Plan B (pseudo-elemento tactil) aplicable en la misma Fase 2 si se detecta solapamiento.
+
+4. **Estimacion por fase (OBSERVACION).** El plan no asigna S/M/L por bloque. Reparto coherente con el "S" total del PRD: Fase 1 = M (6 archivos + ratchet, el grueso), Fase 2/3/4/5 = S. Ningun bloque introduce logica, tests ni datos.
+
+**Nota:** El plan es solido en orden de fases, granularidad (1 commit logico por bloque), file ownership (9 archivos sin overlap entre S1/S2/S3, una sola rama) y risk staging (cambios reversibles, sin schema/rules/datos). Rama `fix/345`: el merge skill corre TODAS las guards 1a-1p + auditoria reducida (security/architecture/performance), no solo guard+tsc — el plan ya las contempla en Fase 4. Sin BLOQUEANTES. Las 4 observaciones no impiden implementar; el ratchet (#1/#2) lo refuerza el propio merge skill aunque el plan no lo agende.
+
+**Listo para pasar a implementacion:** Si, con observaciones.

--- a/docs/feat/ux/345-techdebt-chips-touch-targets-fab-safe-area/prd.md
+++ b/docs/feat/ux/345-techdebt-chips-touch-targets-fab-safe-area/prd.md
@@ -1,0 +1,319 @@
+# PRD: Tech debt ui-ux — chips ad-hoc (R5/R8), touch targets <44px y FAB sin safe-area
+
+**Feature:** 345-techdebt-chips-touch-targets-fab-safe-area
+**Categoria:** ux
+**Fecha:** 2026-06-09
+**Issue:** #345
+**Prioridad:** Media (severidad MEDIUM en el reporte /health-check)
+
+---
+
+## Contexto
+
+El guard `scripts/guards/lib/check-chip-height.mjs` (multiline-aware) reporta **6 chips** que evaden el token de diseño `CHIP_SMALL_SX` (introducido en #326) usando `height`/`fontSize` ad-hoc, más superficies con touch targets bajo el mínimo WCAG 2.5.5 (44x44px) y un FAB que no respeta `env(safe-area-inset-bottom)`. Son violaciones de las reglas R5/R8 del Guard #305 y observaciones de accesibilidad mobile que ya tienen patrón canónico establecido en el proyecto (`CHIP_SMALL_SX` en `theme/cards.ts`, `pb: 'calc(24px + env(safe-area-inset-bottom))'` en BusinessSheet/BusinessDetailScreen).
+
+Output del guard al 2026-06-10 (6 violaciones en 6 archivos):
+
+- `src/components/business/BusinessComments.tsx:262`
+- `src/components/business/BusinessQuestions.tsx:259` (chip "Mejor respuesta" — DUPLICADO de QuestionAnswerThread)
+- `src/components/business/QuestionAnswerThread.tsx:125`
+- `src/components/home/TrendingBusinessCard.tsx:61`
+- `src/components/social/VerificationBadge.tsx:34`
+- `src/components/user/UserProfileContent.tsx:64`
+
+## Problema
+
+- **Seis** chips definen `height`/`fontSize` inline en vez de usar `CHIP_SMALL_SX`, lo que reabre el Guard #305 R5/R8 y desincroniza la altura de chips chicos con el resto de la app: `BusinessComments.tsx:262`, `BusinessQuestions.tsx:259`, `QuestionAnswerThread.tsx:125`, `TrendingBusinessCard.tsx:61`, `VerificationBadge.tsx:34`, `UserProfileContent.tsx:64`. El chip "Mejor respuesta" está **duplicado** en `BusinessQuestions.tsx:259` y `QuestionAnswerThread.tsx:125` (markup idéntico, `sx={{ height: 20, fontSize: '0.65rem', mb: 0.5 }}`). Todos evadieron el grep canónico single-line por estar `<Chip` y `height:` en líneas separadas; el detector multiline-aware los detecta.
+- Chips clicables en `FilterChips.tsx` (filtros de tags y precio) y `BusinessTags.tsx:186-195` no garantizan touch target de 44x44px en mobile, violando WCAG 2.5.5 (target size). Son elementos de uso frecuente (filtrado del mapa, etiquetado de comercios).
+- `LocationFAB.tsx` posiciona el FAB con `bottom: 24` fijo, sin sumar `env(safe-area-inset-bottom)`. En dispositivos con home indicator (iPhone X+) el FAB puede quedar parcialmente tapado, dificultando el tap de "Mi ubicación".
+
+## Solucion
+
+Migración de deuda técnica acotada a 8 archivos de componente (6 para los chips de S1 + `FilterChips`/`BusinessTags` para S2 + `LocationFAB` para S3), sin lógica de negocio nueva. El detector multilínea recomendado por el issue (`scripts/guards/lib/check-chip-height.mjs`) **ya existe** y es multiline-aware: este feature corrige las **6 violaciones** que el detector endurecido reporta, cerrando el loop audit → guard.
+
+### S1 — Migrar los 6 chips ad-hoc a `CHIP_SMALL_SX` (R5/R8)
+
+El token canónico (`src/theme/cards.ts`) define: `height: 24`, `fontSize: '0.75rem'`, `'& .MuiChip-icon': { fontSize: 14, ml: 0.5 }`, `'& .MuiChip-label': { px: 1 }`. Cada migración hace spread del token y preserva únicamente los overrides específicos del caso. En los 6 archivos hay que **agregar el import** `import { CHIP_SMALL_SX } from '../../theme/cards';` (los 6 están en `src/components/<dominio>/`, profundidad relativa `../../`; ninguno lo importa hoy).
+
+- **`BusinessComments.tsx:262` (chips de orden "Recientes/Antiguos/Útiles")**: reemplazar `sx={{ height: 24, fontSize: '0.7rem' }}` por `sx={CHIP_SMALL_SX}`. El token mantiene `height: 24` (idéntico) y unifica `fontSize` a `0.75rem` (vs `0.7rem`, diferencia cosmética menor aceptable). Sin overrides necesarios.
+- **`BusinessQuestions.tsx:259` (chip "Mejor respuesta" — DUPLICADO de QuestionAnswerThread)**: reemplazar `sx={{ height: 20, fontSize: '0.65rem', mb: 0.5 }}` por `sx={{ ...CHIP_SMALL_SX, mb: 0.5 }}`. El token sube `height` 20→24 y `fontSize` 0.65rem→0.75rem; `mb: 0.5` se preserva como override válido. **Markup idéntico** al de `QuestionAnswerThread.tsx:125` — misma migración en ambos (no se deduplica el componente en este PRD; ver Out of Scope).
+- **`QuestionAnswerThread.tsx:125` (chip "Mejor respuesta")**: misma migración que el anterior — `sx={{ height: 20, fontSize: '0.65rem', mb: 0.5 }}` → `sx={{ ...CHIP_SMALL_SX, mb: 0.5 }}`.
+- **`TrendingBusinessCard.tsx:61` (chips de breakdown con icono)**: reemplazar `sx={{ fontSize: '0.7rem', height: 24 }}` por `sx={CHIP_SMALL_SX}`. El token incluye `'& .MuiChip-icon': { fontSize: 14, ml: 0.5 }`, coherente con el `<Icon sx={{ fontSize: 14 }} />` ya presente (queda redundante pero no conflictivo; opcionalmente quitar el `sx` inline del icono en specs). Sin overrides necesarios.
+- **`VerificationBadge.tsx:34` (rama `compact`, líneas 38-44)**: reemplazar el `sx` ad-hoc (`fontSize: '0.75rem', height: 24, borderColor, bgcolor, '& .MuiChip-label': { px: 0.75 }`) por `sx={{ ...CHIP_SMALL_SX, borderColor: badge.earned ? GOLD_HEX : undefined, bgcolor: badge.earned ? goldBg : undefined }}`. El token ya provee `height: 24`, `fontSize: '0.75rem'` y `'& .MuiChip-label': { px: 1 }` (vs `px: 0.75` actual — diferencia cosmética menor, aceptable). Se preservan los overrides de color de la medalla de oro (`borderColor`, `bgcolor`) específicos del badge.
+- **`UserProfileContent.tsx:64` (chip de medalla/ranking)**: reemplazar `sx={{ fontSize: '0.7rem', height: 22 }}` por `sx={CHIP_SMALL_SX}`. El token sube `height` 22→24 y unifica `fontSize` 0.7rem→0.75rem. Sin overrides necesarios.
+- Patrón aplicado: convención documentada en patterns.md — "Si un chip necesita override puntual, hacer spread: `sx={{ ...CHIP_SMALL_SX, mb: 0.5 }}`"; si no, `sx={CHIP_SMALL_SX}` directo.
+
+### S2 — Touch targets >=44x44px en chips clicables (WCAG 2.5.5)
+
+WCAG 2.5.5 (Target Size, Level AAA) exige que el área accionable sea **>=44px en ambos ejes** (44x44). El criterio de este feature es por lo tanto bidimensional: el target efectivo debe medir >=44px de alto **y** >=44px de ancho. Como los chips de filtro/tag son pequeños (alto ~24-32px) y de ancho variable según el label, la solución debe garantizar ambos mínimos sin agrandar visualmente el chip (densidad del header/scroller).
+
+- **`FilterChips.tsx`**: los chips de tag y precio usan `size` default de MUI (~32px de alto). Para alcanzar 44x44 de target mínimo sin agrandar visualmente todos los chips, las opciones (a evaluar en specs) son: (a) `minHeight: 44, minWidth: 44` en el `chipSx` helper compartido — garantiza ambos ejes pero altera el alto visual; (b) mantener el alto visual y expandir el área táctil con padding/pseudo-elemento (`::before` con `min(44px)`) o un wrapper táctil de 44x44 envolviendo el chip. El criterio es: el área accionable efectiva debe ser **>=44px en alto y >=44px en ancho**. La decisión concreta queda para specs.
+- **`BusinessTags.tsx:186-195`**: el `<Chip size="small">` (target ~24px de alto) es clicable (`onClick={handleToggleTag}`). El `IconButton` hermano ya tiene `minWidth: 44, minHeight: 44` (línea 202), pero el chip no. Aplicar el mismo mínimo de touch target bidimensional al chip clicable. Nota: este chip usa `size="small"` deliberadamente por densidad visual en el header de comercio; la solución debe expandir el target en ambos ejes sin romper la densidad — se define en specs (padding/wrapper táctil vs `minHeight`/`minWidth`).
+- Patrón aplicado: el proyecto ya usa `minWidth: 44, minHeight: 44` en IconButtons (ej. `BusinessTags.tsx:202`) — el umbral 44x44 bidimensional ya existe en el repo. Se reutiliza el mismo umbral en ambos ejes.
+- **Riesgo a validar en specs** (observación de la pre-revisión): si los chips viven en un contenedor con `overflowX: auto`, un `minHeight: 44` no debe introducir scroll vertical no deseado; medir antes de elegir la estrategia.
+
+### S3 — FAB con safe-area-inset-bottom
+
+- **`LocationFAB.tsx:14-24`**: cambiar `bottom: 24` por `bottom: 'calc(24px + env(safe-area-inset-bottom))'`. Patrón idéntico al ya usado en `BusinessSheet.tsx:105` y `BusinessDetailScreen.tsx:292` (`pb: 'calc(24px + env(safe-area-inset-bottom))'`). El FAB se renderiza en `SearchScreen.tsx:162` sobre el mapa; el fix evita que el home indicator lo tape en dispositivos notch.
+
+### UX / interacción
+
+- Sin cambios de flujo ni de navegación. Los chips "Mejor respuesta" (20→24px), la medalla de ranking (22→24px) y el resto crecen levemente en alto para unificarse con el sistema. Los chips de filtro y tags ganan área táctil 44x44 sin (idealmente) cambiar su apariencia visual. El FAB de ubicación se mueve hacia arriba lo justo para no superponerse con el home indicator.
+- Verificación visual manual en mobile real o emulador con notch (no hay cobertura E2E de layout en el proyecto).
+
+---
+
+## Scope
+
+| Item | Prioridad | Esfuerzo |
+|------|-----------|----------|
+| S1: migrar `BusinessComments.tsx:262` a CHIP_SMALL_SX | Alta | S |
+| S1: migrar `BusinessQuestions.tsx:259` (Mejor respuesta) a CHIP_SMALL_SX | Alta | S |
+| S1: migrar `QuestionAnswerThread.tsx:125` (Mejor respuesta) a CHIP_SMALL_SX | Alta | S |
+| S1: migrar `TrendingBusinessCard.tsx:61` a CHIP_SMALL_SX | Alta | S |
+| S1: migrar `VerificationBadge.tsx:34` (compact) a CHIP_SMALL_SX | Alta | S |
+| S1: migrar `UserProfileContent.tsx:64` a CHIP_SMALL_SX | Alta | S |
+| S2: touch target >=44x44px en `FilterChips.tsx` (tag + precio) | Media | S |
+| S2: touch target >=44x44px en chip clicable de `BusinessTags.tsx` | Media | S |
+| S3: `LocationFAB.tsx` safe-area-inset-bottom | Media | S |
+| Verificar que `check-chip-height.mjs` reporta 0 violaciones post-fix (las 6 cerradas) | Alta | S |
+
+**Esfuerzo total estimado:** S (6 chips en 6 archivos para S1 + 3 archivos para S2/S3)
+
+---
+
+## Out of Scope
+
+- Crear o endurecer el detector de chips ad-hoc — `scripts/guards/lib/check-chip-height.mjs` ya es multiline-aware (cubre el caso `<Chip` + `height:` en líneas separadas). El issue lo recomienda como "endurecer detector" pero ya está implementado; este PRD solo corrige las 6 violaciones que el guard reporta.
+- Deduplicar el chip "Mejor respuesta" entre `BusinessQuestions.tsx` y `QuestionAnswerThread.tsx` en un componente compartido — se migran ambos por separado a `CHIP_SMALL_SX`; extraer un componente común es refactor aparte (no requerido para cerrar el guard).
+- Auditoría exhaustiva de touch targets en toda la app — solo se corrigen las 2 superficies citadas en el issue (`FilterChips`, `BusinessTags`).
+- Rediseño visual de chips, badges o del FAB más allá de los ajustes mínimos de altura/área táctil/posición.
+- Cambios en lógica de filtrado, etiquetado, verificación o geolocalización.
+
+---
+
+## Tests
+
+El proyecto no tiene cobertura de tests de layout/estilo visual (los componentes son mayormente "visual, sin lógica" — excepción de la política de tests.md). Estos cambios son puramente de estilo (`sx`) y no introducen lógica condicional nueva, validación de input ni side effects. Caen bajo la **excepción documentada en tests.md**: "Componentes puramente visuales sin lógica".
+
+El gate de regresión es el guard `check-chip-height.mjs`, no un test unitario.
+
+### Archivos que necesitaran tests
+
+| Archivo | Tipo | Que testear |
+|---------|------|-------------|
+| `scripts/guards/lib/check-chip-height.mjs` | Guard (existente) | Ejecutar `node scripts/guards/lib/check-chip-height.mjs` post-fix → debe salir con código 0 (las 6 violaciones cerradas). Es el test de regresión efectivo. |
+
+No se agregan tests unitarios de Vitest: ninguno de los 6 componentes de chips tiene test existente ni introduce lógica testeable (son cambios de `sx`). Si specs decide expandir touch target con un wrapper con `role`/handler, evaluar ahí si amerita un test de accesibilidad (improbable — no hay infra de a11y testing automatizado en el repo).
+
+### Criterios de testing
+
+- `node scripts/guards/lib/check-chip-height.mjs` retorna exit 0 (0 violaciones) tras S1 — las 6 violaciones actuales cerradas.
+- `npm run guards` (o el runner que invoca `checks.mjs`) pasa sin nuevas violaciones.
+- Build TypeScript (`tsc`) sin errores tras agregar el import de `CHIP_SMALL_SX` en los 6 archivos.
+- Verificación visual manual: chips no se solapan, FAB visible sobre home indicator.
+
+---
+
+## Seguridad
+
+Este feature no toca Firestore, Cloud Functions, Storage, auth, ni inputs de usuario. No escribe ni lee datos. No expone superficie nueva. No agrega colecciones ni callables. La sección de seguridad estándar (Firestore rules, rate limit, moderación) **no aplica**.
+
+- [x] Sin escritura a Firestore (solo cambios de `sx` en componentes)
+- [x] Sin lectura de datos nueva (no permite scraping)
+- [x] Sin inputs de usuario nuevos
+- [x] Sin `dangerouslySetInnerHTML`, `eval`, ni `Function`
+- [x] Sin secretos, API keys ni emails hardcodeados (revisar diff antes de commit — repo público)
+
+### Vectores de ataque automatizado
+
+| Superficie | Ataque posible | Mitigacion requerida |
+|-----------|---------------|---------------------|
+| Ninguna superficie nueva | N/A — cambios solo de estilo visual | N/A |
+
+El feature no expone ninguna superficie atacable por bots/scripts. No hay endpoints, escrituras ni lecturas nuevas.
+
+---
+
+## Deuda tecnica y seguridad
+
+Consulta de issues abiertos (2026-06-09): no hay issues con label `security` ni `tech debt` (los tech-debt usan label `enhancement`). Issues abiertos relacionados por dominio: #346 (copy), #347 (perf), #348/#349 (admin/docs), #344 (offline). Ninguno colisiona con los archivos de este feature.
+
+Este feature **es en sí mismo** la mitigación de deuda técnica (#345). Cierra el loop audit → guard: el guard `check-chip-height.mjs` ya fue endurecido (multiline-aware) y este PRD elimina las 6 violaciones que reporta.
+
+### Issues relacionados
+
+| Issue | Relacion | Accion |
+|-------|----------|--------|
+| #305 Guard R5/R8 (chips ad-hoc) | mitiga | Cerrar las 6 violaciones de `height`/`fontSize` ad-hoc migrando a `CHIP_SMALL_SX` |
+| #326 (introdujo `CHIP_SMALL_SX` y `SearchFab`) | mitiga | Completa la adopción del token en los 6 chips que quedaron fuera del barrido original |
+| #196 / #319 (accesibilidad WCAG) | mitiga | Touch targets >=44x44px alinean con el trabajo de accesibilidad previo |
+
+### Mitigacion incorporada
+
+- Cerrar Guard #305 R5/R8 en los 6 chips (`BusinessComments`, `BusinessQuestions`, `QuestionAnswerThread`, `TrendingBusinessCard`, `VerificationBadge`, `UserProfileContent`) migrando a `CHIP_SMALL_SX` (paso S1 del plan).
+- Cerrar observaciones WCAG 2.5.5 (44x44) en `FilterChips.tsx` y `BusinessTags.tsx` (paso S2).
+- Cerrar observación safe-area en `LocationFAB.tsx` (paso S3).
+- Confirmar que el guard endurecido reporta 0 violaciones (paso de verificación).
+
+---
+
+## Robustez del codigo
+
+Los componentes no hacen operaciones async nuevas en este feature (solo cambian `sx`). El checklist de hooks async no aplica a los cambios. Igualmente se verifica que no se rompa nada existente.
+
+### Checklist de hooks async
+
+- [x] No se agregan `useEffect` con `await` ni handlers async nuevos
+- [x] No hay `setState` post-async nuevo
+- [x] No se exportan funciones nuevas
+- [x] No se crean archivos en `src/hooks/`
+- [x] No se agregan constantes de localStorage
+- [x] Archivos modificados siguen bajo 300 líneas
+- [x] No se agrega `logger.error` dentro de `if (import.meta.env.DEV)`
+
+### Checklist de observabilidad
+
+- [x] No hay Cloud Function trigger nuevo
+- [x] No hay service nuevo con queries Firestore
+- [x] No hay `trackEvent` nuevo (el `trackEvent` existente en `VerificationBadge` se preserva sin cambios)
+
+### Checklist offline
+
+- [x] No hay formularios/dialogs que escriban a Firestore
+- [x] No se agregan error handlers nuevos
+
+### Checklist de documentacion
+
+- [x] No hay secciones nuevas de HomeScreen
+- [x] No hay analytics events nuevos
+- [x] No hay tipos nuevos
+- [ ] `docs/reference/patterns.md`: confirmar que la nota de `CHIP_SMALL_SX` sigue vigente (ya documenta el patrón de spread — no requiere cambios salvo mencionar que la adopción se completó en los 6 chips restantes)
+- [x] `docs/reference/features.md`: sin cambios (no es feature de usuario, es deuda técnica de estilo)
+- [x] `docs/reference/firestore.md`: sin cambios (no toca datos)
+
+---
+
+## Offline
+
+Sin impacto offline. Ninguno de los cambios involucra lectura ni escritura de Firestore, APIs externas ni estado que dependa de conectividad. Los chips de filtro operan sobre data estática local (`PREDEFINED_TAGS`, `PRICE_CHIPS`). El badge de verificación se calcula client-side con cache (sin writes). El FAB de ubicación usa la Geolocation API del browser (ya manejada por `useUserLocation`, fuera de scope).
+
+### Data flows
+
+| Operacion | Tipo (read/write) | Estrategia offline | Fallback UI |
+|-----------|-------------------|-------------------|-------------|
+| Render de chips/FAB | N/A (solo estilo) | N/A | N/A |
+
+### Checklist offline
+
+- [x] Reads de Firestore: ninguno nuevo
+- [x] Writes: ninguno
+- [x] APIs externas: ninguna nueva (Geolocation ya manejada fuera de scope)
+- [x] UI: no requiere indicador offline nuevo
+- [x] Datos críticos: N/A
+
+### Esfuerzo offline adicional: S (nulo)
+
+---
+
+## Modularizacion y % monolitico
+
+Cambios contenidos en componentes de dominio ya existentes (`business/`, `home/`, `social/`, `user/`, `search/`, `map/`), todos en su carpeta correcta. No se agrega estado global, no se tocan AppShell/SideMenu, no se crean contextos. La importación de `CHIP_SMALL_SX` desde `theme/cards` es un import de token de diseño (permitido en componentes). Reduce el acoplamiento al consolidar estilos ad-hoc en el token compartido en 6 chips más.
+
+### Checklist modularizacion
+
+- [x] Lógica de negocio en hooks/services — no se agrega lógica
+- [x] Componentes siguen siendo reutilizables
+- [x] No se agregan useState a AppShell/SideMenu
+- [x] Props explícitas — sin cambios de props
+- [x] Cada prop de acción tiene handler real — sin props nuevas
+- [x] Ningún componente importa de `firebase/firestore`, `firebase/functions`, `firebase/storage` (solo `theme/cards`)
+- [x] No se crean archivos en `src/hooks/`
+- [x] Ningún archivo supera 400 líneas
+- [x] No se crean converters
+- [x] Archivos en carpeta de dominio correcta (NO en `components/menu/`)
+- [x] No se necesita estado global nuevo
+
+### Impacto en % monolitico
+
+| Aspecto | Impacto | Justificacion |
+|---------|---------|---------------|
+| Acoplamiento de componentes | - | Reemplaza `sx` ad-hoc (incl. el duplicado "Mejor respuesta") por token compartido `CHIP_SMALL_SX` en 6 chips |
+| Estado global | = | No se toca estado global |
+| Firebase coupling | = | No hay imports de Firebase nuevos |
+| Organizacion por dominio | = | Archivos ya en carpetas de dominio correctas |
+
+---
+
+## Accesibilidad y UI mobile
+
+Este feature **mejora** la accesibilidad mobile: es su objetivo principal (touch targets WCAG 2.5.5 44x44 + safe-area).
+
+### Checklist de accesibilidad
+
+- [x] `LocationFAB` ya tiene `aria-label="Mi ubicación"` (se preserva)
+- [x] Chips de `FilterChips` usan `<Chip onClick>` (semántica MUI clickable correcta)
+- [x] Chip de `BusinessTags` usa `<Chip onClick>` (semántica correcta); su IconButton hermano ya tiene `aria-label` dinámico
+- [x] **Touch targets >=44x44px (ambos ejes)**: objetivo central de S2 — `FilterChips` y `BusinessTags` chip clicable
+- [x] `IconButton` con `p: 0.25` — no aplica (no se introduce)
+- [x] Componentes con carga de datos: sin cambios en estados de error
+- [x] Imágenes dinámicas: N/A
+- [x] Formularios: N/A
+
+### Checklist de copy
+
+- [x] Sin textos nuevos. Los existentes ("Mi ubicación", "Mejor respuesta", "Recientes/Antiguos/Útiles", labels de tags/precio/medallas) se preservan sin cambios.
+- [x] Tono y terminología: sin cambios de copy
+- [x] Strings reutilizables: N/A
+- [x] Mensajes de error: sin cambios
+
+---
+
+## Success Criteria
+
+1. `node scripts/guards/lib/check-chip-height.mjs` retorna exit **0 violaciones**: los **6 chips** (`BusinessComments.tsx:262`, `BusinessQuestions.tsx:259`, `QuestionAnswerThread.tsx:125`, `TrendingBusinessCard.tsx:61`, `VerificationBadge.tsx:34`, `UserProfileContent.tsx:64`) usan `CHIP_SMALL_SX` (con overrides puntuales vía spread donde corresponde — `mb: 0.5` en los chips "Mejor respuesta", colores de oro en `VerificationBadge`).
+2. Los chips clicables de `FilterChips.tsx` (tag + precio) y el chip clicable de `BusinessTags.tsx` tienen un área táctil efectiva **>=44px en ambos ejes (44x44, WCAG 2.5.5)**, sin romper la densidad visual del header de comercio ni introducir scroll vertical en contenedores con `overflowX: auto`.
+3. `LocationFAB` usa `bottom: 'calc(24px + env(safe-area-inset-bottom))'` y queda visible sobre el home indicator en dispositivos con notch.
+4. `tsc` y `npm run guards` pasan sin errores ni nuevas violaciones; no se rompe ningún test existente.
+5. Verificación visual manual en mobile/emulador con notch confirma que chips no se solapan y el FAB es alcanzable.
+
+---
+
+## Validacion Funcional
+
+**Analista**: Sofia (gate formal pendiente)
+**Fecha**: 2026-06-09
+**Estado**: PENDIENTE DE GATE
+
+> Nota para el orquestador: este PRD fue redactado por el agente prd-writer ejecutándose como subagente, sin capacidad de spawnear el subagente `sofia`. El gate funcional de Sofia debe correrse desde el orquestador antes de pasar a specs/plan. La pre-revisión interna aplicada (checklist funcional) no detectó BLOQUEANTES: el scope es acotado (8 archivos, solo `sx`/posición), los criterios de aceptación son medibles (guard exit 0 sobre los 6 chips, >=44x44 ambos ejes, `calc(...)` presente) y la decisión de diseño abierta de S2 (minHeight/minWidth vs wrapper táctil) está correctamente delegada a specs con criterio cuantitativo. Una observación menor abierta: confirmar en specs que `minHeight: 44` en chips dentro de contenedores con `overflowX: auto` no introduce scroll vertical no deseado.
+
+
+## Validacion Funcional (Gate Sofia)
+
+**Estado:** NO VALIDADO
+**Fecha:** 2026-06-10
+**Revisor:** Sofia (analista funcional)
+
+**Observaciones clave (detalle completo incorporado a specs):** BLOQUEANTE: el guard check-chip-height.mjs reporta 6 violaciones (BusinessComments, BusinessQuestions, QuestionAnswerThread, TrendingBusinessCard, VerificationBadge, UserProfileContent), el PRD cubre 2 → SC#1 (guard exit 0) inalcanzable. Touch target solo mide eje vertical (WCAG pide 44x44). En reconciliacion via prd-writer.
+
+### Reconciliacion (prd-writer, 2026-06-12) — pendiente re-gate
+
+Se aplicaron los siguientes cambios para resolver los 2 BLOQUEANTES; el veredicto final lo emite Sofia en el re-gate.
+
+- **BLOQUEANTE 1 (SC#1 inalcanzable):** S1 ampliada de 2 a **6 chips**, cubriendo las 6 violaciones que reporta el guard (confirmadas con `node scripts/guards/lib/check-chip-height.mjs`, exit 1). Cada chip tiene su migración concreta a `CHIP_SMALL_SX` por archivo (con el `sx` ad-hoc actual verificado contra el código y los overrides puntuales preservados). Se documenta el chip "Mejor respuesta" DUPLICADO en `BusinessQuestions.tsx:259` y `QuestionAnswerThread.tsx:125` (misma migración en ambos; deduplicación marcada Out of Scope). Tabla de Scope, Success Criteria, Tests, Mitigacion y conteos actualizados de "2 chips/4 archivos" a "6 chips/6 archivos" (S1) + 3 archivos (S2/S3).
+- **BLOQUEANTE 2 (touch target solo eje vertical):** S2 y SC#2 corregidos para exigir área táctil **>=44px en ambos ejes (44x44, WCAG 2.5.5)**. Se reformuló el criterio como bidimensional (alto y ancho) y se referenció el umbral 44x44 ya presente en `BusinessTags.tsx:202`.
+
+**Estado de la reconciliacion:** reconciliado, pendiente re-gate de Sofia (Ciclo 2). No estampar veredicto hasta que Sofia revise.
+
+### Re-gate Ciclo 2 (Sofia, 2026-06-12)
+**Estado:** VALIDADO CON OBSERVACIONES
+**Observaciones:** Los 2 BLOQUEANTES del Ciclo 1 quedaron cerrados y verificados contra el codigo:
+- BLOQUEANTE 1 (SC#1 inalcanzable) → CERRADO. El guard `check-chip-height.mjs` reporta exit 1 con exactamente las 6 violaciones (`BusinessComments.tsx:262`, `BusinessQuestions.tsx:259`, `QuestionAnswerThread.tsx:125`, `TrendingBusinessCard.tsx:61`, `VerificationBadge.tsx:34`, `UserProfileContent.tsx:64`) y S1 ahora cubre las 6 con migracion concreta por archivo. El token `CHIP_SMALL_SX` (`src/theme/cards.ts:62`) coincide con lo descrito (`height: 24`, `fontSize: '0.75rem'`, icon `fontSize:14,ml:0.5`, label `px:1`); los overrides puntuales (`mb: 0.5`, colores de oro) son coherentes. Duplicado "Mejor respuesta" documentado y deduplicacion correctamente fuera de scope. SC#1 (guard exit 0) es alcanzable.
+- BLOQUEANTE 2 (touch target solo eje vertical) → CERRADO. S2 y SC#2 exigen ahora >=44px en ambos ejes (44x44, WCAG 2.5.5). Umbral 44x44 ya presente en `BusinessTags.tsx:202` (verificado); decision de estrategia (minHeight/minWidth vs wrapper/padding tactil) delegada a specs con criterio cuantitativo.
+
+Observaciones abiertas (no bloquean — para tener en cuenta en specs):
+1. Riesgo de scroll vertical: confirmar en specs que expandir el target a 44px en chips dentro de contenedores con `overflowX: auto` (FilterChips) no introduzca scroll vertical no deseado. Ya esta marcado en S2.
+2. `TrendingBusinessCard.tsx:61`: el `sx={{ fontSize: 14 }}` inline del `<Icon>` queda redundante con el `'& .MuiChip-icon'` del token; el PRD lo deja como limpieza opcional en specs — OK.
+3. Diferencias cosmeticas menores de fontSize (0.7/0.65rem → 0.75rem) y label px (0.75 → 1) aceptadas explicitamente en el PRD — OK, no bloquean.
+
+Completitud, coherencia con el proyecto (voseo, patrones de safe-area de BusinessSheet/BusinessDetailScreen, token CHIP_SMALL_SX), testabilidad (guard exit 0 + tsc + npm run guards + verificacion visual con notch) y casos edge: correctos para deuda tecnica de estilo sin Firestore/auth/billing. HABILITADO para pasar a specs+plan.

--- a/docs/feat/ux/345-techdebt-chips-touch-targets-fab-safe-area/specs.md
+++ b/docs/feat/ux/345-techdebt-chips-touch-targets-fab-safe-area/specs.md
@@ -1,0 +1,309 @@
+# Specs: Tech debt ui-ux — chips ad-hoc (R5/R8), touch targets <44px y FAB sin safe-area
+
+**PRD:** [prd.md](prd.md)
+**Issue:** #345
+**Fecha:** 2026-06-12
+
+---
+
+## Resumen
+
+Deuda técnica de estilo (`sx`) acotada a 8 componentes existentes. No toca Firestore, auth, Cloud Functions, Storage, billing ni offline. No agrega tipos, hooks, servicios, contextos ni estado global. Tres bloques:
+
+- **S1** — Migrar 6 chips ad-hoc al token `CHIP_SMALL_SX` (`src/theme/cards.ts:62`), cerrando Guard #305 R5/R8.
+- **S2** — Touch targets >=44x44px (ambos ejes, WCAG 2.5.5) en chips clicables de `FilterChips.tsx` y `BusinessTags.tsx`.
+- **S3** — `LocationFAB.tsx` con `bottom: 'calc(24px + env(safe-area-inset-bottom))'`.
+
+El gate de regresión es `node scripts/guards/lib/check-chip-height.mjs` (exit 0). Verificado el 2026-06-12: el guard reporta exit 1 con exactamente las 6 violaciones listadas en S1.
+
+---
+
+## Modelo de datos
+
+No aplica. El feature no lee ni escribe Firestore. No agrega colecciones, campos ni tipos. No se modifican interfaces de `src/types/`.
+
+## Firestore Rules
+
+No aplica. Sin queries nuevas, sin colecciones nuevas, sin campos nuevos. Las tablas de Rules impact, Field whitelist y Cloud Functions del template se omiten por no haber superficie de datos.
+
+## Seed Data
+
+No aplica. No hay cambios de schema.
+
+---
+
+## Archivos afectados
+
+### Nuevos (0)
+
+No se crean archivos. Todos los cambios son ediciones a componentes existentes.
+
+### Modificados (9)
+
+| Archivo | Bloque | Cambio |
+|---------|--------|--------|
+| `src/components/business/BusinessComments.tsx` | S1 | Chip orden (Recientes/Antiguos/Útiles) → `CHIP_SMALL_SX` + import |
+| `src/components/business/BusinessQuestions.tsx` | S1 | Chip "Mejor respuesta" → `{ ...CHIP_SMALL_SX, mb: 0.5 }` + import |
+| `src/components/business/QuestionAnswerThread.tsx` | S1 | Chip "Mejor respuesta" → `{ ...CHIP_SMALL_SX, mb: 0.5 }` + import |
+| `src/components/home/TrendingBusinessCard.tsx` | S1 | Chip breakdown → `CHIP_SMALL_SX` + import (+ limpieza icono opcional) |
+| `src/components/social/VerificationBadge.tsx` | S1 | Chip compact → `{ ...CHIP_SMALL_SX, borderColor, bgcolor }` + import |
+| `src/components/user/UserProfileContent.tsx` | S1 | Chip medalla/ranking → `CHIP_SMALL_SX` + import |
+| `src/components/search/FilterChips.tsx` | S2 | Touch target 44x44 en `chipSx` helper |
+| `src/components/business/BusinessTags.tsx` | S2 | Touch target 44x44 en chip clicable de tag |
+| `src/components/map/LocationFAB.tsx` | S3 | `bottom: 'calc(24px + env(safe-area-inset-bottom))'` |
+
+### Tests
+
+| Archivo | Cambio |
+|---------|--------|
+| `scripts/guards/lib/check-chip-height.mjs` | Sin cambios — se ejecuta como gate de regresión (exit 0 post-fix) |
+
+No se crean tests unitarios de Vitest (ver sección Tests — excepción documentada en `tests.md`).
+
+---
+
+## Componentes
+
+Ningún componente cambia su firma de props, estado ni comportamiento. Solo cambian valores en `sx`. No hay props de acción nuevas, no hay handlers nuevos, no hay datos mutables vía props. La tabla "Mutable prop audit" del template no aplica (no se editan datos vía props).
+
+### Token de referencia
+
+`CHIP_SMALL_SX` (`src/theme/cards.ts:62`) define:
+
+```ts
+export const CHIP_SMALL_SX: SxProps<Theme> = {
+  height: 24,
+  fontSize: '0.75rem',
+  '& .MuiChip-icon': { fontSize: 14, ml: 0.5 },
+  '& .MuiChip-label': { px: 1 },
+};
+```
+
+Import canónico en los 6 archivos de S1 (todos en `src/components/<dominio>/`, profundidad `../../`; ninguno lo importa hoy):
+
+```ts
+import { CHIP_SMALL_SX } from '../../theme/cards';
+```
+
+Verificado contra consumidores existentes que ya usan ese path desde la misma profundidad: `BusinessHeader.tsx:8`, `UserScoreCard.tsx:19`, `SearchListView.tsx:9`.
+
+---
+
+## S1 — Migrar los 6 chips ad-hoc a `CHIP_SMALL_SX`
+
+Patrón documentado en `patterns.md`: si el chip no necesita override, `sx={CHIP_SMALL_SX}` directo; si lo necesita, spread `sx={{ ...CHIP_SMALL_SX, <override> }}`. El `<` ordinal de cada chip en la tabla es el `sx` ad-hoc actual verificado contra el código (2026-06-12).
+
+| Archivo:línea | `sx` actual | `sx` nuevo | Efecto cosmético |
+|---------------|-------------|-----------|------------------|
+| `BusinessComments.tsx:269` (chip dentro del `<Chip key={mode}>` que abre en :262) | `{ height: 24, fontSize: '0.7rem' }` | `CHIP_SMALL_SX` | height idéntico (24); fontSize 0.7→0.75rem |
+| `BusinessQuestions.tsx:264` (chip que abre en :259) | `{ height: 20, fontSize: '0.65rem', mb: 0.5 }` | `{ ...CHIP_SMALL_SX, mb: 0.5 }` | height 20→24; fontSize 0.65→0.75rem; `mb: 0.5` preservado |
+| `QuestionAnswerThread.tsx:130` (chip que abre en :125) | `{ height: 20, fontSize: '0.65rem', mb: 0.5 }` | `{ ...CHIP_SMALL_SX, mb: 0.5 }` | idem anterior (markup duplicado, misma migración) |
+| `TrendingBusinessCard.tsx:67` (chip que abre en :61) | `{ fontSize: '0.7rem', height: 24 }` | `CHIP_SMALL_SX` | height idéntico (24); fontSize 0.7→0.75rem |
+| `VerificationBadge.tsx:38-44` (chip que abre en :34) | `{ fontSize: '0.75rem', height: 24, borderColor: badge.earned ? GOLD_HEX : undefined, bgcolor: badge.earned ? goldBg : undefined, '& .MuiChip-label': { px: 0.75 } }` | `{ ...CHIP_SMALL_SX, borderColor: badge.earned ? GOLD_HEX : undefined, bgcolor: badge.earned ? goldBg : undefined }` | height/fontSize idénticos; label px 0.75→1; colores de oro preservados |
+| `UserProfileContent.tsx:69` (chip que abre en :64) | `{ fontSize: '0.7rem', height: 22 }` | `CHIP_SMALL_SX` | height 22→24; fontSize 0.7→0.75rem |
+
+### Observación #2 de Sofia — icono redundante en TrendingBusinessCard
+
+El `<Icon sx={{ fontSize: 14 }} />` en `TrendingBusinessCard.tsx:63` queda redundante con `'& .MuiChip-icon': { fontSize: 14, ml: 0.5 }` que ya aporta el token. **Decisión de specs:** quitar el `sx={{ fontSize: 14 }}` inline del `<Icon>` (línea 63) en la misma edición — el token ya fija `fontSize: 14` en el slot `.MuiChip-icon`. Limpieza segura (mismo valor, sin diff visual) que evita el override duplicado. Si por algún motivo el wrapper del icono no aplicara el selector del slot, se revierte a dejar el `sx` inline; no es bloqueante.
+
+### Observación #3 de Sofia — diffs cosméticos de fontSize
+
+Las diferencias de `fontSize` (0.7/0.65rem → 0.75rem) y `label px` (0.75 → 1) son crecimientos menores de 1-2px aceptados explícitamente en el PRD. Unifican los chips con el sistema de diseño. No requieren mitigación; se verifican en la revisión visual manual (no se solapan, mantienen legibilidad).
+
+---
+
+## S2 — Touch targets >=44x44px (WCAG 2.5.5)
+
+WCAG 2.5.5 exige área accionable **>=44px en alto y >=44px en ancho**. Los dos contenedores tienen layout distinto, lo que determina la estrategia:
+
+### Observación #1 de Sofia — riesgo de scroll vertical (resuelto en specs)
+
+| Contenedor | Layout del wrapper | Riesgo de `minHeight: 44` |
+|-----------|--------------------|--------------------------|
+| `FilterChips.tsx` | `display: flex; overflowX: auto` (scroller horizontal, `FilterChips.tsx:24-32`) | **Sí** — aumentar el alto del chip aumenta el alto de la fila scroller; medir |
+| `BusinessTags.tsx` | `display: flex; flexWrap: wrap` (`BusinessTags.tsx:172`) | **No** — wrap vertical, sin `overflowX`; `minHeight` solo aumenta el alto de la fila de wrap (mismo comportamiento que el IconButton hermano que ya tiene `minHeight: 44`) |
+
+**Decisión de estrategia por contenedor:**
+
+#### `FilterChips.tsx` — `minHeight`/`minWidth` directo en el `chipSx` helper
+
+El contenedor es un scroller horizontal de una sola fila; no hay otras filas debajo que se desplacen. Aumentar el alto del chip a 44 **aumenta el alto de la fila scroller** pero NO introduce scroll vertical: el scroller solo tiene `overflowX: auto` (no `overflowY`), y la fila crece para acomodar su contenido más alto. El padre (`SearchScreen.tsx:155`) ya posiciona la fila de filtros como un bloque de altura natural. Por lo tanto la opción (a) del PRD es segura aquí.
+
+Cambio en el helper compartido `chipSx(isActive)`:
+
+```ts
+const chipSx = (isActive: boolean) => ({
+  bgcolor: isActive ? undefined : 'background.paper',
+  boxShadow: 1,
+  flexShrink: 0,
+  minHeight: 44,
+  minWidth: 44,
+  '&:hover, &.MuiChip-clickable:hover': {
+    boxShadow: 2,
+    bgcolor: isActive ? undefined : 'background.paper',
+  },
+});
+```
+
+Aplica automáticamente a los chips de tag y de precio (ambos usan `sx={chipSx(isActive)}`). El `label` con padding lateral de MUI ya garantiza ancho >=44 para los labels existentes; `minWidth: 44` cubre el caso de label corto. **Verificación visual obligatoria:** confirmar en DevTools 360px que la fila de filtros no se solapa con el contenido inferior (mapa/lista) ni recorta los chips. Si la fila crece más de lo aceptable, fallback a opción (b): mantener alto visual ~32 y usar pseudo-elemento táctil (`'&::before': { content: '""', position: 'absolute', inset: '-6px 0', minHeight: 44 }`) — documentado como plan B, no se aplica por defecto.
+
+#### `BusinessTags.tsx` — `minHeight`/`minWidth` en el chip clicable
+
+El chip usa `size="small"` (alto ~24) y es clicable (`onClick={handleToggleTag}`, `BusinessTags.tsx:190`). El contenedor es `flexWrap: wrap` (sin `overflowX`), así que `minHeight: 44` no introduce scroll horizontal ni vertical no deseado: la fila de wrap crece, igual que ya lo hace por el IconButton hermano de 44x44 (`BusinessTags.tsx:202`).
+
+```tsx
+sx={{ opacity: isVisible ? 1 : 0.6, borderRadius: 1, minHeight: 44, minWidth: 44 }}
+```
+
+Se preservan `opacity` y `borderRadius: 1` actuales. El `size="small"` se mantiene (densidad visual del header); `minHeight`/`minWidth` expanden el área accionable sin agrandar el `fontSize` del label. El IconButton hermano ya tiene el mismo umbral, así que la fila ya está dimensionada para 44px de alto — el cambio no rompe la densidad existente.
+
+**Nota:** el chip de `BusinessTags.tsx:194` NO dispara el guard `check-chip-height.mjs` (no tiene `height:` ad-hoc), y `minHeight`/`minWidth` no son `height`, por lo que no reintroduce violación. Idem para `FilterChips` (`minHeight`/`minWidth` ≠ `height`).
+
+---
+
+## S3 — FAB con safe-area-inset-bottom
+
+`LocationFAB.tsx:16`: cambiar `bottom: 24` por `bottom: 'calc(24px + env(safe-area-inset-bottom))'`. Patrón idéntico al ya usado en `BusinessSheet.tsx:105` y `BusinessDetailScreen.tsx:292`. El FAB se renderiza en `SearchScreen.tsx` sobre el mapa con `position: absolute`; el fix evita que el home indicator (iPhone X+) lo tape. El `aria-label="Mi ubicación"` (`LocationFAB.tsx:11`) se preserva.
+
+```tsx
+sx={{
+  position: 'absolute',
+  bottom: 'calc(24px + env(safe-area-inset-bottom))',
+  right: 16,
+  // ...resto sin cambios
+}}
+```
+
+---
+
+## Hooks
+
+No aplica. No se crean ni modifican hooks. `LocationFAB` sigue usando `useUserLocation` sin cambios.
+
+## Servicios
+
+No aplica. No se crean ni modifican servicios. Sin operaciones Firestore.
+
+## Cloud Functions
+
+No aplica.
+
+## Integración
+
+Los cambios son internos a cada componente. Ningún consumidor cambia: las firmas de props de `VerificationBadge`, `UserProfileContent`, `TrendingBusinessCard`, `FilterChips`, `BusinessTags`, `LocationFAB`, `BusinessComments`, `BusinessQuestions` y `QuestionAnswerThread` permanecen idénticas.
+
+### Preventive checklist
+
+- [x] **Service layer**: ningún componente importa `firebase/firestore` (solo se agrega import de `theme/cards`).
+- [x] **Duplicated constants**: no se definen arrays/objetos nuevos; se consolida en el token existente `CHIP_SMALL_SX`.
+- [x] **Context-first data**: no hay `getDoc` nuevo; no se lee data.
+- [x] **Silent .catch**: no se agregan `.catch`.
+- [x] **Stale props**: no hay componente que reciba props y mute esa data.
+
+## Tests
+
+El proyecto no tiene cobertura de tests de layout/estilo visual (componentes "puramente visuales sin lógica" — excepción documentada en `tests.md`). Estos cambios son solo `sx`/posición: no introducen lógica condicional, validación de input ni side effects. No se agregan tests unitarios de Vitest.
+
+| Archivo test | Qué testear | Tipo |
+|-------------|-------------|------|
+| `scripts/guards/lib/check-chip-height.mjs` | Ejecutar post-fix → exit 0 (las 6 violaciones de S1 cerradas) | Guard (regresión, existente) |
+
+El gate de regresión efectivo es el guard, no un test unitario. `tsc` y `npm run guards` deben pasar sin errores ni nuevas violaciones.
+
+## Analytics
+
+No aplica. No se agregan `trackEvent`/`logEvent`. El `trackEvent('verification_badge_tooltip', ...)` existente en `VerificationBadge.tsx:28` se preserva sin cambios. Los `trackEvent` de filtro en `FilterChips.tsx:41,60` se preservan sin cambios.
+
+---
+
+## Offline
+
+Sin impacto. Ningún cambio involucra lectura/escritura de Firestore, APIs externas ni estado dependiente de conectividad. Las tablas de cache, writes offline y fallback UI del template no aplican.
+
+---
+
+## Accesibilidad y UI mobile
+
+Este feature **mejora** la accesibilidad mobile (es su objetivo: touch targets WCAG 2.5.5 + safe-area).
+
+| Componente | Elemento | aria-label | Min touch target | Error state |
+|-----------|----------|------------|-----------------|-------------|
+| `FilterChips` | Chip tag/precio (clicable) | N/A (Chip con label de texto visible) | 44x44 (S2) | N/A (data estática local) |
+| `BusinessTags` | Chip tag (clicable) | N/A (label visible); IconButton hermano ya tiene `aria-label` dinámico | 44x44 (S2) | N/A |
+| `LocationFAB` | Fab | `"Mi ubicación"` (ya presente, se preserva) | Fab `size="medium"` (48px) | N/A |
+
+### Reglas
+
+- Todo `<IconButton>` → no se agregan IconButtons.
+- No se introduce `<Typography onClick>`, `<Box onClick>` ni `<Avatar onClick>`.
+- Touch targets: S2 garantiza 44x44 en ambos ejes en los chips clicables (no se usa `p: 0.25` ni `width: 32`).
+- Componentes con fetch: sin cambios en estados de error.
+- `<img>` con URL dinámica: N/A.
+
+## Textos y copy
+
+Sin textos nuevos. Los existentes ("Mi ubicación", "Mejor respuesta", "Recientes/Antiguos/Útiles", labels de tags/precio/medallas) se preservan sin cambios. No hay tabla de copy nueva.
+
+### Reglas de copy
+
+- [x] Sin strings nuevos visibles al usuario.
+- [x] Tildes y voseo: sin cambios (no se toca copy).
+- [x] Terminología: sin cambios.
+
+---
+
+## Decisiones técnicas
+
+1. **`minHeight`/`minWidth` directo (opción a del PRD) en ambos contenedores de S2.** Tras verificar el layout: `FilterChips` es scroller `overflowX: auto` sin `overflowY` (crecer en alto no introduce scroll vertical) y `BusinessTags` es `flexWrap: wrap` sin `overflowX` (su IconButton hermano ya impone 44px de alto). El wrapper táctil / pseudo-elemento (opción b) queda documentado como plan B solo si la verificación visual en 360px muestra solapamiento. Se elige (a) por simplicidad y consistencia con el umbral 44x44 ya presente en el repo (`BusinessTags.tsx:202`).
+2. **`minHeight`/`minWidth` no reintroducen el guard.** El guard `check-chip-height.mjs` detecta `height:` literal en el tag del Chip; `minHeight`/`minWidth` son propiedades distintas y no disparan la regla. Confirmado leyendo el regex del guard (`/\bheight\s*:/` matchea `minHeight`? No — `\bheight` requiere word boundary; en `minHeight` el `n` precede a `height` y no hay boundary entre `n` y `h`, por lo que `\bheight` NO matchea `minHeight`). Verificado: el guard no reporta `minHeight`/`minWidth`.
+3. **Limpieza del icono en TrendingBusinessCard (obs #2).** Se quita el `sx={{ fontSize: 14 }}` inline porque el token ya lo provee vía `.MuiChip-icon`. Misma medida visual, menos override.
+4. **No se deduplica "Mejor respuesta".** `BusinessQuestions.tsx` y `QuestionAnswerThread.tsx` tienen markup idéntico; extraer un componente común es refactor aparte (Out of Scope del PRD). Se migran ambos por separado.
+
+---
+
+## Hardening de seguridad
+
+No aplica. El feature no introduce ninguna superficie nueva (sin Firestore, sin callables, sin Storage, sin inputs de usuario, sin `dangerouslySetInnerHTML`/`eval`). Las tablas de Firestore rules, rate limiting y vectores de ataque del template no aplican — confirmado en la sección Seguridad del PRD.
+
+| Aspecto | Estado |
+|---------|--------|
+| Escritura a Firestore | Ninguna |
+| Lectura de datos nueva | Ninguna |
+| Inputs de usuario nuevos | Ninguno |
+| Secretos/API keys/emails hardcodeados | Revisar diff antes de commit (repo público) — no se agregan |
+
+---
+
+## Deuda técnica: mitigación incorporada
+
+Consulta de issues (2026-06-09, según PRD): los tech-debt usan label `enhancement` (no `tech debt`/`security`). Este feature **es** la mitigación de deuda técnica de #345.
+
+| Issue | Qué se resuelve | Paso del plan |
+|-------|----------------|---------------|
+| #305 Guard R5/R8 (chips ad-hoc) | Cerrar las 6 violaciones de `height`/`fontSize` ad-hoc migrando a `CHIP_SMALL_SX` | Fase 1 |
+| #326 (introdujo `CHIP_SMALL_SX`) | Completar la adopción del token en los 6 chips que quedaron fuera del barrido original | Fase 1 |
+| #196 / #319 (accesibilidad WCAG) | Touch targets >=44x44px en `FilterChips` y `BusinessTags` | Fase 2 |
+
+No se agrava deuda existente: los 9 archivos quedan por debajo de 400 líneas, sin nuevos imports de Firebase, en sus carpetas de dominio correctas.
+
+---
+
+## Validación Tecnica
+
+**Arquitecto**: Diego
+**Fecha**: (pendiente — sello de Diego)
+**Estado**: (pendiente — sello de Diego)
+
+---
+
+## Revisión Técnica (Gate Diego)
+
+**Estado:** VALIDADO CON OBSERVACIONES
+**Fecha:** 2026-06-12
+**Revisor:** Diego (solution architect)
+
+**Observaciones:**
+- Cobertura PRD→specs completa. Las 3 preguntas críticas quedaron verificadas contra el código: (a) FilterChips vive en una fila flotante `position:absolute` (SearchScreen:155) de altura natural sin `overflowY`, e internamente solo tiene `overflowX:auto` → `minHeight:44` crece la fila sin scroll vertical; BusinessTags es `flexWrap:wrap` con IconButton hermano que ya impone 44px (`:202`); (b) ejecuté el regex del guard `\bheight\s*:` contra `minHeight:44` → `false`, confirma que minHeight/minWidth NO reintroducen el guard; (c) el guard reporta exit 1 con exactamente las 6 violaciones listadas, y reemplazar el `height:` literal por `CHIP_SMALL_SX` deja exit 0. Token, import path (`../../theme/cards`, precedente en BusinessHeader/UserScoreCard/SearchListView) y patrón safe-area (BusinessSheet:105, BusinessDetailScreen:292) verificados.
+- OBSERVACION 1 (para el plan): la "verificación visual obligatoria a 360px" de S2/FilterChips no es automatizable (no hay E2E de layout). El plan debe dejar ese check como paso manual explícito y tener el plan B (pseudo-elemento táctil) listo por si la fila se solapa con el ViewToggle hermano o recorta chips — la fila comparte ancho con ViewToggle vía `gap:1` y `minWidth:0`.
+- OBSERVACION 2 (cosmética, no bloquea): la migración de VerificationBadge descarta `'& .MuiChip-label':{px:0.75}` quedándose con el `px:1` del token; coherente con el diff cosmético aceptado en el PRD. La limpieza del `<Icon sx={{fontSize:14}}>` en TrendingBusinessCard:63 es opcional y reversible como dice el specs — el slot `.MuiChip-icon` del token aplica al icono pasado vía prop `icon=`, así que el inline es redundante.
+- Sin tests unitarios nuevos: correcto por excepción de tests.md (cambios solo `sx`). El gate de regresión efectivo es `node scripts/guards/lib/check-chip-height.mjs` (exit 0) + `tsc` + `npm run guards`. HABILITADO para pasar a plan (Pablo).

--- a/docs/reference/devops.md
+++ b/docs/reference/devops.md
@@ -31,7 +31,7 @@ VITE_SENTRY_DSN=
 ### Cloud Functions (`functions/.env`)
 
 ```bash
-ADMIN_EMAIL=benoffi11@gmail.com  # Email del admin (usado por defineString en backups.ts)
+ADMIN_EMAIL=benoffi11@gmail.com  # Email del admin (usado por defineString en claims.ts)
 ```
 
 ### Sentry (CI/CD — secrets de GitHub)
@@ -146,6 +146,15 @@ Trigger: push a `staging`
 - Tests que importan modulos que chainan a `firebase.ts` deben mockear la cadena
 
 **Todo se despliega automaticamente** en cada push a main: hosting, Firestore rules/indexes, y Cloud Functions.
+
+### Invariante de `npm audit` (runtime vs dev/CLI) — #342
+
+El step `npm audit --audit-level=high` del job `lint` corre con `continue-on-error: true` (soft-gate): documenta vulnerabilidades sin romper el pipeline. El invariante se interpreta en **dos capas distintas**, no como un umbral unico:
+
+- **Runtime de Cloud Functions (`functions/`):** debe quedar en **0 vulnerabilidades HIGH**. Es codigo que corre en produccion, sin ramas dev. Verificable con `cd functions && npm audit --audit-level=high` → exit 0. La cadena transitiva critica (`protobufjs` via `google-gax` via `firebase-admin`) debe estar parcheada (`protobufjs >= 7.2.5`; hoy resuelve a `7.5.5` con `firebase-admin@^13.10.0`).
+- **Dev/CLI transitivas del root (`package.json`):** el root incluye herramientas de build/CLI (`firebase-tools`, etc.) cuyas dependencias transitivas pueden listar vulns moderate/high que **no llegan al bundle de produccion**. Estas quedan **documentadas con justificacion**; el `continue-on-error: true` se mantiene deliberadamente para no bloquear merges de bajo riesgo detras de vulns de tooling. Convertirlo en gate duro esta fuera de scope (riesgo alto, adyacente a #168).
+
+> #342 redefine este invariante en TEXTO; **no** introduce un gate duro nuevo en `deploy.yml` / `guards.yml`. La distincion runtime-vs-dev es la salida valida del Success Criteria #3.
 
 ### IAM roles requeridos
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -317,6 +317,26 @@ feedback-media/{userId}/{feedbackId}/{fileName}:
   delete: auth != null && auth.uid == userId
 ```
 
+### Validacion client-side de `mediaUrl` (`isValidStorageUrl`, #342)
+
+`src/utils/media.ts` valida en el cliente (render del preview) que la URL sea un objeto canonico de Firebase Storage: host exacto **+** segmento `/v0/b/<bucket>/o/` (regex anclada con `^`). Bucket generico (`[^/]+`) para no romper render de `mediaUrl` legacy que pudiera apuntar a otro bucket; un solo segmento sin `/` impide inyectar sub-paths en la posicion del bucket.
+
+Esta validacion es **independiente** de la rule de Firestore (`firestore.rules:222`), no un espejo:
+
+| Capa | Que valida | Donde |
+|------|-----------|-------|
+| Rule (write, server) | Path canonico **encoded** (`%2F`) + ownership (`uid`/`docId`), con `.*` (NO ancla `/v0/b/`) | `firestore.rules:222,242` |
+| `isValidStorageUrl` (read/render, client) | Host exacto + segmento `/v0/b/<bucket>/o/` decodificado | `src/utils/media.ts` |
+
+Son dos capas de defense-in-depth con responsabilidades separadas; ninguna reemplaza a la otra.
+
+### Dependencias con advisories parchadas (#342)
+
+- `react-router-dom >= 7.14.2` (root): cierra GHSA-49rj-9fvp-4h2h (turbo-stream RCE), GHSA-8646-j5j9-6r62 (RSC XSS) y GHSA-2j2x-hqr9-3h42 (open redirect). No alcanzables con la API declarativa del proyecto, parchados de todas formas.
+- `firebase-admin@^13.10.0` (functions, dentro del major 13 para no romper el peer dep de `firebase-functions`): asegura `protobufjs >= 7.2.5` (resuelve a `7.5.5`) en la cadena runtime via `google-gax`.
+
+> NOTA: el bump de `firebase-admin` se mantiene dentro del major 13 a proposito; subir a 14 rompe el peer dep de `firebase-functions` y agrava #168 (fuera de scope).
+
 ---
 
 ## Límites de validación
@@ -330,7 +350,7 @@ feedback-media/{userId}/{feedbackId}/{fileName}:
 | Feedback message | 1000 chars | Server |
 | Rating score | 1-5 | Server |
 | Feedback rating | 1-5 (int, optional) | Server |
-| Feedback mediaUrl | Firebase Storage URL only | Server + Client |
+| Feedback mediaUrl | Firebase Storage URL only (cliente exige segmento canonico `/v0/b/<bucket>/o/`, #342) | Server + Client |
 | Feedback mediaType | image, pdf | Server |
 | Custom tags por comercio | 10 | Client |
 | Comentarios por usuario/día | 20 | Client |

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,7 +13,7 @@
         "@google-cloud/storage": "^7.19.0",
         "@octokit/rest": "^22.0.1",
         "@sentry/node": "^10.45.0",
-        "firebase-admin": "^13.0.0",
+        "firebase-admin": "^13.10.0",
         "firebase-functions": "^7.2.2",
         "sharp": "^0.34.5"
       },
@@ -4194,9 +4194,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
-      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -4206,9 +4206,7 @@
         "fast-deep-equal": "^3.1.1",
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.4.0",
-        "uuid": "^11.0.2"
+        "jwks-rsa": "^3.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -5874,15 +5872,6 @@
         }
       }
     },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7037,19 +7026,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -24,7 +24,7 @@
     "@google-cloud/storage": "^7.19.0",
     "@octokit/rest": "^22.0.1",
     "@sentry/node": "^10.45.0",
-    "firebase-admin": "^13.0.0",
+    "firebase-admin": "^13.10.0",
     "firebase-functions": "^7.2.2",
     "sharp": "^0.34.5"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "modo-mapa",
-  "version": "2.51.0",
+  "version": "2.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modo-mapa",
-      "version": "2.51.0",
+      "version": "2.52.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -20,7 +21,7 @@
         "firebase": "^12.11.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.13.1",
+        "react-router-dom": "^7.17.0",
         "recharts": "^3.8.0"
       },
       "devDependencies": {
@@ -15753,9 +15754,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -15775,12 +15776,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "firebase": "^12.11.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.13.1",
+    "react-router-dom": "^7.17.0",
     "recharts": "^3.8.0"
   },
   "devDependencies": {

--- a/src/utils/media.test.ts
+++ b/src/utils/media.test.ts
@@ -58,4 +58,34 @@ describe('isValidStorageUrl', () => {
   it('rejects an unrelated https URL', () => {
     expect(isValidStorageUrl('https://example.com/photo.jpg')).toBe(false);
   });
+
+  it('rejects a valid host without the /v0/b/<bucket>/o/ segment', () => {
+    // Correct host + scheme, but not a canonical Storage object URL.
+    expect(
+      isValidStorageUrl('https://firebasestorage.googleapis.com/some/other/path'),
+    ).toBe(false);
+  });
+
+  it('rejects a valid host with /v0/b/<bucket>/ but missing /o/', () => {
+    expect(
+      isValidStorageUrl('https://firebasestorage.googleapis.com/v0/b/modo-mapa.appspot.com/'),
+    ).toBe(false);
+  });
+
+  it('accepts a canonical URL with a different bucket (generic [^/]+ bucket)', () => {
+    // Generic bucket matcher must not break legacy mediaUrl pointing at
+    // another well-formed bucket (e.g. *.firebasestorage.app).
+    expect(
+      isValidStorageUrl(
+        'https://firebasestorage.googleapis.com/v0/b/another-project.firebasestorage.app/o/feedback-media%2Fuid%2Fdoc%2Fphoto.jpg?alt=media',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects an injected sub-path in the bucket position', () => {
+    // [^/]+ forbids a '/' in the bucket segment, blocking evil.com/x injection.
+    expect(
+      isValidStorageUrl('https://firebasestorage.googleapis.com/v0/b/evil.com/x/o/file'),
+    ).toBe(false);
+  });
 });

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,5 +1,11 @@
-const STORAGE_URL_PREFIX = 'https://firebasestorage.googleapis.com/';
+// Host exacto + segmento canonico /v0/b/<bucket>/o/.
+// El ^ ancla el inicio (cierra prefix-bypass y arbitrary-content-before-prefix).
+// Bucket generico ([^/]+): un solo segmento de path, sin '/', para no romper
+// render de mediaUrl legacy que pudiera apuntar a otro bucket. La autorizacion
+// real (ownership) la da la rule de write de Firestore, no este check.
+const STORAGE_URL_RE =
+  /^https:\/\/firebasestorage\.googleapis\.com\/v0\/b\/[^/]+\/o\//;
 
-/** Validates that a URL points to Firebase Storage */
+/** Validates that a URL points to a canonical Firebase Storage object */
 export const isValidStorageUrl = (url: string | undefined): url is string =>
-  typeof url === 'string' && url.startsWith(STORAGE_URL_PREFIX);
+  typeof url === 'string' && STORAGE_URL_RE.test(url);


### PR DESCRIPTION
## #342 — PR-A (deps + hardening + docs)

Verificado en LOCAL. El check 'Regression guards' de CI está en rojo por el artefacto Mac/Linux preexistente de new-home (no es de este PR).

### Cambios (scope PR-A)
- **F1**: `react-router-dom` → `^7.17.0` (≥7.14.2; parcha GHSA-49rj/8646/2j2x).
- **F2**: `firebase-admin` → `^13.10.0` (patch dentro de major 13; `protobufjs 7.5.5` vía google-gax). **No** sube a 14 para no agravar #168.
- **F4**: `isValidStorageUrl` exige el segmento `/v0/b/<bucket>/o/` (bucket genérico `[^/]+`, default seguro para no romper históricos).
- **F5 (parcial)**: `devops.md` (redefinición del invariante `npm audit` runtime-vs-dev + fix stale `backups.ts`→`claims.ts`) + `security.md`.

### Tests (local)
- vitest `main.test.ts`+`media.test.ts`: 17 passed · build root: OK · functions `test:run`: 528 passed · functions tsc: clean.
- ⚠️ `npm audit` está bloqueado en el entorno; verificado por inspección de lockfile (protobufjs 7.5.5). **Un humano debe correr `cd functions && npm audit --audit-level=high` para confirmar exit 0.**

### ⚠️ Deferred — PR-B (acción humana)
**Fase 3**: migrar `ADMIN_EMAIL` (`defineSecret`) y `APP_CHECK_ENFORCEMENT` (`defineString`) a Secret Manager — requiere `firebase deploy --only functions` + smoke de `ENFORCE_APP_CHECK` en la instancia prod/staging. **No incluido acá.**

Refs #342