### PR TITLE
chore: excluir onBeforeUserCreated del deploy (requiere GCIP) + sacar continue-on-error que lo enmascaraba

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -88,7 +88,9 @@ jobs:
         run: bash scripts/deploy-staging-rules.sh
 
       - name: Deploy Cloud Functions (if changed)
-        continue-on-error: true
+        # Sin continue-on-error: un fallo real de deploy de functions ahora corta
+        # el workflow (antes lo enmascaraba — ocultaba p.ej. el fallo de
+        # onBeforeUserCreated por GCIP, hoy excluido del deploy en functions/src/index.ts).
         run: |
           if git diff origin/main -- functions/src/ functions/package.json | grep -q .; then
             echo "Functions changed — deploying..."

--- a/docs/reference/devops.md
+++ b/docs/reference/devops.md
@@ -53,6 +53,28 @@ firebase functions:secrets:set ADMIN_EMAIL --project modo-mapa-app
 > Remover ambas líneas localmente; los valores reales viven en Secret Manager /
 > parameter store y nunca se commitean.
 
+### Identity Platform (GCIP) / blocking functions
+
+La función `onBeforeUserCreated` (`functions/src/triggers/authBlocking.ts`) es un
+**blocking auth function** que hace rate-limit anti-flood de cuentas anónimas por IP
+(único writer de `_ipRateLimits`, la data del inspector admin de #348) y seedea
+`userSettings`. Las blocking functions **solo se pueden deployar en proyectos con
+Identity Platform (GCIP) habilitado**; `modo-mapa-app` hoy NO lo tiene, por lo que
+su deploy falla con:
+
+```
+HTTP 400 OPERATION_NOT_ALLOWED: Blocking Functions may only be configured for GCIP projects.
+```
+
+**Estado actual:** el export está **comentado** en `functions/src/index.ts`, así que la
+función queda excluida del deploy (no lo hace fallar). El código se conserva intacto.
+
+**Para reactivarla:** (1) habilitar Identity Platform en el proyecto (Firebase Console →
+Authentication → Settings, o GCP Identity Platform — tiene implicancias de pricing);
+(2) descomentar el `export { onBeforeUserCreated }` en `index.ts`; (3) re-deployar
+functions. Recién ahí el anti-flood se activa y `_ipRateLimits` empieza a poblarse
+(dándole datos al inspector de #348).
+
 ### Sentry (CI/CD — secrets de GitHub)
 
 ```bash

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,7 +20,15 @@ export { onCheckInCreated, onCheckInDeleted } from './triggers/checkins';
 export { onFollowCreated, onFollowDeleted } from './triggers/follows';
 export { onUserSettingsWritten } from './triggers/userSettings';
 export { onRecommendationCreated } from './triggers/recommendations';
-export { onBeforeUserCreated } from './triggers/authBlocking';
+// onBeforeUserCreated (blocking auth fn: rate-limit anti-flood de cuentas anónimas
+// por IP + seed de userSettings) REQUIERE Identity Platform (GCIP) habilitado en el
+// proyecto. Sin GCIP, su deploy falla con `400 OPERATION_NOT_ALLOWED: Blocking
+// Functions may only be configured for GCIP projects` y la función nunca se activa.
+// Por eso queda EXCLUIDO del deploy (export comentado) hasta habilitar GCIP.
+// NOTA: es el ÚNICO writer de `_ipRateLimits` (la colección que lee el inspector
+// admin de #348); al reactivarlo (habilitar GCIP + descomentar) ese inspector pasa
+// a tener datos. Ver docs/reference/devops.md (Identity Platform / blocking functions).
+// export { onBeforeUserCreated } from './triggers/authBlocking';
 export { onUserTagCreated, onUserTagDeleted } from './triggers/userTags';
 
 // Scheduled


### PR DESCRIPTION
## Contexto

Durante el deploy de #342 PR-B se descubrió que `onBeforeUserCreated` (blocking auth fn) **nunca pudo deployarse**: requiere **Identity Platform (GCIP)** habilitado en `modo-mapa-app`, que no lo tiene → falla con `400 OPERATION_NOT_ALLOWED: Blocking Functions may only be configured for GCIP projects`. El workflow de staging lo venía **enmascarando** con `continue-on-error: true`.

Decisión (opción 3): **preservar el código, dejar de enmascarar**, sin habilitar GCIP ni borrar la feature.

## Cambios
- **`functions/src/index.ts`**: export de `onBeforeUserCreated` **comentado** → excluido del deploy (no lo hace fallar). Código de `authBlocking.ts` intacto.
- **`deploy-staging.yml`**: removido `continue-on-error: true` del step de deploy de functions → un fallo real ahora corta el workflow (antes lo silenciaba).
- **`devops.md`**: sección *Identity Platform / blocking functions* con estado actual y pasos para reactivar.

## Importante (no se pierde nada, queda en pausa)
`onBeforeUserCreated` es el **único writer de `_ipRateLimits`** (la data del inspector admin de #348). Para reactivar: habilitar GCIP → descomentar el export → re-deployar. Recién ahí se activa el anti-flood y #348 obtiene datos.

## Verificación local
- functions: `build` (tsc) clean · `lint` clean · `authBlocking.test.ts` 9/9 (la impl sigue testeada).

Refs #342 (follow-up del deploy de PR-B)